### PR TITLE
Implement CLI driver for auth0

### DIFF
--- a/collectors/auth0/auth0_collector.js
+++ b/collectors/auth0/auth0_collector.js
@@ -39,7 +39,7 @@ class Auth0Collector extends PawsCollector {
         let collector = this;
         const auth0Client = new ManagementClient({
             domain: process.env.paws_endpoint,
-            clientId: collector.collectorId,
+            clientId: collector.clientId,
             clientSecret: collector.secret,
             scope: 'read:logs'
         });

--- a/collectors/auth0/cli.js
+++ b/collectors/auth0/cli.js
@@ -1,0 +1,102 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2019, Alert Logic, Inc
+ * @doc
+ *
+ * CLI driver for local collector testing.
+ *
+ * This driver simply exercises the collector and prints collection state and
+ * logs to the console. Can be enhanced with dumping to a file or similar in
+ * future.
+ *
+ * USAGE:
+ *
+ * node cli.js [ARGUMENTS]
+ *
+ * Command line parameters are copied one-for-one into process.env. Any parameters
+ * required by YOUR collector are required here. There are no additional requirements
+ * since this CLI driver is essentially orthogonal to the real collection framework.
+ *
+ * For Auth0, for example:
+ *   REQUIRED:
+ *     --paws_endpoint=YOUR_OAUTH_DOMAIN
+ *     --paws_api_client_id=YOUR_OAUTH_CLIENT_ID
+ *     --paws_api_secret=YOUR_OAUTH_SECRET
+ *
+ *   OPTIONAL:
+ *     --paws_collection_start_ts="2019-11-21T00:00:00Z"
+ *     --poll_interval=5
+ *     --poll_count=1
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+// Instantiate your collector
+const Collector = require('./auth0_collector').Auth0Collector;
+
+// Environment
+const debug = require('debug') ('index');
+const argv = require('yargs').argv;
+
+// Initialization
+const pollInterval = argv.poll_interval ? argv.poll_interval : 5;
+const pollCount = argv.poll_count ? argv.poll_count : 1;
+
+// Service credentials
+//   - simulate decrypted credentials by passing in from CLI arguments
+const pawsCreds = {
+    auth_type: "oauth",
+    client_id: argv.paws_api_client_id,
+    secret: argv.paws_api_secret
+};
+
+// AIMS credentials (can be empty)
+//   - simulate decrypted credentials by passing in from CLI arguments
+const aimsCreds = {
+    access_key_id: argv.aims_access_key_id,
+    secret_key: argv.aims_secret_key
+};
+
+// Copy command line arguments into process.env
+process.env = argv;
+
+// Create the collector
+var c = new Collector({}, {aimsCreds, pawsCreds});
+c.pollInterval = pollInterval;  // we need to set this b/c we don't have the CFN setting it for us
+
+var pollsExecuted = 0;
+
+var handleLogs = function(error, newLogs, state, nextInterval) {
+    if (error) {
+        console.log("ERROR: " + error);
+        return null;
+    }
+    else {
+        var formattedLogs = [];
+        newLogs.forEach(function(msg) { formattedLogs.push(c.pawsFormatLog(msg)); });
+
+        console.log(formattedLogs);
+        console.log(state);
+        pollsExecuted++;
+
+        if (pollsExecuted >= pollCount) {
+            console.log("Completed " + pollsExecuted + " polling calls");
+            return state;
+        } else {
+            console.log("Initiating poll number " + (pollsExecuted+1));
+            c.pawsGetLogs(state, handleLogs);
+        }
+    }
+};
+
+c.pawsInitCollectionState(null, function(error, state, interval) {
+    if (error) {
+        console.log("ERROR from pawsInitCollectionState: " + error);
+    } else {
+        console.log(state);
+        console.log("Initiating poll number " + (pollsExecuted+1));
+        c.pawsGetLogs(state, handleLogs);
+    }
+});
+
+

--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -9,6 +9,7 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura mocha --colors --reporter mocha-jenkins-reporter"
   },
   "devDependencies": {
+    "aws-sdk": "^2.588.0",
     "jshint": "^2.9.5",
     "mocha": "^6.2.2",
     "mocha-jenkins-reporter": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mocha-jenkins-reporter": "^0.4.2",
     "nyc": "^14.1.1",
     "rewire": "^4.0.1",
+    "yargs": "^15.0.2",
     "sinon": "^7.5.0"
   },
   "dependencies": {


### PR DESCRIPTION
### Problem Description
Unnecessary effort is required to simply test that the collection implementation in a paws collector works.

### Solution Description
Provide a simple command-line driver that will exercise the collection aspect of a collector independent of any Alert Logic identity, registration, transport, etc.

This is not a substitute for automated tests but it will confirm that the collector implementation actually collects logs.

I suggest we integrate this into the collector template/generator also (separate PR).

Compared to #22 -
  * Updated for changes in paws framework
  * Fix auth0 clientId

To run this (**please note argument changes**):
```
cd collectors/auth0
npm install
node cli.js --paws_endpoint=$DOMAIN --paws_api_client_id=$CLIENT_ID --paws_api_secret=$CLIENT_SECRET
```
