### PR TITLE
change progression on next state function

### DIFF
--- a/collectors/sentinelone/collector.js
+++ b/collectors/sentinelone/collector.js
@@ -83,7 +83,7 @@ class SentineloneCollector extends PawsCollector {
 
         const untilMoment = moment(curState.until);
 
-        const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('no-cap', untilMoment, this.pollInterval);
+        const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-day-progression', untilMoment, this.pollInterval);
 
         return {
             since: nextSinceMoment.toISOString(),
@@ -129,4 +129,4 @@ class SentineloneCollector extends PawsCollector {
 
 module.exports = {
     SentineloneCollector: SentineloneCollector
-}
+};

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,


### PR DESCRIPTION
### Problem Description
Sentinelone was configured to have the "no cap" progression for catching up with historical logs, which was not very efficient.

### Solution Description
changed it to "day hour" progression.