### PR TITLE
remove apiToken from log object

### DIFF
--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -126,12 +126,10 @@ class OktaCollector extends PawsCollector {
 
         if (properties.length > 1) {
             if (!obj.hasOwnProperty(properties[0]))
-                return true
-
+                return
             return this.redactValue(properties.slice(1), obj[properties[0]])
         } else {
             obj[properties[0]] = undefined
-            return true
         }
     }
 }

--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -26,6 +26,11 @@ const tsPaths = [
     { path: ['published'] }
 ];
 
+const sensitiveFields = [
+    "client.apiToken",
+    "client.http.defaultHeaders.Authorization"
+];
+
 
 class OktaCollector extends PawsCollector {
 
@@ -95,8 +100,8 @@ class OktaCollector extends PawsCollector {
         const ts = parse.getMsgTs(msg, tsPaths);
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
-        // TODO remove this when okta filter this field out
-        delete msg.client.apiToken;
+        // TODO remove this when okta updates api
+        sensitiveFields.forEach((path) => this.redactValue(path, msg));
 
         let formattedMsg = {
             messageTs: ts.sec,
@@ -114,6 +119,20 @@ class OktaCollector extends PawsCollector {
             formattedMsg.messageTsUs = ts.usec;
         }
         return formattedMsg;
+    }
+
+    redactValue(propertyPath, obj) {
+        let properties = Array.isArray(propertyPath) ? propertyPath : propertyPath.split(".")
+
+        if (properties.length > 1) {
+            if (!obj.hasOwnProperty(properties[0]))
+                return true
+
+            return this.redactValue(properties.slice(1), obj[properties[0]])
+        } else {
+            obj[properties[0]] = undefined
+            return true
+        }
     }
 }
 

--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -97,6 +97,8 @@ class OktaCollector extends PawsCollector {
     pawsFormatLog(msg) {
         let collector = this;
 
+        console.log("message = ", msg);
+
         const ts = parse.getMsgTs(msg, tsPaths);
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
@@ -131,6 +133,7 @@ class OktaCollector extends PawsCollector {
             return this.redactValue(properties.slice(1), obj[properties[0]])
         } else {
             obj[properties[0]] = undefined
+            console.log("object", obj)
             return true
         }
     }

--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -97,8 +97,6 @@ class OktaCollector extends PawsCollector {
     pawsFormatLog(msg) {
         let collector = this;
 
-        console.log("message = ", msg);
-
         const ts = parse.getMsgTs(msg, tsPaths);
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
@@ -133,7 +131,6 @@ class OktaCollector extends PawsCollector {
             return this.redactValue(properties.slice(1), obj[properties[0]])
         } else {
             obj[properties[0]] = undefined
-            console.log("object", obj)
             return true
         }
     }

--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -95,6 +95,9 @@ class OktaCollector extends PawsCollector {
         const ts = parse.getMsgTs(msg, tsPaths);
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
+        // TODO remove this when okta filter this field out
+        delete msg.client.apiToken;
+
         let formattedMsg = {
             messageTs: ts.sec,
             priority: 11,

--- a/collectors/okta/test/okta_mock.js
+++ b/collectors/okta/test/okta_mock.js
@@ -25,10 +25,17 @@ const OKTA_LOG_EVENT = {
       "client": {
         "zone": "OFF_NETWORK",
         "device": "Unknown",
+        "apiToken": "PrivateToken",
         "userAgent": {
           "os": "Unknown",
           "browser": "UNKNOWN",
           "rawUserAgent": "UNKNOWN-DOWNLOAD"
+        },
+        "http": {
+            "defaultHeaders": {
+                "Authorization": "SSWS PrivateToken",
+                "User-Agent": "Mozilla Firefox 1.1.1"
+            }
         },
         "ipAddress": "12.97.85.90"
       },


### PR DESCRIPTION
### Problem Description
- Okta publish sensitive apiToken information in log objects 

### Solution Description
- Remove this field from the object for the time being
