### PR TITLE
Bump paws-collector dep in ciscoduo collector

### DIFF
--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.3",
+    "@alertlogic/paws-collector": "^2.0.5",
     "@duosecurity/duo_api": "1.2.1",
     "async": "3.1.0",
     "debug": "4.1.1",


### PR DESCRIPTION
### Problem Description
I did not use the `update-collector-versions.js` script to update the collector versions and subsequently missed a collector.

### Solution Description
Bump dependency + package version in the missed collector.