### PR TITLE
update al-aws-collector dependency with unlink file fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "3.0.7",
+    "@alertlogic/al-aws-collector-js": "3.0.8",
     "datadog-lambda-js": "2.23.0",
     "async": "3.1.0",
     "debug": "4.1.1",


### PR DESCRIPTION
### Problem Description
- Collection periodically fails due to unlink of cache throwing a ENOENT error: https://github.com/alertlogic/al-collector-js/pull/42

### Solution Description
- Update al-aws-collector dependency to include fix

 
