### PR TITLE
update permission set for o365 collectors

### DIFF
--- a/collectors/o365/README.md
+++ b/collectors/o365/README.md
@@ -33,8 +33,8 @@ In the Office 365 portal, you must register a new Office 365 web application to 
 
 1. On the main panel under the new application, select `View API Permissions`, and then click `+ Add`.
 1. Locate the `Office 365 Management APIs`, and then click `Select`.
-1. In `Application permissions`, expand then select `ActivityFeed.Read`, `ActivityFeed.ReadDlp`, `ActivityReports.Read`(both), `ServiceHealth.Read`, and `ThreatIntelligence.Read`(both). 
-1. Click `Select`, and then click `Done`. 
+1. In `Application permissions`, expand then select `ActivityFeed.Read`, `ActivityFeed.ReadDlp`, and `ServiceHealth.Read`.
+1. Click `Select`, and then click `Done`.
 1. Click `Grant Permissions`, and then click `Yes`. 
 **Note:** Only the Active Directory tenant administrator can grant permissions to an Azure Active Directory application.
 1. On the `Settings` panel for the application, select `Certificated & Secrets`.


### PR DESCRIPTION
### Problem Description
Azure has deprecated a few of their permissions, namely `ThreatIntelligence.Read` and `ActivityReports.Read`. They have been wrapped into the remaining permissions

### Solution Description
Remove references to the deprecated permissions in the ReadMe

### Acceptance Criteria for Contributors
- [x] No errors / warnings on build (including linter)
- [x] 100% automated test coverage
- [x] Source layout followed from other collectors
- [x] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [x] Logging of main steps in the collector’s code
- [x] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [x] API throttling errors are understood and and properly handled
- [x] Registration/update/deregistration validated
- [x] Stats and status validated
- [x] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [x] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [x] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [x] Links to API documentation
- [x] At least temporary access to an environment where RCS can validate collector implementation
- [x] Contact details in case access to this environment is needed in the future
 
