### PR TITLE
Fix time rounding an next page token issue

### DIFF
--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -85,10 +85,12 @@ class O365Collector extends PawsCollector {
         let collector = this;
         console.info(`O365000001 Collecting data from ${state.since} till ${state.until} for stream ${state.stream}`);
 
-        if(moment().diff(state.since, 'days') > 7){
+        if(moment().diff(state.since, 'days', true) > 7){
             const newStart = moment().subtract(PARTIAL_WEEK, 'days');
             state.since = newStart.toISOString();
             state.until = newStart.add(1, 'hours').toISOString();
+            // remove next page token if the state is out of date as well.
+            state.nextPage = null;
             console.warn(
                 "O365000005 Start timestamp is more than 7 days in the past. ",
                 "This is not allowed in the MS managment API. ",

--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -19,9 +19,9 @@ const packageJson = require('./package.json');
 const parse = require('@alertlogic/al-collector-js').Parse;
 
 // Subtracting less than 7 days to avoid weird race conditions with the azure api...
-// Missing about 9 seconds of historical logs shouldn't be too bad.
+// Missing about 2 hours of historical logs shouldn't be too bad.
 // If you get an error form the o365 managment api about your date range being more than 7 days in the past, you should remove some 9s from this number.
-const PARTIAL_WEEK = 6.9999;
+const PARTIAL_WEEK = 6.99;
 
 const typeIdPaths = [
    { path: ['CreationTime'] }

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/o365/test/o365_test.js
+++ b/collectors/o365/test/o365_test.js
@@ -375,6 +375,32 @@ describe('O365 Collector Tests', function() {
             });
         });
 
+        it('Updates a stale state', function(done) {
+            setO365MangementStub();
+            O365Collector.load().then(function(creds) {
+                var collector = new O365Collector(ctx, creds, 'o365');
+                const startDate = moment().subtract(10, 'days');
+                const curState = {
+                    stream: "FakeStream",
+                    since: startDate.toISOString(),
+                    until: startDate.add(1, 'days').toISOString(),
+                    nextPage: 'https://www.joecantprogram.com?nextpagetoken=8675309',
+                    poll_interval_sec: 1
+                };
+
+                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) =>{
+                    const callArgs = subscriptionsContentStub.getCall(0).args;
+
+                    assert.equal(callArgs[0], curState.stream);
+                    assert.equal(moment().diff(callArgs[1], 'days'), 7);
+                    assert.equal(moment(callArgs[2]).diff(callArgs[1], 'hours'), 1);
+                    assert.equal(getPreFormedUrlStub.calledWith(curState.nextPage), false);
+                    restoreO365ManagemntStub();
+                    done();
+                });
+            });
+        });
+
         it('Get Logs Sunny', function(done) {
             setO365MangementStub();
             O365Collector.load().then(function(creds) {


### PR DESCRIPTION
### Problem Description
There was an issue with time rounding in the last fix. by default, moment truncates time diffs rather than rounds up.

there was also an issue where, even if the collector was updating the state, it would try the next page token anyway, causing an error.

### Solution Description
force moment to give time ranges as a float
remove nextpage url if the state is out of date. 