### PR TITLE
add function to calculate collection interval to the library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,5 @@ node_js:
   - "10"
 install:
   - make deps
-  - make -C collectors/okta deps
 script:
   - make test
-  - make -C collectors/okta test

--- a/collectors/auth0/auth0_collector.js
+++ b/collectors/auth0/auth0_collector.js
@@ -26,7 +26,7 @@ const tsPaths = [
 
 
 class Auth0Collector extends PawsCollector {
-    
+
     pawsInitCollectionState(event, callback) {
         const initialState = {
             since: process.env.paws_collection_start_ts ? process.env.paws_collection_start_ts : moment().subtract(5, 'minutes').toISOString(),
@@ -34,7 +34,7 @@ class Auth0Collector extends PawsCollector {
         };
         return callback(null, initialState, 1);
     }
-    
+
     pawsGetLogs(state, callback) {
         let collector = this;
         const auth0Client = new ManagementClient({
@@ -60,25 +60,25 @@ class Auth0Collector extends PawsCollector {
             return callback(error);
         });
     }
-    
+
     _getNextCollectionState(curState, nextLogId, lastLogTs) {
         const nowMoment = moment();
         const lastLogMoment = moment(lastLogTs);
-        
+
         // Check if we're behind collection schedule and need to catch up.
         const nextPollInterval = nowMoment.diff(lastLogMoment, 'seconds') > this.pollInterval ?
                 1 : this.pollInterval;
-        
+
         return  {
             last_log_id: nextLogId,
             poll_interval_sec: nextPollInterval
         };
     }
-    
+
     pawsFormatLog(msg) {
         const ts = parse.getMsgTs(msg, tsPaths);
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
-        
+
         let formattedMsg = {
             messageTs: ts.sec,
             priority: 11,
@@ -86,7 +86,7 @@ class Auth0Collector extends PawsCollector {
             message: JSON.stringify(msg),
             messageType: 'json/auth0'
         };
-        
+
         if (typeId !== null && typeId !== undefined) {
             formattedMsg.messageTypeId = `${typeId}`;
         }

--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "auth0": "2.20.0",
     "@alertlogic/al-collector-js": "1.4.2",
-    "@alertlogic/paws-collector": "1.0.12",
+    "@alertlogic/paws-collector": "1.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "1.4.2",
-    "@alertlogic/paws-collector": "1.0.12",
+    "@alertlogic/paws-collector": "1.0.15",
     "@google-cloud/logging": "6.0.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/collectors/gsuite/collector.js
+++ b/collectors/gsuite/collector.js
@@ -11,6 +11,7 @@
 
 const moment = require("moment");
 const PawsCollector = require("@alertlogic/paws-collector").PawsCollector;
+const calcNextCollectionInterval = require('@alertlogic/paws-collector').calcNextCollectionInterval;
 const parse = require("@alertlogic/al-collector-js").Parse;
 
 const { auth } = require("google-auth-library");
@@ -123,36 +124,14 @@ class GsuiteCollector extends PawsCollector {
     }
 
     _getNextCollectionState(curState) {
-        const nowMoment = moment();
-        const curUntilMoment = moment(curState.until);
 
-        // Check if current 'until' is in the future.
-        const nextSinceTs = curUntilMoment.isAfter(nowMoment)
-            ? nowMoment.toISOString()
-            : curState.until;
+        const untilMoment = moment(curState.until);
 
-
-        let nextUntilMoment;
-        if (nowMoment.diff(nextSinceTs, 'hours') > 24) {
-            console.log('collection is more than 24 hours behind. Increasing the collection time to catch up')
-            nextUntilMoment = moment(nextSinceTs).add(24, 'hours');
-        }
-        else if (nowMoment.diff(nextSinceTs, 'hours') > 1) {
-            console.log('collection is more than 1 hour behind. Increasing the collection time to catch up')
-            nextUntilMoment = moment(nextSinceTs).add(1, 'hours');
-        }
-        else {
-            nextUntilMoment = moment(nextSinceTs).add(this.pollInterval, 'seconds');
-        }
-        // Check if we're behind collection schedule and need to catch up.
-        const nextPollInterval =
-            nowMoment.diff(nextUntilMoment, "seconds") > this.pollInterval
-                ? 1
-                : this.pollInterval;
+        const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-day-progression', untilMoment, this.pollInterval);
 
         return {
             application: curState.application,
-            since: nextSinceTs,
+            since: nextSinceMoment.toISOString(),
             until: nextUntilMoment.toISOString(),
             apiQuotaResetDate: null,
             poll_interval_sec: nextPollInterval

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@alertlogic/al-collector-js": "1.4.2",
-        "@alertlogic/paws-collector": "1.0.14",
+        "@alertlogic/paws-collector": "1.0.15",
         "async": "3.1.0",
         "debug": "4.1.1",
         "googleapis": "39.2.0",

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "1.4.0",
-    "@alertlogic/paws-collector": "1.0.10",
+    "@alertlogic/paws-collector": "1.0.15",
     "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-azure-js": "2.0.1",
     "@azure/ms-rest-nodeauth": "2.0.5",

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@okta/okta-sdk-nodejs": "3.1.0",
     "@alertlogic/al-collector-js": "1.4.2",
-    "@alertlogic/paws-collector": "1.0.14",
+    "@alertlogic/paws-collector": "1.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/index.js
+++ b/index.js
@@ -10,5 +10,6 @@
  */
 
 module.exports = {
-    PawsCollector : require('./paws_collector').PawsCollector
+    PawsCollector : require('./paws_collector').PawsCollector,
+    calcNextCollectionInterval : require('./paws_utils').calcNextCollectionInterval
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_utils.js
+++ b/paws_utils.js
@@ -1,0 +1,76 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2020, Alert Logic, Inc
+ * @doc
+ *
+ * Utility functions for PAWS collector
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+'use strict';
+
+const moment = require('moment');
+
+function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
+    const nowMoment = moment();
+    const nextSinceMoment = curUntilMoment.isAfter(nowMoment) ?
+        nowMoment : curUntilMoment;
+
+    let nextUntilMoment;
+
+    switch(strategy) {
+        case 'day-week-progression':
+            if (nowMoment.diff(nextSinceMoment, 'days') > 7) {
+                nextUntilMoment = moment(nextSinceMoment).add(7, 'days');
+            }
+            else if (nowMoment.diff(nextSinceMoment, 'days') > 1) {
+                nextUntilMoment = moment(nextSinceMoment).add(24, 'hours');
+            }
+            else {
+                nextUntilMoment = moment(nextSinceMoment).add(pollInterval, 'seconds');
+            }
+            break;
+        case 'hour-day-progression':
+            if (nowMoment.diff(nextSinceMoment, 'hours') > 24) {
+                nextUntilMoment = moment(nextSinceMoment).add(24, 'hours');
+            }
+            else if (nowMoment.diff(nextSinceMoment, 'hours') > 1) {
+                nextUntilMoment = moment(nextSinceMoment).add(1, 'hours');
+            }
+            else {
+                nextUntilMoment = moment(nextSinceMoment).add(pollInterval, 'seconds');
+            }
+            break;
+        case 'hour-cap':
+            if (nowMoment.diff(nextSinceMoment, 'hours') > 1) {
+                nextUntilMoment = moment(nextSinceMoment).add(1, 'hours');
+            }
+            else {
+                nextUntilMoment = moment(nextSinceMoment).add(pollInterval, 'seconds');
+            }
+            break;
+        case 'day-cap':
+            if (nowMoment.diff(nextSinceMoment, 'hours') > 24) {
+                nextUntilMoment = moment(nextSinceMoment).add(24, 'hours');
+            }
+            else {
+                nextUntilMoment = moment(nextSinceMoment).add(pollInterval, 'seconds');
+            }
+            break;
+        case 'no-cap':
+            nextUntilMoment = moment(nextSinceMoment).add(pollInterval, 'seconds');
+            break;
+        default:
+            throw new Error("Unknow strategy for capping next until timestamp!");
+    }
+
+    const nextPollInterval = nowMoment.diff(nextUntilMoment, 'seconds') > pollInterval ?
+            1 : pollInterval;
+
+    return { nextSinceMoment, nextUntilMoment, nextPollInterval };
+}
+
+module.exports = {
+    calcNextCollectionInterval: calcNextCollectionInterval
+}
+


### PR DESCRIPTION
### Problem Description
Collection interval-related calculations are duplicated across all collectors.

### Solution Description
New function has been added in paws_collector library: `calcNextCollectionInterval`
- strategy: can be one from the list
  1. `'no-cap'` - do not cap collection interval length
  2. `'day-cap'` - limit collection interval length to day
  3. `'hour-cap'` - limit collection interval length to hour
  4. `'hour-day-progression`' - if collection interval is longer than day limit it to one day, if it shorter than day but longer than hour limit it to one hour
  5. `'day-week-progression`' - if collection interval is longer than week limit it to one week, if it shorter than week but longer than day limit it to one day
- `curUntilMoment` - current until moment() from collection state
- `pollInterval` - current polling interval from collection state
