### PR TITLE
update carbonblack readme with api urls

### DIFF
--- a/collectors/carbonblack/README.md
+++ b/collectors/carbonblack/README.md
@@ -29,6 +29,16 @@ This access level is used for collecting Alerts.
 
 ![ScreenShot](./docs/carbonblack_credentials_custom.png)
 
+API URLs required for CarbonBlack collector
+
+| Environment (Region)   | URL                                  |
+|------------------------|--------------------------------------|
+| Prod01 (N Am)          | https://api.confer.net               |
+| Prod02 (N Am)          | https://api5.conferdeploy.net        |
+| Prod05 (N Am)          | https://api-prod05.conferdeploy.net  |
+| Prod06 (EU)            | https://api-prod06.conferdeploy.net  |
+| ProdNRT (Asia Pacific) | https://api-prodnrt.conferdeploy.net |
+
 ### 2. CloudFormation Template (CFT)
 
 Refer to [CF template readme](./cfn/README-CARBONBLACK.md) for installation instructions.
@@ -114,4 +124,3 @@ make sam-local
 ```
   4. Please see `local/event.json` for the event payload used for local invocation.
 Please write your readme here
-


### PR DESCRIPTION
### Problem Description
Some confusion around which url was required for the CarbonBlack collector

### Solution Description
Add a table of URLs in API credentials setup section of ReadMe

### Acceptance Criteria for Contributors
- [x] No errors / warnings on build (including linter)
- [x] 100% automated test coverage
- [x] Source layout followed from other collectors
- [x] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [x] Logging of main steps in the collector’s code
- [x] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [x] API throttling errors are understood and and properly handled
- [x] Registration/update/deregistration validated
- [x] Stats and status validated
- [x] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [x] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [x] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [x] Links to API documentation
- [x] At least temporary access to an environment where RCS can validate collector implementation
- [x] Contact details in case access to this environment is needed in the future
 
