### PR TITLE
fix malformed json in cfn regex

### DIFF
--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -87,7 +87,7 @@
         "PawsCredsS3Uri": {
             "Description": "The S3 uri where object where credentials are stored. in the for s3://<bucket>/<object-path> Only used when PawsAuthType is 's3object'",
             "Type": "String",
-            "AllowedPattern" : "^s3:\/\/[a-z,\-,0-9]*\/[a-z,\-,\.,\_,0-9]*",
+            "AllowedPattern" : "^s3:\/\/[a-z,\\-,0-9]*\/[a-z,\\-,\\.,\\_,0-9]*",
             "Default": ""
         },
         "CollectionStartTs": {


### PR DESCRIPTION
### Problem Description
Regex for AllowedPAttern on PawsCredsS3Uri had unescaped backslash characters, leading to malformed JSON errors upon deploy

### Solution Description
Escape the backslash characters in the regex

