### PR TITLE
Fix paws collector registration

### DIFF
--- a/cfn/okta-collector.template
+++ b/cfn/okta-collector.template
@@ -48,13 +48,13 @@
             "Type": "Number",
             "Default": 60
         },
-        "PollApiEndpoint": {
+        "OktaEndpoint": {
             "Description": "URL to poll",
             "Type": "String",
             "Default": "https://alertlogic-admin.okta.com/"
         },
-        "PollApiSecret": {
-            "Description": "Authentication secret to use for requests to PollApiEndpoint",
+        "OktaSecret": {
+            "Description": "Authentication secret to use for requests to OktaEndpoint",
             "Type": "String",
             "NoEcho": true
         },
@@ -389,7 +389,8 @@
                ]
              ]
             },
-            "VisibilityTimeout": 900
+            "VisibilityTimeout": 900,
+            "MessageRetentionPeriod": 1209600
          }
       },
       "CollectLambdaFunction":{
@@ -462,10 +463,10 @@
                       "Ref":"PollingInterval"
                   },
                   "paws_endpoint":{
-                      "Ref":"PollApiEndpoint"
+                      "Ref":"OktaEndpoint"
                   },
                   "paws_api_secret":{
-                      "Ref":"PollApiSecret"
+                      "Ref":"OktaSecret"
                   },
                   "paws_collection_start_ts":{
                       "Ref":"CollectionStartTs"

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@okta/okta-sdk-nodejs": "3.1.0",
     "@alertlogic/al-collector-js": "1.3.4",
-    "@alertlogic/paws-collector": "1.0.2",
+    "@alertlogic/paws-collector": "1.0.3",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
     "type": "git",

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -18,14 +18,14 @@ const AlAwsCollector = require('@alertlogic/al-aws-collector-js').AlAwsCollector
 const m_packageJson = require('./package.json');
 
 class PawsCollector extends AlAwsCollector {
-    constructor(context, creds, collectorType) {
+    constructor(context, creds, pawsCollectorType) {
         super(context, 'paws',
               AlAwsCollector.IngestTypes.LOGMSGS,
               m_packageJson.version,
               creds,
               null, [], []);
-        console.info('PAWS000100 Loading collector', collectorType);
-        this._collectorType = collectorType;
+        console.info('PAWS000100 Loading collector', pawsCollectorType);
+        this._pawsCollectorType = pawsCollectorType;
         this.pollInterval = process.env.paws_poll_interval;
     };
     
@@ -33,7 +33,7 @@ class PawsCollector extends AlAwsCollector {
         let collector = this;
         let stack = {
             stackName : event.ResourceProperties.StackName,
-            pawsCollectorType : collector._collectorType,
+            pawsCollectorType : collector._pawsCollectorType,
             pawsEndpoint : process.env.paws_endpoint
         };
         
@@ -62,7 +62,7 @@ class PawsCollector extends AlAwsCollector {
         let collector = this;
         let stack = {
             stackName : event.ResourceProperties.StackName,
-            pawsCollectorType : collector._collectorType
+            pawsCollectorType : collector._pawsCollectorType
         };
         let custom = collector.pawsGetRegisterParameters(event, function(err, customRegister) {
             if (err) {


### PR DESCRIPTION
### Problem Description
PAWS mistakenly overriden `_collectorType` property of the base class.

### Solution Description
Use `paws._pawsCollectorType` instead.
Make okta template parameters friendly.

