### PR TITLE
Okta: Report throttling errors

### DIFF
--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -61,7 +61,7 @@ class OktaCollector extends PawsCollector {
             return callback(null, logAcc, newState, newState.poll_interval_sec);
         })
         .catch((error) => {
-            if (error.message && error.message.match(THROTTLING_ERROR_REGEXP)) {
+            if (this._isThrottlingError(error)) {
                 collector.reportApiThrottling(function() {
                     return callback(error);
                 });
@@ -69,6 +69,11 @@ class OktaCollector extends PawsCollector {
                 return callback(error);
             }
         });
+    }
+    
+    _isThrottlingError(error) {
+        return (error.status === 429) ||
+             (error.message && error.message.match(THROTTLING_ERROR_REGEXP));
     }
     
     _getNextCollectionState(curState) {

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -14,6 +14,7 @@
     "jshint": "^2.9.5",
     "mocha": "^6.2.2",
     "mocha-jenkins-reporter": "^0.4.2",
+    "nock": "^10.0.6",
     "nyc": "^14.1.1",
     "rewire": "^4.0.1",
     "sinon": "^7.5.0"

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@okta/okta-sdk-nodejs": "3.1.0",
     "@alertlogic/al-collector-js": "1.4.2",
-    "@alertlogic/paws-collector": "1.0.12",
+    "@alertlogic/paws-collector": "1.0.14",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"


### PR DESCRIPTION
### Solution Description
Make okta collector report 429 rate exceeded errors.
Unfortunately okta SDK doesn't include any codes into errors, only test messages.

