### PR TITLE
Fixed the SophoSIEM  stream issue

### DIFF
--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sophossiem/test/sophossiem_test.js
+++ b/collectors/sophossiem/test/sophossiem_test.js
@@ -121,7 +121,7 @@ describe('Unit Tests', function () {
                 var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
                 const startDate = moment().subtract(23, 'hours');
                 const curState = {
-                    objectName: "Events",
+                    stream: "Events",
                     from_date: startDate.unix(),
                     poll_interval_sec: 1
                 };
@@ -148,7 +148,7 @@ describe('Unit Tests', function () {
             SophossiemCollector.load().then(function (creds) {
                 var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
                 const curState = {
-                    objectName: "Events",
+                    stream: "Events",
                     nextPage: "nextPage",
                     poll_interval_sec: 1
                 };
@@ -176,7 +176,7 @@ describe('Unit Tests', function () {
                 var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
                 const startDate = moment().subtract(23, 'hours');
                 const curState = {
-                    objectName: "Events",
+                    stream: "Events",
                     from_date: startDate.unix(),
                     poll_interval_sec: 1
                 };
@@ -211,7 +211,7 @@ describe('Unit Tests', function () {
                 var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
                 const startDate = moment().subtract(23, 'hours');
                 const curState = {
-                    objectName: "Events",
+                    stream: "Events",
                     from_date: startDate.unix(),
                     poll_interval_sec: 1
                 };
@@ -240,7 +240,7 @@ describe('Unit Tests', function () {
                 var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
                 const startDate = moment();
                 const curState = {
-                    objectName: "Events",
+                    stream: "Events",
                     from_date: startDate.unix(),
                     poll_interval_sec: 1
                 };
@@ -258,7 +258,7 @@ describe('Unit Tests', function () {
                 var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
                 const startDate = moment();
                 const curState = {
-                    objectName: "Events",
+                    stream: "Events",
                     from_date: startDate.unix(),
                     poll_interval_sec: 1
                 };

--- a/collectors/sophossiem/test/utils_test.js
+++ b/collectors/sophossiem/test/utils_test.js
@@ -21,7 +21,7 @@ describe('Unit Tests', function () {
             let headers = {};
             const startDate = moment().subtract(23, 'hours');
             const state = {
-                objectName: "Events",
+                stream: "Events",
                 from_date: startDate.unix(),
                 poll_interval_sec: 1
             };
@@ -46,7 +46,7 @@ describe('Unit Tests', function () {
             let accumulator = [];
             let headers = {};
             const state = {
-                objectName: "Alerts",
+                stream: "Alerts",
                 nextPage: "next_cursor",
                 poll_interval_sec: 1
             };

--- a/collectors/sophossiem/utils.js
+++ b/collectors/sophossiem/utils.js
@@ -15,7 +15,7 @@ function getAPILogs(BaseAPIURL, headers, state, accumulator, maxPagesPerInvocati
 
     let restServiceClient = new RestServiceClient(BaseAPIURL);
 
-    switch (state.objectName) {
+    switch (state.stream) {
         case Events:
             APIURL = `/siem/v1/events`;
             break;


### PR DESCRIPTION
### Problem Description
Sophosiem  collector showing the as unhealthy/not receiving logs within the last 24hours.

The undefined is getting appended instated of api url as objectName was not available in state object and so getting error code 403 from below api request.
https://api5.central.sophos.com/gatewayundefined?from_date=&limit=1000

### Solution Description
Used stream from state object and remove objectName which no longer available in state object.


 
