### PR TITLE
Update al-aws-collector dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -31,7 +31,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "3.0.3",
+    "@alertlogic/al-aws-collector-js": "3.0.4",
     "datadog-lambda-js": "2.23.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -94,14 +94,9 @@ class PawsCollector extends AlAwsCollector {
         this._pawsCreds = pawsCreds;
         this._pawsCollectorType = process.env.paws_type_name;
         this.pollInterval = process.env.paws_poll_interval;
-        this.applicationId = process.env.al_application_id;
         this._pawsEndpoint = process.env.paws_endpoint
         this._pawsDomainEndpoint = endpointDomain;
         this._pawsHttpsEndpoint = 'https://' + endpointDomain;
-    };
-
-    get application_id () {
-        return this.applicationId;
     };
 
     get secret () {


### PR DESCRIPTION
### Solution Description
update to the latest `al-aws-collector-js`. The `application_id` getter was moved there.