### PR TITLE
VTT-2603: Create SSM secure parameter by Lambda function

### DIFF
--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -563,11 +563,27 @@
                                 "    });\n",
                                 "}\n",
                                 "\n",
+                                "function deleteSSMParam(event, context) {\n",
+                                "    var params = {\n",
+                                "        Name: event.ResourceProperties.Name\n",
+                                "    };\n",
+                                "    const ssm = new AWS.SSM();\n",
+                                "    ssm.deleteParameter(params, function(err, data) {\n",
+                                "        if (err) {\n",
+                                "            console.log(err, err.stack); // an error occurred\n",
+                                "            return response.send(event, context, response.FAILED);\n",
+                                "        }\n",
+                                "        return response.send(event, context, response.SUCCESS, data);\n",
+                                "    });\n",
+                                "}\n",
                                 "\n",
                                 "exports.handler = (event, context, callback) => {\n",
                                 "    if (event.ResourceType == 'AWS::CloudFormation::CustomResource' &&\n",
                                 "        (event.RequestType == 'Create' || event.RequestType == 'Update')) {\n",
                                 "        return createSSMParam(event, context);\n",
+                                "     } else if (event.ResourceType == 'AWS::CloudFormation::CustomResource' &&\n",
+                                "        (event.RequestType == 'Delete')) {\n",
+                                "        return deleteSSMParam(event, context);\n",
                                 "    }\n",
                                 "    return response.send(event, context, response.SUCCESS);\n",
                                 "}"
@@ -644,12 +660,14 @@
                 "Tier": {
                     "Ref": "PawsSecretParamTier"
                 },
-                "Tags": [{
+                "Tags": [
+                    {
                         "Key": "StackId",
                         "Value": {
                             "Ref": "AWS::StackId"
                         }
-                    }]
+                    }
+                ]
             }
         },
       "PawsPollStateQueue":{

--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -434,7 +434,9 @@
                             "Effect":"Allow",
                             "Action":[
                                 "ssm:GetParameter",
-                                "ssm:PutParameter"
+                                "ssm:PutParameter",
+                                "ssm:DeleteParameter",
+                                "ssm:AddTagsToResource"
                             ],
                             "Resource":[
                                 { "Fn::Join":["", [
@@ -547,8 +549,8 @@
                                 "        Type: 'SecureString',\n",
                                 "        KeyId: event.ResourceProperties.KeyId,\n",
                                 "        Value: event.ResourceProperties.Plaintext,\n",
-                                "        Overwrite: true,\n",
-                                "        Tier: event.ResourceProperties.Tier\n",
+                                "        Tier: event.ResourceProperties.Tier,\n",
+                                "        Tags: event.ResourceProperties.Tags",
                                 "    };\n",
                                 "    const ssm = new AWS.SSM();\n",
                                 "    ssm.putParameter(params, function(err, data) {\n",
@@ -641,7 +643,13 @@
                 },
                 "Tier": {
                     "Ref": "PawsSecretParamTier"
-                }
+                },
+                "Tags": [{
+                        "Key": "StackId",
+                        "Value": {
+                            "Ref": "AWS::StackId"
+                        }
+                    }]
             }
         },
       "PawsPollStateQueue":{

--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -133,6 +133,12 @@
             "Description": "Collector specific streams",
             "Type": "String",
             "Default": ""
+        },
+        "SsmDirect" :{
+            "Description": "Used System manger secure string",
+            "Type": "String",
+            "Default": "true",
+            "AllowedValues":["true"]
         }
     },
     "Conditions":{
@@ -316,7 +322,8 @@
             "Type":"AWS::IAM::Policy",
             "DependsOn":[
                 "EncryptLambdaRole",
-                "EncryptLambdaFunction"
+                "EncryptLambdaFunction",
+                "CreateSsmParameterLambdaFunction"
             ],
             "Properties":{
                 "Roles":[
@@ -351,6 +358,26 @@
                                             ":*"
                                         ]
                                     ]
+                                },
+                                {
+                                    "Fn::Join":[
+                                        "",
+                                        [
+                                            "arn:aws:logs:",
+                                            {
+                                                "Ref":"AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref":"AWS::AccountId"
+                                            },
+                                            ":log-group:/aws/lambda/",
+                                            {
+                                                "Ref":"CreateSsmParameterLambdaFunction"
+                                            },
+                                            ":*"
+                                        ]
+                                    ]
                                 }
                             ]
                         },
