### PR TITLE
Collector state batch splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -229,9 +229,10 @@ class PawsCollector extends AlAwsCollector {
         });
 
         var promises = [];
-        for (let i = 0; i < SQSMsgs.length; i += 10) {
+        const SQS_BATCH_LIMIT = 10
+        for (let i = 0; i < SQSMsgs.length; i += SQS_BATCH_LIMIT) {
             let params = {
-                Entries: SQSMsgs.slice(i, i + 10),
+                Entries: SQSMsgs.slice(i, i + SQS_BATCH_LIMIT),
                 QueueUrl: process.env.paws_state_queue_url
             };
             let promise = new Promise((resolve, reject) => {

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -131,7 +131,12 @@ class TestCollectorMultiState extends PawsCollector {
     }
     
     pawsGetLogs(state, callback) {
-        return callback(null, ['log1', 'log2'], [{state: 'new-state-1'}, {state: 'new-state-2'}], 900);
+        return callback(
+            null,
+            ['log1','log2'],
+            new Array(99).fill(0).map((e,i) => ({state: 'new-state-' + i})),
+            900
+        );
     }
     
     pawsGetRegisterParameters(event, callback) {

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -252,13 +252,9 @@ describe('Unit Tests', function() {
 
         it('sends multiple SQS batches when greater than len privCollectorStates is > 10', function(done) {
 
-            let counter = 0;
-            AWS.remock('SQS', 'sendMessageBatch', function (params, callback) {
-                let buf = Buffer(JSON.stringify({}));
-                counter++;
-                callback(null, {Body: buf});
-            });
-
+            let buf = Buffer(JSON.stringify({}));
+            let spy = sinon.spy((params, callback) => callback(null, {Body: buf}));
+            AWS.remock('SQS', 'sendMessageBatch', spy);
 
             let ctx = {
                 invokedFunctionArn : pawsMock.FUNCTION_ARN,
@@ -280,7 +276,7 @@ describe('Unit Tests', function() {
             TestCollectorMultiState.load().then(function(creds) {
                 let collector = new TestCollectorMultiState(ctx, creds);
                 collector._storeCollectionState(initialPawsState, privCollectorStates, 0, err => {
-                    assert.equal(counter, 8);
+                    assert.equal(spy.callCount, 8);
                     done();
                 });
             });


### PR DESCRIPTION
### Problem Description
- SQS batch size is limited to 10 messages per batch

### Solution Description
- split batches into slices of >10 and submit concurrently to AWS
