### PR TITLE
token healthcheck for okta

### DIFF
--- a/collectors/okta/health_checks.js
+++ b/collectors/okta/health_checks.js
@@ -1,0 +1,41 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2019, Alert Logic, Inc
+ * @doc
+ *
+ * Okta health checks.
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+ 'use strict';
+
+ const https = require('https');
+ const PawsCollector = require('@alertlogic/paws-collector').PawsCollector;
+ 
+    function oktaTokenHealthCheck(asyncCallback){
+        /* No explicit call to validate an API token, the token expires after 30 days, this 30 day timeout is refreshed 
+         * upon any API calls. This call will refresh token, without being time consuming/destructive
+         */
+        var orgUrl = process.env.paws_endpoint;
+        var token = String.concat("SSWS ", PawsCollector._pawsCreds.secret);
+        var options = {
+            host: orgUrl,
+            path: "/api/v1/users/me",
+            headers: {
+                authorization: token
+            }
+        };
+        https.get(options, (res) => {
+          res.on('end', () => {
+                asyncCallback(null);
+          });
+      
+        }).on('error', (e) => {
+          asyncCallback(e);
+      });
+    }
+    
+module.exports = {
+    oktaTokenHealthCheck
+};

--- a/collectors/okta/health_checks.js
+++ b/collectors/okta/health_checks.js
@@ -11,19 +11,20 @@
  'use strict';
 
  const https = require('https');
- const PawsCollector = require('@alertlogic/paws-collector').PawsCollector;
  
     function oktaTokenHealthCheck(asyncCallback){
         /* No explicit call to validate an API token, the token expires after 30 days, this 30 day timeout is refreshed 
          * upon any API calls. This call will refresh token, without being time consuming/destructive
          */
         var orgUrl = process.env.paws_endpoint;
-        var token = "SSWS " + PawsCollector._pawsCreds.secret;
+        var token = "SSWS " + this._pawsCreds.secret;
         var options = {
-            host: orgUrl,
+            host: orgUrl.replace("https://", ""),
             path: "/api/v1/users/me",
             headers: {
-                authorization: token
+                Accept: "application/json",
+                Content: "application/json",
+                Authorization: token
             }
         };
         https.get(options, (res) => {

--- a/collectors/okta/health_checks.js
+++ b/collectors/okta/health_checks.js
@@ -18,7 +18,7 @@
          * upon any API calls. This call will refresh token, without being time consuming/destructive
          */
         var orgUrl = process.env.paws_endpoint;
-        var token = String.concat("SSWS ", PawsCollector._pawsCreds.secret);
+        var token = "SSWS " + PawsCollector._pawsCreds.secret;
         var options = {
             host: orgUrl,
             path: "/api/v1/users/me",
@@ -32,7 +32,8 @@
           });
       
         }).on('error', (e) => {
-          asyncCallback(e);
+            var err = e.message;
+            asyncCallback(`OKTA000003 Failed to validate auth token for ${orgUrl} due to error ${err}`);
       });
     }
     

--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -31,11 +31,9 @@ const tsPaths = [
 class OktaCollector extends PawsCollector {
 
     constructor(context, {aimsCreds, pawsCreds}){
-        super(context, 'paws',
-            AlAwsCollector.IngestTyps.LOGMSGS,
-            m_packageJson.version,
-            aimsCreds,
-            null, [healthChecks.oktaTokenHealthCheck], []);
+        super(context,
+            {aimsCreds, pawsCreds},
+            [healthChecks.oktaTokenHealthCheck], []);
     }
     
     pawsInitCollectionState(event, callback) {

--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -11,6 +11,7 @@
 
 const moment = require('moment');
 const okta = require('@okta/okta-sdk-nodejs');
+const healthChecks = require('./health_checks');
 const parse = require('@alertlogic/al-collector-js').Parse;
 const PawsCollector = require('@alertlogic/paws-collector').PawsCollector;
 const calcNextCollectionInterval = require('@alertlogic/paws-collector').calcNextCollectionInterval;
@@ -29,6 +30,14 @@ const tsPaths = [
 
 class OktaCollector extends PawsCollector {
 
+    constructor(context, {aimsCreds, pawsCreds}){
+        super(context, 'paws',
+            AlAwsCollector.IngestTyps.LOGMSGS,
+            m_packageJson.version,
+            aimsCreds,
+            null, [healthChecks.oktaTokenHealthCheck], []);
+    }
+    
     pawsInitCollectionState(event, callback) {
         const startTs = process.env.paws_collection_start_ts ?
                 process.env.paws_collection_start_ts :

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -22,7 +22,7 @@
   "dependencies": {
     "@okta/okta-sdk-nodejs": "3.1.0",
     "@alertlogic/al-collector-js": "^1.4.2",
-    "@alertlogic/paws-collector": "^1.1.0",
+    "@alertlogic/paws-collector": "^1.1.3",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/okta/test/okta_test.js
+++ b/collectors/okta/test/okta_test.js
@@ -314,4 +314,26 @@ describe('Unit Tests', function() {
             });
         });
     });
+    describe('Health Check Tests', function() {
+        it('token validation check success', function(done) {
+            let ctx = {
+                invokedFunctionArn : oktaMock.FUNCTION_ARN,
+                fail : function(error) {
+                    assert.fail(error);
+                    done();
+                },
+                succeed : function() {
+                    done();
+                }
+            };
+            
+            OktaCollector.load().then(function(creds) {
+                var collector = new OktaCollector(ctx, creds);
+                let fmt = collector.pawsFormatLog(oktaMock.OKTA_LOG_EVENT);
+                assert.equal(fmt.progName, 'OktaCollector');
+                assert.ok(fmt.messageTypeId);
+                done();
+            });
+        });
+    });
 });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "2.0.6",
+    "@alertlogic/al-aws-collector-js": "2.0.7",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "1.2.0",
+  "version": "1.1.3",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -71,7 +71,7 @@ class PawsCollector extends AlAwsCollector {
         });
     }
 
-    constructor(context, {aimsCreds, pawsCreds}) {
+    constructor(context, {aimsCreds, pawsCreds}, healthChecks, statsChecks) {
         super(context, 'paws',
               AlAwsCollector.IngestTypes.LOGMSGS,
               m_packageJson.version,

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -76,7 +76,7 @@ class PawsCollector extends AlAwsCollector {
               AlAwsCollector.IngestTypes.LOGMSGS,
               m_packageJson.version,
               aimsCreds,
-              null, [], []);
+              null, healthChecks, statsChecks);
         console.info('PAWS000100 Loading collector', process.env.paws_type_name);
         this._pawsCreds = pawsCreds;
         this._pawsCollectorType = process.env.paws_type_name;


### PR DESCRIPTION
### Problem Description
needed a health check to monitor status of okta collector

### Solution Description
add a healthcheck, calling the /me endpoint of the okta API manually as this method isn't implemented by the SDK

### Acceptance Criteria for Contributors
- [ ] No errors / warnings on build (including linter)
- [ ] 100% automated test coverage
- [ ] Source layout followed from other collectors
- [ ] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [ ] Logging of main steps in the collector’s code
- [ ] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [ ] API throttling errors are understood and and properly handled
- [ ] Registration/update/deregistration validated
- [ ] Stats and status validated
- [ ] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [ ] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [ ] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [ ] Links to API documentation
- [ ] At least temporary access to an environment where RCS can validate collector implementation
- [ ] Contact details in case access to this environment is needed in the future
 
