### PR TITLE
make org key optional + description fixes

### DIFF
--- a/collectors/carbonblack/cfn/carbonblack-collector.template
+++ b/collectors/carbonblack/cfn/carbonblack-collector.template
@@ -56,17 +56,18 @@
             "Type": "String"
         },
         "CarbonblackClientId": {
-            "Description": "Carbon Black Client ID for oauth2 authentication type.",
+            "Description": "Carbon Black Client ID for authentication.",
             "Type": "String"
         },
         "CarbonblackSecret": {
-            "Description": "Carbon Black Client secret for oauth2.",
+            "Description": "Carbon Black Client secret for authentication.",
             "Type": "String",
             "NoEcho": true
         },
         "CarbonblackOrgKey": {
-            "Description": "Carbon Black ORG key for oauth2 authentication type",
-            "Type": "String"
+            "Description": "Optional. Carbon Black organisation key, used for collection of CB Defense alerts",
+            "Type": "String",
+            "Default": ""
         },
         "CarbonblackAPINames": {
             "Description": "Define API names. Please pass JSON formatted list. Possible values are [\"AuditLogEvents\", \"SearchAlerts\", \"SearchAlertsCBAnalytics\", \"SearchAlertsVmware\", \"SearchAlertsWatchlist\"]",


### PR DESCRIPTION
### Problem Description
Organisation key should be optional, as it's only required to ping the CarbonBlack Alerts API.
Also, some descriptions of fields reference OAuth2 authentication, which is not used by CarbonBlack.

### Solution Description
Add a default value for organisation key.
Update field descriptions.

### Acceptance Criteria for Contributors
- [ ] No errors / warnings on build (including linter)
- [ ] 100% automated test coverage
- [ ] Source layout followed from other collectors
- [ ] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [ ] Logging of main steps in the collector’s code
- [ ] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [ ] API throttling errors are understood and and properly handled
- [ ] Registration/update/deregistration validated
- [ ] Stats and status validated
- [ ] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [ ] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [ ] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [ ] Links to API documentation
- [ ] At least temporary access to an environment where RCS can validate collector implementation
- [ ] Contact details in case access to this environment is needed in the future
 
