### PR TITLE
Default to SSM Standard tier where tier is undefined in env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -22,6 +22,7 @@ const packageJson = require('./package.json');
 
 const CREDS_FILE_PATH = '/tmp/paws_creds';
 var PAWS_DECRYPTED_CREDS = null;
+const DEFAULT_PAWS_SECRET_PARAM_TIER = 'Standard';
 const DOMAIN_REGEXP = /^[htps]*:\/\/|\/$/gi;
 
 const STATE_RECORD_COMPLETE = "COMPLETE";
@@ -198,7 +199,7 @@ class PawsCollector extends AlAwsCollector {
                     Type: 'String',
                     Overwrite: true,
                     Value: base64,
-                    Tier: process.env.paws_secret_param_tier
+                    Tier: process.env.paws_secret_param_tier ? process.env.paws_secret_param_tier : DEFAULT_PAWS_SECRET_PARAM_TIER
                 };
                 ssm.putParameter(params, function(err, data) {
                     if (err) return reject(err, err.stack);


### PR DESCRIPTION
### Problem Description
Existing collectors won't have `paws_secret_param_tier` exposed in env vars which would cause parameter updates to fail when SSM set-parameter request is sent with `Tier=undefined`.

### Solution Description
Default to `Standard` tier when `paws_secret_param_tier` is not defined in environment variables since this likely means the stack is using an old template version and so its parameters will have been created with the `Standard` tier initially anyway. 

### Acceptance Criteria for Contributors
- [ ] No errors / warnings on build (including linter)
- [ ] 100% automated test coverage
- [ ] Source layout followed from other collectors
- [ ] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [ ] Logging of main steps in the collector’s code
- [ ] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [ ] API throttling errors are understood and and properly handled
- [ ] Registration/update/deregistration validated
- [ ] Stats and status validated
- [ ] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [ ] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [ ] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [ ] Links to API documentation
- [ ] At least temporary access to an environment where RCS can validate collector implementation
- [ ] Contact details in case access to this environment is needed in the future
 
