### PR TITLE
Add DescribeStack action

### DIFF
--- a/cfn/auth0-collector.template
+++ b/cfn/auth0-collector.template
@@ -616,16 +616,7 @@
                      "Action":[
                         "cloudformation:DescribeStacks"
                      ],
-                     "Resource":[{
-                         "Fn::Join":[ "",
-                              [
-                                  "arn:aws:cloudformation:", { "Ref":"AWS::Region" },
-                                  ":",{ "Ref":"AWS::AccountId" },
-                                  ":stack/", { "Ref":"AWS::StackName" },
-                                  "/*"
-                              ]
-                          ]
-                      }]
+                     "Resource": "*"
                   },
                   {
                      "Effect":"Allow",

--- a/cfn/okta-collector.template
+++ b/cfn/okta-collector.template
@@ -609,16 +609,7 @@
                      "Action":[
                         "cloudformation:DescribeStacks"
                      ],
-                     "Resource":[{
-                         "Fn::Join":[ "",
-                              [
-                                  "arn:aws:cloudformation:", { "Ref":"AWS::Region" },
-                                  ":",{ "Ref":"AWS::AccountId" },
-                                  ":stack/", { "Ref":"AWS::StackName" },
-                                  "/*"
-                              ]
-                          ]
-                      }]
+                     "Resource": "*"
                   },
                   {
                      "Effect":"Allow",


### PR DESCRIPTION
### Problem Description
Collector get permission error  for `DescribeStacks` because of resource constraint.

### Solution Description
Use `*` resource for `DescribeStacks`
