### PR TITLE
ENG-0000: Removed the collector type from dd metrics name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -155,7 +155,7 @@ class PawsCollector extends AlAwsCollector {
         ];
 
         ddLambda.sendDistributionMetric(
-            `paws_${this.pawsCollectorType}.${name}`,
+            `paws.${name}`,
             value,
             ...baseTags.concat(tags)
         );

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -265,7 +265,7 @@ describe('Unit Tests', function() {
                 var collector = new TestCollector(ctx, creds);
                 collector.reportDDMetric('test_metric', 2);
 
-                assert(ddLambdaSendMetricStub.calledWith('paws_okta.test_metric'));
+                assert(ddLambdaSendMetricStub.calledWith('paws.test_metric'));
                 done();
             });
         });


### PR DESCRIPTION
Removed the **collector type** from datadog metrics name and used  the collector type as the tag (`paws_platform:${this.pawsCollectorType}`) while creating graph on DD.
 