@@ -380,6 +407,46 @@
                                             ":log-stream:*"
                                         ]
                                     ]
+                                },
+                                {
+                                    "Fn::Join":[
+                                         "",
+                                         [
+                                             "arn:aws:logs:",
+                                             {
+                                                 "Ref":"AWS::Region"
+                                             },
+                                             ":",
+                                             {
+                                                 "Ref":"AWS::AccountId"
+                                             },
+                                             ":log-group:/aws/lambda/",
+                                             {
+                                                 "Ref":"CreateSsmParameterLambdaFunction"
+                                             },
+                                             ":log-stream:*"
+                                         ]
+                                     ]
+                                 }
+                            ]
+                        },
+                        {
+                            "Effect":"Allow",
+                            "Action":[
+                                "ssm:GetParameter",
+                                "ssm:PutParameter"
+                            ],
+                            "Resource":[
+                                { "Fn::Join":["", [
+                                    "arn:aws:ssm:",
+                                    {"Ref": "AWS::Region"},
+                                    ":",
+                                    {"Ref": "AWS::AccountId"},
+                                    ":parameter/PAWS-SECRET-",
+                                    {"Ref": "PawsCollectorTypeName"},
+                                    "-",
+                                    {"Ref": "AWS::StackName"}
+                                   ]]
                                 }
                             ]
                         }
@@ -452,6 +519,72 @@
                 ]
             }
         },
+        "CreateSsmParameterLambdaFunction":{
+            "Type":"AWS::Lambda::Function",
+            "DependsOn":[
+                "EncryptLambdaRole"
+            ],
+            "Properties":{
+                "Description":"Alert Logic System manager parameter creation Lambda function",
+                "Role":{
+                    "Fn::GetAtt":[
+                        "EncryptLambdaRole",
+                        "Arn"
+                     ]
+                },
+                "Code":{
+                    "ZipFile": {
+                       "Fn::Join": [
+                           "",
+                           [
+                                "const AWS = require('aws-sdk');\n",
+                                "const response = require('./cfn-response');\n",
+                                "\n",
+                                "\n",
+                                "function createSSMParam(event, context) {\n",
+                                "    var params = {\n",
+                                "        Name: event.ResourceProperties.Name,\n",
+                                "        Type: 'SecureString',\n",
+                                "        KeyId: event.ResourceProperties.KeyId,\n",
+                                "        Value: event.ResourceProperties.Plaintext,\n",
+                                "        Overwrite: true,\n",
+                                "        Tier: event.ResourceProperties.Tier\n",
+                                "    };\n",
+                                "    const ssm = new AWS.SSM();\n",
+                                "    ssm.putParameter(params, function(err, data) {\n",
+                                "        if (err) {\n",
+                                "            console.log(err, err.stack); // an error occurred\n",
+                                "            return response.send(event, context, response.FAILED);\n",
+                                "        }\n",
+                                "        data.PawsSecretParamName = params.Name\n",
+                                "        return response.send(event, context, response.SUCCESS, data);\n",
+                                "    });\n",
+                                "}\n",
+                                "\n",
+                                "\n",
+                                "exports.handler = (event, context, callback) => {\n",
+                                "    if (event.ResourceType == 'AWS::CloudFormation::CustomResource' &&\n",
+                                "        (event.RequestType == 'Create' || event.RequestType == 'Update')) {\n",
+                                "        return createSSMParam(event, context);\n",
+                                "    }\n",
+                                "    return response.send(event, context, response.SUCCESS);\n",
+                                "}"
+                            ]
+                        ]
+                    }
+                },
+                "Handler":"index.handler",
+                "Runtime":"nodejs12.x",
+                "MemorySize":128,
+                "Timeout": 5,
+                "Tags": [
+                    {
+                        "Key": "AlertLogic",
+                        "Value": "Collect"
+                    }
+                ]
+            }
+        },
         "EncryptSecretKeyCustomResource": {
             "Type": "AWS::CloudFormation::CustomResource",
             "DependsOn": [
@@ -477,34 +610,20 @@
                 }
             }
         },
