### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -81,10 +81,11 @@ class PawsCollector extends AlAwsCollector {
         this._pawsCreds = pawsCreds;
         this._pawsCollectorType = process.env.paws_type_name;
         this.pollInterval = process.env.paws_poll_interval;
+        this.applicationId = process.env.al_application_id;
     };
 
     get application_id () {
-        return process.env.al_application_id;
+        return this.applicationId;
     };
 
     get secret () {
@@ -171,7 +172,7 @@ class PawsCollector extends AlAwsCollector {
             },
             function(logs, privCollectorState, nextInvocationTimeout, asyncCallback) {
                 console.info('PAWS000200 Log events received ', logs.length);
-                return collector.processLog(logs, collector.pawsFormatLog, null, function(err) {
+                return collector.processLog(logs, collector.pawsFormatLog.bind(collector), null, function(err) {
                     return asyncCallback(err, privCollectorState, nextInvocationTimeout);
                 });
             },

--- a/test/paws_mock.js
+++ b/test/paws_mock.js
@@ -18,6 +18,7 @@ process.env.paws_api_secret = 'api-token';
 process.env.collector_id = 'collector-id';
 process.env.paws_secret_param_name = 'PAWS-SECRET-paws';
 process.env.paws_api_client_id = 'api-client-id';
+process.env.al_application_id = 'paws';
 
 const AIMS_TEST_CREDS = {
     access_key_id: 'test-access-key-id',

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -108,12 +108,15 @@ class TestCollector extends PawsCollector {
     }
     
     pawsFormatLog(msg) {
+        const collector = this;
+        
         let formattedMsg = {
             messageTs: 12345678,
             priority: 11,
             progName: 'OktaCollector',
             message: JSON.stringify(msg),
-            messageType: 'json/aws.test'
+            messageType: 'json/aws.test',
+            applicationId: collector.application_id
         };
         return formattedMsg;
     }
@@ -143,13 +146,17 @@ class TestCollectorMultiState extends PawsCollector {
     }
     
     pawsFormatLog(msg) {
+        const collector = this;
+        
         let formattedMsg = {
             messageTs: 12345678,
             priority: 11,
             progName: 'OktaCollectorArrayState',
             message: JSON.stringify({test: 'message'}),
-            messageType: 'json/aws.test'
+            messageType: 'json/aws.test',
+            applicationId: collector.application_id
         };
+        
         return formattedMsg;
     }
 }
@@ -360,12 +367,14 @@ describe('Unit Tests', function() {
                 priority: 11,
                 progName: 'OktaCollector',
                 message: '"test"',
-                messageType: 'json/aws.test'
+                messageType: 'json/aws.test',
+                applicationId: 'paws'
             };
             
-            PawsCollector.load().then((creds) => {
-            const collector = new TestCollector(ctx, creds);
-            const returned = collector.pawsFormatLog("test");
+            TestCollector.load().then((creds) => {
+            let collector = new TestCollector(ctx, creds);
+            let bindFormat = collector.pawsFormatLog.bind(collector);
+            const returned = bindFormat("test");
             assert.deepEqual(returned, formattedMsg);
             done();
             });


### PR DESCRIPTION
### Problem Description
Log formatting function is called without object context. There for collector properties are not available within this function

### Solution Description
Bind collector object to `pawsFormatLog` callback when it is called.

Similar to https://github.com/alertlogic/paws-collector/pull/73

