### PR TITLE
convert collection_start_ts to ISO8601

### DIFF
--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,

--- a/collectors/auth0/utils.js
+++ b/collectors/auth0/utils.js
@@ -1,7 +1,9 @@
+const moment = require('moment');
+
 function getAPILogs(auth0Client, state, accumulator, maxPagesPerInvocation) {
     let pageCount = 0;
 
-    let params = state.last_log_id ? { from: state.last_log_id, take:100 } : { q: "date=[" + state.since + " TO *]", per_page:100, sort: "date:1" };
+    let params = state.last_log_id ? { from: state.last_log_id, take:100 } : { q: "date=[" + moment(state.since).toISOString() + " TO *]", per_page:100, sort: "date:1" };
     let nextLogId = state.last_log_id ? state.last_log_id : null;
     let lastLogTs = null;
 

--- a/collectors/auth0/utils.js
+++ b/collectors/auth0/utils.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 function getAPILogs(auth0Client, state, accumulator, maxPagesPerInvocation) {
     let pageCount = 0;
 
-    let params = state.last_log_id ? { from: state.last_log_id, take:100 } : { q: "date=[" + moment(state.since).toISOString() + " TO *]", per_page:100, sort: "date:1" };
+    let params = state.last_log_id ? { from: state.last_log_id, take:100 } : { q: "date:[" + moment(state.since).toISOString() + " TO *]", per_page:100, sort: "date:1" };
     let nextLogId = state.last_log_id ? state.last_log_id : null;
     let lastLogTs = null;
 


### PR DESCRIPTION
### Problem Description
- cases where customers have used valid date times such as `2021-02-16T21:46:54Z` (missing millisecond time)
- auth0 throws error when attempting to call apis without milliseconds timestamp

### Solution Description
- convert such datetime strings into valid ISO8601 format 
