### PR TITLE
Common template with PAWS secret encryption

### DIFF
--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -1,0 +1,869 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Alert Logic template for creating a Poll based log collector",
+    "Parameters": {
+        "AlertlogicAccessKeyId": {
+            "Description": "Alert Logic Access Key Id obtained from AIMS",
+            "Type": "String"
+        },
+        "AlertlogicSecretKey": {
+            "Description": "Alert Logic Secret Key returned from AIMS for the Access Key Id",
+            "Type": "String",
+            "NoEcho": true
+        },
+        "AlApiEndpoint": {
+            "Description": "Alert Logic API endpoint",
+            "Type": "String",
+            "Default": "api.global-services.global.alertlogic.com",
+            "AllowedValues": [
+                "api.global-services.global.alertlogic.com",
+                "api.global-integration.product.dev.alertlogic.com"
+            ]
+        },
+        "AlDataResidency": {
+            "Description": "Alert Logic Data Residency",
+            "Type": "String",
+            "Default": "default",
+            "AllowedValues": ["default"]
+        },
+        "PackagesBucketPrefix": {
+            "Description": "S3 bucket name prefix where collector packages are located.",
+            "Type": "String",
+            "Default": "alertlogic-collectors"
+        },
+        "PawsCollectorTypeName": {
+            "Description": "A collector type name. For example, okta, auth0",
+            "Type": "String"
+        },
+        "CollectorFuctionMemorySize": {
+            "Description": "Memory size for a collector function",
+            "Type": "Number",
+            "Default": 256
+        },
+        "CollectorFuctionTimeout": {
+            "Description": "Invocation timeout for a collector function.",
+            "Type": "Number",
+            "Default" : 300
+        },
+        "AlertlogicCustomerId": {
+            "Description": "Optional, Alert Logic customer ID which collected data should be reported for. If not set customer ID is derived from AIMs tokens",
+            "Type": "String",
+            "Default": ""
+        },
+        "CollectorId": {
+            "Description": "Optional, a collector UUID if known.",
+            "Type": "String",
+            "Default": "none"
+        },
+        "PollingInterval": {
+            "Description": "Interval in seconds between two consecutive poll requests.",
+            "Type": "Number",
+            "Default": 60
+        },
+        "PawsEndpoint": {
+            "Description": "URL to poll",
+            "Type": "String",
+            "Default": "https://alertlogic-admin.okta.com/"
+        },
+        "PawsAuthType": {
+            "Description": "Target API authentication type. Supported types: ssws, oauth2",
+            "Type": "String",
+            "Default": "ssws"
+        },
+        "PawsClientId": {
+            "Description": "Client ID for oauth2 authentication type",
+            "Type": "String"
+        },
+        "PawsSecret": {
+            "Description": "Client secret for oauth2 or secret token for ssws.",
+            "Type": "String",
+            "NoEcho": true
+        },
+        "CollectionStartTs": {
+            "Description": "Timestamp when log collection starts",
+            "Type": "String",
+            "Default" : "2019-11-21T16:00:00Z",
+            "AllowedPattern" : "^\\d{4}(-\\d{2}){2}T(\\d{2}:){2}\\d{2}Z$"
+        }
+    },
+    "Resources":{
+      "CollectLambdaRole":{
+         "Type":"AWS::IAM::Role",
+         "Properties":{
+            "Path":"/",
+            "AssumeRolePolicyDocument":{
+               "Version":"2012-10-17",
+               "Statement":[
+                  {
+                     "Effect":"Allow",
+                     "Principal":{
+                        "Service":[
+                           "lambda.amazonaws.com"
+                        ]
+                     },
+                     "Action":[
+                        "sts:AssumeRole"
+                     ]
+                  }
+               ]
+            }
+         }
+      },
+        "LambdaKmsKey": {
+            "Type": "AWS::KMS::Key",
+            "DependsOn":[
+                "CollectLambdaRole",
+                "EncryptLambdaRole"
+            ],
+            "Properties": {
+               "Description": "kms key used to encrypt credentials for lambda",
+               "KeyPolicy": {
+                    "Version": "2012-10-17",
+                    "Id": "al-kms-policy",
+                    "Statement": [
+                        {
+                            "Sid": "Enable IAM User Permissions",
+                            "Effect": "Allow",
+                            "Principal": {
+                            "AWS": {
+                             "Fn::Join": [
+                               ":",
+                               [
+                                 "arn:aws:iam",
+                                 "",
+                                 {
+                                   "Ref": "AWS::AccountId"
+                                 },
+                                 "root"
+                               ]
+                             ]
+                            }
+                            },
+                            "Action": "kms:*",
+                            "Resource": "*"
+                       },
+                       {
+                            "Sid": "Allow use of the key for lambda",
+                            "Effect": "Allow",
+                            "Principal": {
+                              "AWS": {
+                                "Fn::GetAtt": [
+                                  "CollectLambdaRole",
+                                  "Arn"
+                                ]
+                              }
+                            },
+                            "Action": [
+                              "kms:Decrypt",
+                              "kms:Encrypt"
+                            ],
+                            "Resource": "*"
+                       },
+                       {
+                          "Sid": "Allow use of the key for lambda encryption",
+                          "Effect": "Allow",
+                          "Principal": {
+                             "AWS": {
+                                "Fn::GetAtt": [
+                                   "EncryptLambdaRole",
+                                   "Arn"
+                                ]
+                             }
+                          },
+                          "Action": [
+                             "kms:Encrypt"
+                          ],
+                          "Resource": "*"
+                       }
+                    ]
+                },
+                "Tags": [
+                    {
+                        "Key": "AlertLogic",
+                        "Value": "Collect"
+                    }
+                ]
+            }
+        },
+        "BasicLambdaRole":{
+            "Type":"AWS::IAM::Role",
+            "Properties":{
+                "Path":"/",
+                "AssumeRolePolicyDocument":{
+                    "Version":"2012-10-17",
+                    "Statement":[
+                        {
+                            "Effect":"Allow",
+                            "Principal":{
+                                "Service":[
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                   ]
+                }
+            }
+        },
+        "EncryptLambdaRole":{
+            "Type":"AWS::IAM::Role",
+            "Properties":{
+                "Path":"/",
+                "AssumeRolePolicyDocument":{
+                    "Version":"2012-10-17",
+                    "Statement":[
+                        {
+                            "Effect":"Allow",
+                            "Principal":{
+                                "Service":[
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                   ]
+                }
+            }
+        },
+        "EncryptLambdaPolicy":{
+            "Type":"AWS::IAM::Policy",
+            "DependsOn":[
+                "EncryptLambdaRole",
+                "EncryptLambdaFunction"
+            ],
+            "Properties":{
+                "Roles":[
+                   {
+                      "Ref":"EncryptLambdaRole"
+                   }
+                ],
+                "PolicyName":"alertlogic-encrypt-lambda-policy",
+                "PolicyDocument":{
+                    "Version":"2012-10-17",
+                    "Statement":[
+                        {
+                            "Effect":"Allow",
+                            "Action":"logs:CreateLogGroup",
+                            "Resource":[
+                                {
+                                    "Fn::Join":[
+                                        "",
+                                        [
+                                            "arn:aws:logs:",
+                                            {
+                                                "Ref":"AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref":"AWS::AccountId"
+                                            },
+                                            ":log-group:/aws/lambda/",
+                                            {
+                                                "Ref":"EncryptLambdaFunction"
+                                            },
+                                            ":*"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "Effect":"Allow",
+                            "Action":[
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents"
+                            ],
+                            "Resource":[
+                                {
+                                   "Fn::Join":[
+                                        "",
+                                        [
+                                            "arn:aws:logs:",
+                                            {
+                                                "Ref":"AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref":"AWS::AccountId"
+                                            },
+                                            ":log-group:/aws/lambda/",
+                                            {
+                                                "Ref":"EncryptLambdaFunction"
+                                            },
+                                            ":log-stream:*"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "EncryptLambdaFunction":{
+            "Type":"AWS::Lambda::Function",
+            "DependsOn":[
+                "EncryptLambdaRole"
+            ],
+            "Properties":{
+                "Description":"Alert Logic Lambda Encrypt function",
+                "Role":{
+                    "Fn::GetAtt":[
+                        "EncryptLambdaRole",
+                        "Arn"
+                    ]
+                },
+                "Code":{
+                    "ZipFile": {
+                       "Fn::Join": [
+                           "",
+                           [
+                                "const AWS = require('aws-sdk');\n",
+                                "const response = require('./cfn-response');\n",
+                                "\n",
+                                "\n",
+                                "function encrypt(event, context) {\n",
+                                "    const params = {\n",
+                                "        KeyId: event.ResourceProperties.KeyId,\n",
+                                "        Plaintext: event.ResourceProperties.Plaintext\n",
+                                "    };\n",
+                                "    const kms = new AWS.KMS();\n",
+                                "    kms.encrypt(params, function(err, data) {\n",
+                                "        if (err) {\n",
+                                "            console.log(err, err.stack); // an error occurred\n",
+                                "            return response.send(event, context, response.FAILED);\n",
+                                "        }\n",
+                                "        var base64 = new Buffer(data.CiphertextBlob).toString('base64');\n",
+                                "        var responseData = {\n",
+                                "            EncryptedText : base64\n",
+                                "        };\n",
+                                "        return response.send(event, context, response.SUCCESS, responseData);\n",
+                                "    });\n",
+                                "}\n",
+                                "\n",
+                                "\n",
+                                "exports.handler = (event, context, callback) => {\n",
+                                "    if (event.ResourceType == 'AWS::CloudFormation::CustomResource' &&\n",
+                                "        event.RequestType == 'Create') {\n",
+                                "        return encrypt(event, context);\n",
+                                "    }\n",
+                                "    return response.send(event, context, response.SUCCESS);\n",
+                                "}"
+                            ]
+                        ]
+                    }
+                },
+                "Handler":"index.handler",
+                "Runtime":"nodejs12.x",
+                "MemorySize":128,
+                "Timeout": 5,
+                "Tags": [
+                    {
+                        "Key": "AlertLogic",
+                        "Value": "Collect"
+                    }
+                ]
+            }
+        },
+        "EncryptSecretKeyCustomResource": {
+            "Type": "AWS::CloudFormation::CustomResource",
+            "DependsOn": [
+                "LambdaKmsKey",
+                "EncryptLambdaFunction",
+                "EncryptLambdaPolicy"
+            ],
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "EncryptLambdaFunction",
+                        "Arn"
+                    ]
+                },
+                "KeyId": {
+                    "Fn::GetAtt": [
+                        "LambdaKmsKey",
+                        "Arn"
+                    ]
+                },
+                "Plaintext": {
+                    "Ref": "AlertlogicSecretKey"
+                }
+            }
+        },
+        "EncryptPawsSecret": {
+            "Type": "AWS::CloudFormation::CustomResource",
+            "DependsOn": [
+                "LambdaKmsKey",
+                "EncryptLambdaFunction",
+                "EncryptLambdaPolicy"
+            ],
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "EncryptLambdaFunction",
+                        "Arn"
+                    ]
+                },
+                "KeyId": {
+                    "Fn::GetAtt": [
+                        "LambdaKmsKey",
+                        "Arn"
+                    ]
+                },
+                "Plaintext": {
+                    "Ref": "PawsSecret"
+                }
+            }
+        },
+      "PawsPollStateQueue":{
+        "Type":"AWS::SQS::Queue",
+        "DependsOn":[
+         ],
+         "Properties":{
+            "QueueName" : {
+             "Fn::Join": [
+               "-",
+               [
+                 {
+                   "Ref": "AWS::StackName"
+                 },
+                 "paws-collection-state"
+               ]
+             ]
+            },
+            "VisibilityTimeout": 900,
+            "MessageRetentionPeriod": 1209600
+         }
+      },
+      "CollectLambdaFunction":{
+         "Type":"AWS::Lambda::Function",
+         "DependsOn":[
+            "CollectLambdaRole",
+            "LambdaKmsKey",
+            "EncryptSecretKeyCustomResource",
+            "EcryptPawsSecret",
+            "PawsPollStateQueue"
+         ],
+         "Properties":{
+            "Description":"Alert Logic Poll based collector",
+            "FunctionName":{ "Ref":"AWS::StackName" },
+            "Role":{
+               "Fn::GetAtt":[
+                  "CollectLambdaRole",
+                  "Arn"
+               ]
+            },
+            "KmsKeyArn": {
+               "Fn::GetAtt": [
+                  "LambdaKmsKey",
+                  "Arn"
+               ]
+            },
+            "Code":{
+               "S3Bucket":{"Fn::Join" : ["", [
+                    {"Ref":"PackagesBucketPrefix"}, "-",
+                    { "Ref" : "AWS::Region" }
+               ]]},
+               "S3Key": {"Fn::Join" : ["", [
+                    "packages/lambda/al-",
+                    { "Ref" : "PawsCollectorTypeName" },
+                    "-collector.zip"
+               ]]}
+            },
+            "Handler":"index.handler",
+            "Runtime":"nodejs12.x",
+            "MemorySize": { "Ref" : "CollectorFunctionMemorySize" },
+            "Timeout": { "Ref" : "CollectorFunctionTimeout" },
+            "Environment":{
+               "Variables":{
+                  "aims_access_key_id": {
+                      "Ref":"AlertlogicAccessKeyId"
+                  },
+                  "aims_secret_key":{
+                      "Fn::GetAtt": ["EncryptSecretKeyCustomResource", "EncryptedText"]
+                  },
+                  "aws_lambda_s3_bucket":{"Fn::Join" : ["", [
+                      {"Ref":"PackagesBucketPrefix"}, "-",
+                      {"Ref":"AWS::Region"}
+                  ]]},
+                  "aws_lambda_zipfile_name": {"Fn::Join" : ["", [
+                      "packages/lambda/al-",
+                      { "Ref" : "PawsCollectorTypeName" },
+                      "-collector.zip"
+                   ]]}, 
+                  "aws_lambda_update_config_name": {"Fn::Join" : ["", [
+                      "configs/lambda/al-",
+                      { "Ref" : "PawsCollectorTypeName" },
+                      "-collector.json"
+                  ]]},
+                  "al_api":{
+                      "Ref":"AlApiEndpoint"
+                  },
+                  "al_data_residency":{
+                      "Ref":"AlDataResidency"
+                  },
+                  "customer_id": {
+                      "Ref":"AlertlogicCustomerId"
+                  },
+                  "collector_id": {
+                      "Ref":"CollectorId"
+                  },
+                  "paws_state_queue_arn":{
+                      "Fn::GetAtt" : ["PawsPollStateQueue", "Arn"]
+                  },
+                  "paws_state_queue_url":{
+                      "Ref" : "PawsPollStateQueue"
+                  },
+                  "paws_poll_interval": {
+                      "Ref":"PollingInterval"
+                  },
+                  "paws_endpoint":{
+                      "Ref":"OktaEndpoint"
+                  },
+                  "paws_api_auth_type":{
+                      "Ref":"PawsAuthType"
+                  },
+                  "paws_api_client_id":{
+                      "Ref":"PawsClientId"
+                  },
+                  "paws_api_secret":{
+                      "Ref":"PawsSecret"
+                  },
+                  "paws_collection_start_ts":{
+                      "Ref":"CollectionStartTs"
+                  },
+                  "paws_type_name":{
+                      "Ref" : "PawsCollectorTypeName"
+                  }
+               }
+            },
+            "Tags": [
+                {
+                    "Key": "AlertLogic",
+                    "Value": "Collect"
+                }
+            ]
+         }
+      },
+      "CollectLambdaEventSourceMapping":{
+         "Type":"AWS::Lambda::EventSourceMapping",
+         "DependsOn":[
+            "CollectLambdaFunction",
+            "CollectLambdaRole",
+            "CollectLambdaPolicy",
+            "PawsPollStateQueue"
+         ],
+         "Properties":{
+            "EventSourceArn" : { "Fn::GetAtt" : ["PawsPollStateQueue", "Arn"] },
+            "FunctionName" : { "Ref":"CollectLambdaFunction" }
+         }
+      },
+      "CollectLambdaPolicy":{
+         "Type":"AWS::IAM::Policy",
+         "DependsOn":[
+            "CollectLambdaFunction",
+            "CollectLambdaRole"
+         ],
+         "Properties":{
+            "Roles":[
+               {
+                  "Ref":"CollectLambdaRole"
+               }
+            ],
+            "PolicyName":"alertlogic-paws-lambda-policy",
+            "PolicyDocument":{
+               "Version":"2012-10-17",
+               "Statement":[
+                  {
+                     "Effect":"Allow",
+                     "Action":"logs:CreateLogGroup",
+                     "Resource":[{
+                       "Fn::Join":[ "",
+                          [
+                             "arn:aws:logs:", { "Ref":"AWS::Region" },
+                             ":", { "Ref":"AWS::AccountId" },
+                             ":log-group:/aws/lambda/", { "Ref":"CollectLambdaFunction" },
+                             ":*"
+                          ]
+                       ]
+                     }]
+                  },
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents"
+                     ],
+                     "Resource":[ {
+                       "Fn::Join":["",
+                          [
+                             "arn:aws:logs:", { "Ref":"AWS::Region" },
+                             ":", { "Ref":"AWS::AccountId" },
+                             ":log-group:/aws/lambda/", { "Ref":"CollectLambdaFunction" },
+                             ":log-stream:*"
+                          ]
+                       ]
+                     }]
+                  },
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "lambda:*"
+                     ],
+                     "Resource":[{
+                       "Fn::GetAtt":[
+                           "CollectLambdaFunction",
+                           "Arn"
+                       ]
+                     }]
+                  },
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "s3:Get*"
+                     ],
+                     "Resource":[{
+                       "Fn::Join":["",
+                          [
+                             "arn:aws:s3:::",
+                             {
+                                "Fn::Join" : ["", [
+                                    { "Ref" : "PackagesBucketPrefix" }, "-",
+                                    { "Ref" : "AWS::Region" }
+                                ]]
+                             },
+                             "/*"
+                          ]
+                       ]
+                     }]
+                  },
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "sqs:*"
+                     ],
+                     "Resource":[{
+                       "Fn::GetAtt":[
+                           "PawsPollStateQueue",
+                           "Arn"
+                       ]
+                     }]
+                  }
+               ]
+            }
+         }
+      },
+      "HealthCheckLambdaPolicy":{
+         "Type":"AWS::IAM::Policy",
+         "DependsOn":[
+              "CollectLambdaRole"
+         ],
+         "Properties":{
+            "Roles":[
+               {
+                  "Ref":"CollectLambdaRole"
+               }
+            ],
+            "PolicyName":"alertlogic-health-check-lambda-policy",
+            "PolicyDocument":{
+               "Version":"2012-10-17",
+               "Statement":[
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "cloudformation:DescribeStacks"
+                     ],
+                     "Resource":[{
+                         "Fn::Join":[ "",
+                              [
+                                  "arn:aws:cloudformation:", { "Ref":"AWS::Region" },
+                                  ":",{ "Ref":"AWS::AccountId" },
+                                  ":stack/", { "Ref":"AWS::StackName" },
+                                  "/*"
+                              ]
+                          ]
+                      }]
+                  },
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "lambda:ListEventSourceMappings"
+                     ],
+                     "Resource": "*"
+                  },
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "cloudwatch:Get*",
+                        "cloudwatch:Describe*",
+                        "cloudwatch:List*"
+                     ],
+                     "Resource": "*"
+                  }
+               ]
+            }
+         }
+      },
+      "UpdaterScheduledRule": {
+         "Type": "AWS::Events::Rule",
+         "DependsOn": [
+            "CollectLambdaPolicy",
+            "CollectLambdaFunction"
+         ],
+         "Properties": {
+            "Description": "Scheduled rule for updater function",
+            "ScheduleExpression": "rate(12 hours)",
+            "State": "ENABLED",
+            "Targets":[
+                {
+                    "Id":"1",
+                    "Arn":{
+                        "Fn::GetAtt":[
+                            "CollectLambdaFunction",
+                            "Arn"
+                        ]
+                    },
+                    "Input": "{\"RequestType\": \"ScheduledEvent\", \"Type\": \"SelfUpdate\"}"
+                }
+            ]
+         }
+      },
+      "UpdaterScheduledRuleLambdaInvokePermission": {
+          "Type": "AWS::Lambda::Permission",
+          "DependsOn": [
+            "CollectLambdaFunction",
+            "CollectLambdaPolicy",
+            "UpdaterScheduledRule"
+          ],
+          "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {
+              "Ref": "CollectLambdaFunction"
+            },
+            "Principal": "events.amazonaws.com",
+            "SourceArn":{
+              "Fn::GetAtt": [
+                "UpdaterScheduledRule",
+                "Arn"
+              ]
+            }
+          }
+      },
+      "CloudWatchEventsRole":{
+         "Type": "AWS::IAM::Role",
+         "DependsOn":[
+            "CollectLambdaFunction",
+            "CollectLambdaPolicy"
+         ],
+         "Properties": {
+            "AssumeRolePolicyDocument": {
+               "Version" : "2012-10-17",
+               "Statement": [ {
+                  "Effect": "Allow",
+                  "Principal": {
+                     "Service": [ "events.amazonaws.com" ]
+                  },
+                  "Action": [ "sts:AssumeRole" ]
+               } ]
+            },
+            "Path": "/",
+            "Policies": [ {
+               "PolicyName": "root",
+               "PolicyDocument": {
+                  "Version" : "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect":"Allow",
+                      "Action":[
+                         "lambda:*"
+                      ],
+                      "Resource":[{
+                          "Fn::GetAtt":[
+                              "CollectLambdaFunction",
+                              "Arn"
+                          ]
+                      }]
+                    }
+                  ]
+               }
+            }]
+         }
+      },
+      "CheckinScheduledRule": {
+         "Type": "AWS::Events::Rule",
+         "DependsOn": [
+            "CollectLambdaFunction",
+            "CollectLambdaPolicy",
+            "HealthCheckLambdaPolicy"
+         ],
+         "Properties": {
+            "Description": "Scheduled rule for checkin function",
+            "ScheduleExpression": "rate(15 minutes)",
+            "State": "ENABLED",
+            "Targets":[
+                {
+                    "Id":"1",
+                    "Arn":{
+                        "Fn::GetAtt":[
+                            "CollectLambdaFunction",
+                            "Arn"
+                        ]
+                    },
+                    "Input": {
+                        "Fn::Join":[
+                            "",
+                            [
+                                "{\"RequestType\": \"ScheduledEvent\", \"Type\": \"Checkin\", \"AwsAccountId\": \"",
+                                { "Ref":"AWS::AccountId" },
+                                "\", \"Region\": \"",
+                                { "Ref": "AWS::Region" },
+                                "\", \"StackName\": \"",
+                                { "Ref":"AWS::StackName" },
+                                "\"}"
+                            ]
+                        ]
+                    }
+                }
+            ]
+         }
+      },
+      "CheckinScheduledRuleLambdaInvokePermission": {
+          "Type": "AWS::Lambda::Permission",
+          "DependsOn": [
+            "CollectLambdaFunction",
+            "CollectLambdaPolicy",
+            "HealthCheckLambdaPolicy",
+            "CheckinScheduledRule"
+          ],
+          "Properties": {
+            "Action": "lambda:InvokeFunction",
+            "FunctionName": {
+              "Ref": "CollectLambdaFunction"
+            },
+            "Principal": "events.amazonaws.com",
+            "SourceArn":{
+              "Fn::GetAtt": [
+                "CheckinScheduledRule",
+                "Arn"
+              ]
+            }
+          }
+      },
+      "RegistrationResource": {
+         "Type": "Custom::RegistrationResource",
+         "DependsOn": [
+            "CollectLambdaFunction",
+            "CollectLambdaPolicy"
+         ],
+         "Properties": {
+            "ServiceToken": { "Fn::GetAtt" : ["CollectLambdaFunction", "Arn"] },
+            "StackName": { "Ref" : "AWS::StackName" },
+            "AwsAccountId": { "Ref": "AWS::AccountId"}
+         }
+      }
+   }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -26,7 +26,7 @@ function getDecryptedPawsCredentials(callback) {
         const kms = new AWS.KMS();
         console.log('Decrypting PAWS creds');
         kms.decrypt(
-            {CiphertextBlob: new Buffer(process.env.paws_api_secret, 'base64')},
+            {CiphertextBlob: Buffer.from(process.env.paws_api_secret, 'base64')},
             (err, data) => {
                 if (err) {
                     return callback(err);

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -17,16 +17,70 @@ const AWS = require('aws-sdk');
 const AlAwsCollector = require('@alertlogic/al-aws-collector-js').AlAwsCollector;
 const m_packageJson = require('./package.json');
 
+var PAWS_DECRYPTED_CREDS = null;
+
+function getDecryptedPawsCredentials(callback) {
+    if (PAWS_DECRYPTED_CREDS) {
+        return callback(null, PAWS_DECRYPTED_CREDS);
+    } else {
+        const kms = new AWS.KMS();
+        console.log('Decrypting PAWS creds');
+        kms.decrypt(
+            {CiphertextBlob: new Buffer(process.env.paws_api_secret, 'base64')},
+            (err, data) => {
+                if (err) {
+                    return callback(err);
+                } else {
+                    PAWS_DECRYPTED_CREDS = {
+                        auth_type: process.env.paws_api_auth_type,
+                        client_id: process.env.paws_api_client_id,
+                        secret: data.Plaintext.toString('ascii')
+                    };
+                    
+                    return callback(null, PAWS_DECRYPTED_CREDS);
+                }
+            });
+    }
+}
+
 class PawsCollector extends AlAwsCollector {
-    constructor(context, creds, pawsCollectorType) {
+    
+    static load() {
+        return new Promise(function(resolve, reject){
+            AlAwsCollector.load().then(function(aimsCreds) {
+                getDecryptedPawsCredentials(function(err, pawsCreds) {
+                    if (err){
+                        reject(err);
+                    } else {
+                        resolve({aimsCreds : aimsCreds, pawsCreds: pawsCreds});
+                    }
+                });
+            })
+        })
+    }
+    
+    constructor(context, creds, pawsCreds) {
         super(context, 'paws',
               AlAwsCollector.IngestTypes.LOGMSGS,
               m_packageJson.version,
               creds,
               null, [], []);
-        console.info('PAWS000100 Loading collector', pawsCollectorType);
-        this._pawsCollectorType = pawsCollectorType;
+        console.info('PAWS000100 Loading collector', process.env.paws_type_name);
+        this._pawsCreds = pawsCreds;
+        this._pawsCollectorType = process.env.paws_type_name;
         this.pollInterval = process.env.paws_poll_interval;
+    };
+    
+    get secret () {
+        return this._pawsCreds.secret;
+    };
+    
+    get clientId () {
+        return this._pawsCreds.client_id;
+    };
+    
+    get authType() {
+        return this._pawsCreds.auth_type;
     };
     
     getProperties() {
@@ -164,7 +218,7 @@ class PawsCollector extends AlAwsCollector {
     
     /** 
      * @function collector callback to format received data
-     * Refer to al-collector-js.buildPayload parseCallback param
+     * Refer to al-collector-js.buildPayload parseCallback parameter
      */
     pawsFormatLog() {
         throw Error("not implemented pawsFormatLog()");

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -59,11 +59,11 @@ class PawsCollector extends AlAwsCollector {
         })
     }
     
-    constructor(context, creds, pawsCreds) {
+    constructor(context, {aimsCreds, pawsCreds}) {
         super(context, 'paws',
               AlAwsCollector.IngestTypes.LOGMSGS,
               m_packageJson.version,
-              creds,
+              aimsCreds,
               null, [], []);
         console.info('PAWS000100 Loading collector', process.env.paws_type_name);
         this._pawsCreds = pawsCreds;

--- a/test/paws_mock.js
+++ b/test/paws_mock.js
@@ -7,11 +7,12 @@ process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';
 process.env.paws_state_queue_arn = 'arn:aws:sqs:us-east-1:352283894008:test-queue';
 process.env.paws_state_queue_url = 'https://sqs.us-east-1.amazonaws.com/352283894008/test-queue';
-process.env.paws_extension = 'okta';
+process.env.paws_type_name = 'okta';
 process.env.paws_poll_interval = 900;
-process.env.okta_endpoint = 'https://test.alertlogic.com/';
-process.env.okta_token = 'okta-token';
+process.env.paws_endpoint = 'https://test.alertlogic.com/';
+process.env.paws_api_secret = 'api-token';
 process.env.collector_id = 'collector-id';
+process.env.paws_api_client_id = 'api-client-id';
 
 const AIMS_TEST_CREDS = {
     access_key_id: 'test-access-key-id',

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -79,8 +79,8 @@ function mockSQSSendMessage(returnObject) {
     });
 }
 class TestCollector extends PawsCollector {
-    constructor(ctx, aimsCreds, pawsCreds) {
-        super(ctx, aimsCreds, pawsCreds);
+    constructor(ctx, creds) {
+        super(ctx, creds);
     }
     
     pawsInitCollectionState(event, callback) {
@@ -156,8 +156,8 @@ describe('Unit Tests', function() {
                 ]
             };
             
-            PawsCollector.load().then(function({aimsCreds, pawsCreds}) {
-                var collector = new TestCollector(ctx, aimsCreds, pawsCreds);
+            PawsCollector.load().then(function(creds) {
+                var collector = new TestCollector(ctx, creds);
                 collector.handleEvent(testEvent);
             });
         });
@@ -193,8 +193,8 @@ describe('Unit Tests', function() {
                 }
             };
             
-            PawsCollector.load().then(({aimsCreds, pawsCreds}) => {
-                var collector = new TestCollector(ctx, aimsCreds, pawsCreds);
+            PawsCollector.load().then((creds) => {
+                var collector = new TestCollector(ctx, creds);
                 collector.handleEvent(testEvent);
             });
         });

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -5,7 +5,6 @@ const m_response = require('cfn-response');
 
 const pawsMock = require('./paws_mock');
 var m_alCollector = require('@alertlogic/al-collector-js');
-var AlAwsCollector = require('@alertlogic/al-aws-collector-js').AlAwsCollector;
 var PawsCollector = require('../paws_collector').PawsCollector;
 const m_al_aws = require('@alertlogic/al-aws-collector-js').Util;
 
@@ -80,8 +79,8 @@ function mockSQSSendMessage(returnObject) {
     });
 }
 class TestCollector extends PawsCollector {
-    constructor(ctx, creds) {
-        super(ctx, creds, 'test-collector');
+    constructor(ctx, aimsCreds, pawsCreds) {
+        super(ctx, aimsCreds, pawsCreds);
     }
     
     pawsInitCollectionState(event, callback) {
@@ -113,7 +112,7 @@ describe('Unit Tests', function() {
     beforeEach(function(){
         AWS.mock('KMS', 'decrypt', function (params, callback) {
             const data = {
-                Plaintext : 'decrypted-aims-sercret-key'
+                Plaintext : 'decrypted-sercret-key'
             };
             return callback(null, data);
         });
@@ -157,8 +156,8 @@ describe('Unit Tests', function() {
                 ]
             };
             
-            AlAwsCollector.load().then(function(creds) {
-                var collector = new TestCollector(ctx, creds, 'test');
+            PawsCollector.load().then(function({aimsCreds, pawsCreds}) {
+                var collector = new TestCollector(ctx, aimsCreds, pawsCreds);
                 collector.handleEvent(testEvent);
             });
         });
@@ -194,8 +193,8 @@ describe('Unit Tests', function() {
                 }
             };
             
-            AlAwsCollector.load().then(function(creds) {
-                var collector = new TestCollector(ctx, creds, 'test');
+            PawsCollector.load().then(({aimsCreds, pawsCreds}) => {
+                var collector = new TestCollector(ctx, aimsCreds, pawsCreds);
                 collector.handleEvent(testEvent);
             });
         });


### PR DESCRIPTION
### Solution Description
Add a common template. Ideally a collector template will proxy input parameters and have only one 
AWS::CloudFormation::Stack resource.
Also PAWS secret parameter encryption was added, same way AIMs secret is encrypted.
