### PR TITLE
update old states to collect last logs

### DIFF
--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -89,7 +89,12 @@ class O365Collector extends PawsCollector {
             const newStart = moment().subtract(PARTIAL_WEEK, 'days');
             state.since = newStart.toISOString();
             state.until = newStart.add(1, 'hours').toISOString();
-            console.warn(`O365000005 Start timestamp is more than 7 days in the past. This is not allowed in the MS managment API. setting the start time to 7 days in the past. Now collecting data from ${state.since} till ${state.until} for stream ${state.stream}`);
+            console.warn(
+                "O365000005 Start timestamp is more than 7 days in the past. ",
+                "This is not allowed in the MS managment API. ",
+                "Setting the start time to 7 days in the past. ",
+                `Now collecting data from ${state.since} till ${state.until} for stream ${state.stream}`
+            );
         }
 
         let pageCount = 0;

--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -88,8 +88,8 @@ class O365Collector extends PawsCollector {
         if(moment().diff(state.since, 'days') > 7){
             const newStart = moment().subtract(PARTIAL_WEEK, 'days');
             state.since = newStart.toISOString();
-            state.until = newStart.add(24, 'hours').toISOString();
-            console.info(`O365000005 Start timestamp is more than 7 days in the past. This is not allowed in the MS managment API. setting the start time to 7 days in the past. Now collecting data from ${state.since} till ${state.until} for stream ${state.stream}`);
+            state.until = newStart.add(1, 'hours').toISOString();
+            console.warn(`O365000005 Start timestamp is more than 7 days in the past. This is not allowed in the MS managment API. setting the start time to 7 days in the past. Now collecting data from ${state.since} till ${state.until} for stream ${state.stream}`);
         }
 
         let pageCount = 0;

--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -84,6 +84,14 @@ class O365Collector extends PawsCollector {
     pawsGetLogs(state, callback) {
         let collector = this;
         console.info(`O365000001 Collecting data from ${state.since} till ${state.until} for stream ${state.stream}`);
+
+        if(moment().diff(state.since, 'days') > 7){
+            const newStart = moment().subtract(PARTIAL_WEEK, 'days');
+            state.since = newStart.toISOString();
+            state.until = newStart.add(24, 'hours').toISOString();
+            console.info(`O365000005 Start timestamp is more than 7 days in the past. This is not allowed in the MS managment API. setting the start time to 7 days in the past. Now collecting data from ${state.since} till ${state.until} for stream ${state.stream}`);
+        }
+
         let pageCount = 0;
 
         // Page aggregation handler

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/o365/test/o365_test.js
+++ b/collectors/o365/test/o365_test.js
@@ -368,7 +368,7 @@ describe('O365 Collector Tests', function() {
 
                     assert.equal(callArgs[0], curState.stream);
                     assert.equal(moment().diff(callArgs[1], 'days'), 7);
-                    assert.equal(moment(callArgs[2]).diff(callArgs[1], 'days'), 1);
+                    assert.equal(moment(callArgs[2]).diff(callArgs[1], 'hours'), 1);
                     restoreO365ManagemntStub();
                     done();
                 });


### PR DESCRIPTION
### Problem Description
o365 just errors if a state has gotten more than 7 days old.

### Solution Description
if the collector gets a state more than 7 days old, collect the last logs.