### PR TITLE
Limit concurrent calls to o365 Management API 

### DIFF
--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -22,12 +22,13 @@
     "@alertlogic/al-aws-collector-js": "^3.0.6",
     "@alertlogic/al-collector-js": "^1.4.5",
     "@alertlogic/paws-collector": "^2.0.1",
-    "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-azure-js": "2.0.1",
+    "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-nodeauth": "2.0.5",
     "async": "3.1.0",
     "debug": "4.1.1",
-    "moment": "2.24.0"
+    "moment": "2.24.0",
+    "tiny-async-pool": "^1.2.0"
   },
   "author": "Alert Logic Inc."
 }


### PR DESCRIPTION
### Problem Description
- When collecting a large number of objects, we hit the OS socket limit due to large number of parallel calls to o365 api's

### Solution Description
- limit concurrent api calls to 20 