### PR TITLE
fix paws_template syntax

### DIFF
--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -13,7 +13,7 @@
         },
         "AlApplicationId": {
             "Description": "Alert Logic Application Id for collector logs",
-            "Type": "String"
+            "Type": "String",
             "Default": "paws"
         },
         "AlApiEndpoint": {


### PR DESCRIPTION
### Problem Description
- missing comma in paws-template cfn

### Solution Description
- add comma

