### PR TITLE
bump package versions for okta and s1

### DIFF
--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,


### PR DESCRIPTION
### Problem Description
Forgot to bump package versions in the previous PR, removing the S1 and Okta healthchecks

### Solution Description
Remedy the situation and bump the versions

### Acceptance Criteria for Contributors
- [ ] No errors / warnings on build (including linter)
- [ ] 100% automated test coverage
- [ ] Source layout followed from other collectors
- [ ] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [ ] Logging of main steps in the collector’s code
- [ ] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [ ] API throttling errors are understood and and properly handled
- [ ] Registration/update/deregistration validated
- [ ] Stats and status validated
- [ ] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [ ] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [ ] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [ ] Links to API documentation
- [ ] At least temporary access to an environment where RCS can validate collector implementation
- [ ] Contact details in case access to this environment is needed in the future
 
