### PR TITLE
ENG-14517 - [salesforce] remediation for failing to query inaccessible objects

### DIFF
--- a/collectors/o365/healthcheck.js
+++ b/collectors/o365/healthcheck.js
@@ -40,8 +40,8 @@ function checkO365Subscriptions(callback){
                     error.message ? error.message :
                         util.inspect(error);
             }
-            callback(al_health.errorMsg('O365000103', 'Bad O365 stream status: ' + errorString)));
-        }
+            callback(al_health.errorMsg('O365000103', 'Bad O365 stream status: ' + errorString));
+        });
 }
 
 function filterSubscriptions(result){

--- a/collectors/salesforce/collector.js
+++ b/collectors/salesforce/collector.js
@@ -120,6 +120,12 @@ class SalesforceCollector extends PawsCollector {
                         return callback(null, [], state, state.poll_interval_sec);
                     }
                     else {
+                        if (error.errorCode && errorCode === "INVALID_FIELD") {
+                            console.log(`API not able to fetch field for object ${state.object}`);
+                        }
+                        if (error.errorCode && errorCode === "INVALID_TYPE") {
+                            console.log(`API not able to fetch logs for object ${state.object}`);
+                        }
                         return callback(error);
                     }
 


### PR DESCRIPTION
Some salesforce customers may not have the platform security events enabled,
In such cases have a relevant error status for these problems with details on which objects are failing to be queried.