### PR TITLE
Add file cache for param store value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
There was no cache for param store credentials. this was causing us to hit AWS rate limits.

### Solution Description
Added a file cache to the param store call. This should reduce the number of calls to AWS SSM.