### PR TITLE
ENG-17586 :  [paws-collectors] Stream specific status reporting 

### DIFF
--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -128,6 +128,11 @@
             "Description": "Collector specific string type parameter 2.",
             "Type": "String",
             "Default": ""
+        },
+        "CollectorStreams" :{
+            "Description": "Collector specific streams",
+            "Type": "String",
+            "Default": ""
         }
     },
     "Conditions":{
@@ -673,6 +678,9 @@
                   },
                   "paws_collector_param_string_2": {
                     "Ref": "CollectorParamString2"
+                  },
+                  "collector_streams": {
+                    "Ref": "CollectorStreams"
                   }
                }
             },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "3.0.8",
+    "@alertlogic/al-aws-collector-js": "3.0.9",
     "datadog-lambda-js": "2.23.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -18,6 +18,7 @@ const moment = require('moment');
 const ddLambda = require('datadog-lambda-js');
 
 const AlAwsCollector = require('@alertlogic/al-aws-collector-js').AlAwsCollector;
+const AlAwsUtil = require('@alertlogic/al-aws-collector-js').Util;
 const packageJson = require('./package.json');
 
 const CREDS_FILE_PATH = '/tmp/paws_creds';
@@ -657,6 +658,20 @@ class PawsCollector extends AlAwsCollector {
         // Current state message will be removed by Lambda trigger upon successful completion
         sqs.sendMessage(params, callback);
     };
+
+    /**
+     * This function to set collector_streams in environment variable for exsisting collector
+     * Streams is send to AL-aws-collector to post stream specific status if there is no error.
+     * @param {*} streams 
+     */
+    setCollectorStreamsEnv(streams) {
+        let collectorStreams = { collector_streams: streams };
+        return AlAwsUtil.setEnv(collectorStreams, (err) => {
+            if (err) {
+                console.error('Paws error while adding collector_streams in environment variable')
+            }
+        });
+    }
 
     /**
      * @function collector callback to initialize collection state

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -661,8 +661,8 @@ class PawsCollector extends AlAwsCollector {
     };
 
     /**
-     * This function to set collector_streams in environment variable for exsisting collector
-     * Streams is send to AL-aws-collector to post stream specific status if there is no error.
+     * This function to set collector_streams in environment variable for existing collectors.
+     * Streams are pass to AL-aws-collector to post stream specific status if there is no error.
      * @param {*} streams 
      */
     setCollectorStreamsEnv(streams) {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -96,15 +96,15 @@ class PawsCollector extends AlAwsCollector {
         }
     }
 
-    constructor(context, {aimsCreds, pawsCreds}, childVersion,healthChecks = [], statsChecks = []) {
+    constructor(context, {aimsCreds, pawsCreds}, childVersion, healthChecks = [], statsChecks = []) {
         const version = childVersion ? childVersion : packageJson.version;
         const endpointDomain = process.env.paws_endpoint.replace(DOMAIN_REGEXP, '');
-        let collectorStreams = process.env.collector_stream ? JSON.parse(process.env.collector_stream) : [];
+        let collectorStreams = process.env.collector_streams && Array.isArray(JSON.parse(process.env.collector_streams)) ? JSON.parse(process.env.collector_streams) : [];
         super(context, 'paws',
               AlAwsCollector.IngestTypes.LOGMSGS,
               version,
               aimsCreds,
-              null, healthChecks, statsChecks,collectorStreams);
+              null, healthChecks, statsChecks, collectorStreams);
         console.info('PAWS000100 Loading collector', process.env.paws_type_name);
         this._pawsCreds = pawsCreds;
         this._pawsCollectorType = process.env.paws_type_name;

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -96,14 +96,15 @@ class PawsCollector extends AlAwsCollector {
         }
     }
 
-    constructor(context, {aimsCreds, pawsCreds}, childVersion,streams =[],healthChecks = [], statsChecks = []) {
+    constructor(context, {aimsCreds, pawsCreds}, childVersion,healthChecks = [], statsChecks = []) {
         const version = childVersion ? childVersion : packageJson.version;
         const endpointDomain = process.env.paws_endpoint.replace(DOMAIN_REGEXP, '');
+        let collectorStreams = process.env.collector_stream ? JSON.parse(process.env.collector_stream) : [];
         super(context, 'paws',
               AlAwsCollector.IngestTypes.LOGMSGS,
               version,
               aimsCreds,
-              null, healthChecks, statsChecks,streams);
+              null, healthChecks, statsChecks,collectorStreams);
         console.info('PAWS000100 Loading collector', process.env.paws_type_name);
         this._pawsCreds = pawsCreds;
         this._pawsCollectorType = process.env.paws_type_name;


### PR DESCRIPTION

1.Passed the streams array to al-aws-collector to post ok status in checkin event
2.Send the stream from done function to post the error  status specific to stream.
3. Added collectorType parameter in prepareErrorStatus to override the prepareErrorStatus of al-aws-collector when there is stream specific error status.


Prerequisite:
[al-aws-collector/62](https://github.com/alertlogic/al-aws-collector-js/pull/62)
