### PR TITLE
Use Intelligent-Tiering for storing parameters in SSM

### DIFF
--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -102,7 +102,7 @@
         "PawsSecretParamTier": {
             "Description": "Tier for AWS Param store param. Change this to advanced if the size of the PAws secrets is over 4kb",
             "Type": "String",
-            "Default": "Standard",
+            "Default": "Intelligent-Tiering",
             "AllowedValues": [
                 "Standard",
                 "Advanced",
@@ -655,6 +655,9 @@
                   },
                   "paws_secret_param_name":{
                       "Ref":"PawsSecretParam"
+                  },
+                  "paws_secret_param_tier": {
+                      "Ref": "PawsSecretParamTier"
                   },
                   "paws_collection_start_ts":{
                       "Ref":"CollectionStartTs"

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -197,7 +197,8 @@ class PawsCollector extends AlAwsCollector {
                     Name: process.env.paws_secret_param_name,
                     Type: 'String',
                     Overwrite: true,
-                    Value: base64
+                    Value: base64,
+                    Tier: process.env.paws_secret_param_tier
                 };
                 ssm.putParameter(params, function(err, data) {
                     if (err) return reject(err, err.stack);


### PR DESCRIPTION
### Problem Description
SSM Parameter Store has a size limit of 4KB for `Standard` tier parameters. This causes problems for the Salesforce collector where the secret is an RSA private key -- after encryption in KMS and base64 encoding, the size of the resulting parameter exceeds the 4KB limit.

### Solution Description
The paws-collector template is updated to use `Intelligent-Tiering` by default, so that `Advanced` tier parameters are created when the parameter's size exceeds 4KB.  `Standard` tier parameters are created otherwise.

### Acceptance Criteria for Contributors
- [ ] No errors / warnings on build (including linter)
- [ ] 100% automated test coverage
- [ ] Source layout followed from other collectors
- [ ] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [ ] Logging of main steps in the collector’s code
- [ ] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [ ] API throttling errors are understood and and properly handled
- [ ] Registration/update/deregistration validated
- [ ] Stats and status validated
- [ ] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [ ] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [ ] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [ ] Links to API documentation
- [ ] At least temporary access to an environment where RCS can validate collector implementation
- [ ] Contact details in case access to this environment is needed in the future
 
