### PR TITLE
Always use HTTPS endpoint

### DIFF
--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -58,7 +58,7 @@ class OktaCollector extends PawsCollector {
     pawsGetLogs(state, callback) {
         let collector = this;
         const oktaClient = new okta.Client({
-            orgUrl: process.env.paws_endpoint,
+            orgUrl: collector.pawsHttpsEndpoint,
             token: collector.secret
         });
         console.info(`OKTA000001 Collecting data from ${state.since} till ${state.until}`);

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@okta/okta-sdk-nodejs": "3.1.0",
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^1.3.1",
+    "@alertlogic/al-collector-js": "^2.0.0",
+    "@alertlogic/paws-collector": "^1.3.2",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"


### PR DESCRIPTION
### Problem Description
Customers can input urls without `https` prefix.

### Solution Description
Stop using `process.env` and use `pawsHttpsEndpoint` property.