### PR TITLE
add param name to test mock

### DIFF
--- a/collectors/o365/test/o365_mock.js
+++ b/collectors/o365/test/o365_mock.js
@@ -8,6 +8,7 @@ process.env.paws_api_client_id = 'a-client-id';
 process.env.paws_api_secret = 'paws-secret-key-encrypted';
 process.env.log_group = 'logGroupName';
 process.env.paws_state_queue_arn = "arn:aws:sqs:us-east-1:352283894008:paws-state-queue";
+process.env.paws_secret_param_name =  "joe-o365-test-param";
 process.env.paws_collector_param_string_1 = '79ca7c9d-83ce-498f-952f-4c03b56ab573';
 process.env.paws_collector_param_string_2 = '["Audit.AzureActiveDirectory", "Audit.Exchange", "Audit.SharePoint", "Audit.General"]';
 process.env.paws_type_name = 'o365';


### PR DESCRIPTION
### Problem Description
there was a param name missing from the test mocks. Looks like i didnt commit it last time

### Solution Description
added the param in. though it is for the collect aws account. you may need to change for you test account.

### Acceptance Criteria for Contributors
- [ ] No errors / warnings on build (including linter)
- [ ] 100% automated test coverage
- [ ] Source layout followed from other collectors
- [ ] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [ ] Logging of main steps in the collector’s code
- [ ] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [ ] API throttling errors are understood and and properly handled
- [ ] Registration/update/deregistration validated
- [ ] Stats and status validated
- [ ] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [ ] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [ ] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [ ] Links to API documentation
- [ ] At least temporary access to an environment where RCS can validate collector implementation
- [ ] Contact details in case access to this environment is needed in the future
 