-        "EncryptPawsSecret": {
+        "StorePawsSecretInSsm": {
             "Type": "AWS::CloudFormation::CustomResource",
             "DependsOn": [
                 "LambdaKmsKey",
-                "EncryptLambdaFunction",
+                "CreateSsmParameterLambdaFunction",
                 "EncryptLambdaPolicy"
             ],
             "Properties": {
                 "ServiceToken": {
                     "Fn::GetAtt": [
-                        "EncryptLambdaFunction",
+                        "CreateSsmParameterLambdaFunction",
                         "Arn"
                     ]
                 },
-                "KeyId": {
-                    "Fn::GetAtt": [
-                        "LambdaKmsKey",
-                        "Arn"
-                    ]
-                },
-                "Plaintext": {
-                    "Ref": "PawsSecret"
-                }
-            }
-        },
-        "PawsSecretParam": {
-            "Type": "AWS::SSM::Parameter",
-            "Properties": {
                 "Name": {"Fn::Join": [
                     "",
                     [
@@ -514,13 +633,14 @@
                         {"Ref": "AWS::StackName"}
                     ]
                 ]},
-                "Type": "String",
-                "Tier": {"Ref": "PawsSecretParamTier"},
-                "Value": {
-                    "Fn::GetAtt": ["EncryptPawsSecret", "EncryptedText"]
+                "KeyId": {
+                    "Fn::GetAtt":["LambdaKmsKey","Arn"]
                 },
-                "Tags": {
-                    "StackId": {"Ref": "AWS::StackId"}
+                "Plaintext": {
+                    "Ref": "PawsSecret"
+                },
+                "Tier": {
+                    "Ref": "PawsSecretParamTier"
                 }
             }
         },
@@ -555,7 +675,7 @@
             "CollectLambdaRole",
             "LambdaKmsKey",
             "EncryptSecretKeyCustomResource",
-            "EncryptPawsSecret",
+            "StorePawsSecretInSsm",
             "PawsPollStateQueue"
          ],
          "Properties":{
@@ -659,7 +779,7 @@
                       "Fn::GetAtt": [ "LambdaKmsKey", "Arn" ]
                   },
                   "paws_secret_param_name":{
-                      "Ref":"PawsSecretParam"
+                      "Fn::GetAtt": ["StorePawsSecretInSsm", "PawsSecretParamName"]
                   },
                   "paws_secret_param_tier": {
                       "Ref": "PawsSecretParamTier"
@@ -684,7 +804,10 @@
                   },
                   "collector_streams": {
                     "Ref": "CollectorStreams"
-                  }
+                  },
+                  "ssm_direct": {
+                    "Ref": "SsmDirect"
+                }
                }
             },
             "Tags": [
@@ -756,7 +879,7 @@
                               ":",
                               {"Ref": "AWS::AccountId"},
                               ":parameter/",
-                              {"Ref":"PawsSecretParam"}
+                              {"Fn::GetAtt": ["StorePawsSecretInSsm", "PawsSecretParamName"]}
                             ]]
                           }
                       ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
The size of the key is grater than 4kb , when encrypted and encoded as base64, is too large to be stored in the CustomResource before being stored in SSM .

### Solution Description

Instead  encrypting the paws secret using EncryptLambdaFunction, we should store the secret directly in **SSM Parameter Store as a SecureString**. Create SSM  SecureString parameter with the help of Lambda function instate of CFN template (as 
 mentioned on AWS doc - `SecureString is not currently supported for AWS CloudFormation templates`.) .

### Implementation
1. Added Lambda Function (CreateSsmParameterLambdaFunction ) which will create the SSM parameter with Secure String and return the Parameter name and version.If `event.RequestType == 'Delete'` then Delete the SSM parameter.

2. Modified the  EncryptLambdaPolicy to allow (ssm:PutParameter) which required to Create SSM parameter by Lambda function and  updated the resources to check logs of  CreateSsmParameterLambdaFunction.

3. Added `ssm_direct` in environment variable and set to "true" for new deployed collect. This ssm_direct  variable use in the paws-collector code to check whether we should 1) fetch the secret from SSM, base64 decode it, then decrypt using KMS (current way of getting paws secret); or 2) request the decrypted parameter directly from SSM when ssm_direct is set.

4. Removed PawsSecretParam( Type :AWS::SSM::Parameter) and now this has been created by lambda function.



 
