### PR TITLE
Use constant paws_endpoint for o365

### DIFF
--- a/cfn/o365-collector.template
+++ b/cfn/o365-collector.template
@@ -65,11 +65,6 @@
             "Type": "String",
             "Default": "[\"Audit.AzureActiveDirectory\", \"Audit.Exchange\", \"Audit.SharePoint\", \"Audit.General\"]"
         },
-        "MsManagementEndpoint": {
-            "Description": "Mangament endpoint to poll",
-            "Type": "String",
-            "Default": "https://managment.office.com/"
-        },
         "CollectionStartTs": {
             "Description": "Timestamp when log collection starts",
             "Type": "String",
@@ -517,9 +512,7 @@
                   "stack_name": {
                       "Ref":"AWS::StackName"
                   },
-                  "paws_endpoint": {
-                      "Ref": "MsManagementEndpoint"
-                  },
+                  "paws_endpoint": "https://managment.office.com/",
                   "paws_type_name": "o365"
                }
             },


### PR DESCRIPTION
### Solution Description
Poll endpoint is constant for all o365 collectors. Therefore there is no need to have it as an input parameter in CFN.
