### PR TITLE
Fix checkin permissions

### DIFF
--- a/cfn/collector.template.template
+++ b/cfn/collector.template.template
@@ -680,16 +680,7 @@
                      "Action":[
                         "cloudformation:DescribeStacks"
                      ],
-                     "Resource":[{
-                         "Fn::Join":[ "",
-                              [
-                                  "arn:aws:cloudformation:", { "Ref":"AWS::Region" },
-                                  ":",{ "Ref":"AWS::AccountId" },
-                                  ":stack/", { "Ref":"AWS::StackName" },
-                                  "/*"
-                              ]
-                          ]
-                      }]
+                     "Resource": "*"
                   },
                   {
                      "Effect":"Allow",

--- a/cfn/o365-collector.template
+++ b/cfn/o365-collector.template
@@ -659,16 +659,7 @@
                      "Action":[
                         "cloudformation:DescribeStacks"
                      ],
-                     "Resource":[{
-                         "Fn::Join":[ "",
-                              [
-                                  "arn:aws:cloudformation:", { "Ref":"AWS::Region" },
-                                  ":",{ "Ref":"AWS::AccountId" },
-                                  ":stack/", { "Ref":"AWS::StackName" },
-                                  "/*"
-                              ]
-                          ]
-                      }]
+                     "Resource": "*"
                   },
                   {
                      "Effect":"Allow",

--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -680,16 +680,7 @@
                      "Action":[
                         "cloudformation:DescribeStacks"
                      ],
-                     "Resource":[{
-                         "Fn::Join":[ "",
-                              [
-                                  "arn:aws:cloudformation:", { "Ref":"AWS::Region" },
-                                  ":",{ "Ref":"AWS::AccountId" },
-                                  ":stack/", { "Ref":"AWS::StackName" },
-                                  "/*"
-                              ]
-                          ]
-                      }]
+                     "Resource": "*"
                   },
                   {
                      "Effect":"Allow",


### PR DESCRIPTION
### Problem Description
`cloudformation:DescribeStacks` only supports `*` resource

### Solution Description
Fix `DescribeStacks` permission
