### PR TITLE
Sophos : Fixed the invalid request issue

### DIFF
--- a/collectors/sophossiem/collector.js
+++ b/collectors/sophossiem/collector.js
@@ -68,11 +68,13 @@ class SophossiemCollector extends PawsCollector {
         if (!state.stream) {
             state = collector.setStreamToCollectionState(state);
         }
-        // If from date > 24 hr api return invalid request , so set the date between 24 hr only. 
-        if (moment().diff((moment.unix(parseInt(state.from_date))), 'hours') > 24) {
+        // If from date > 24 hr api return invalid request , so set the date between 24 hr only and report the skip duration on DD metrics
+        if (moment().diff((moment.unix(parseInt(state.from_date))), 'hours') >= 24) {
             const previuosDate = state.from_date;
-            state.from_date = moment().subtract(23.45, 'hours').unix();
+            state.from_date = moment().subtract(23.75, 'hours').unix();
             console.warn(`Adjusted date from  ${moment.unix(parseInt(previuosDate)).format("YYYY-MM-DDTHH:mm:ssZ")} to ${moment.unix(parseInt(state.from_date)).format("YYYY-MM-DDTHH:mm:ssZ")} as api require date must be within last 24 hours`);
+            const skipDuration = moment.unix(parseInt(state.from_date)).diff(moment.unix(parseInt(previuosDate)),'hours');
+            collector.reportDDMetric("adjust_collection_interval", 1, [`skip_hrs:${skipDuration}`]);
         }
         const clientSecret = collector.secret;
         if (!clientSecret) {

--- a/collectors/sophossiem/collector.js
+++ b/collectors/sophossiem/collector.js
@@ -68,6 +68,10 @@ class SophossiemCollector extends PawsCollector {
         if (!state.stream) {
             state = collector.setStreamToCollectionState(state);
         }
+        // If from date > 24 hr api return invalid request , so set the date between 24 hr only. 
+        if (moment().diff((moment.unix(parseInt(state.from_date))), 'hours') > 24) {
+            state.from_date = moment().subtract(23, 'hours').unix();
+        }
         const clientSecret = collector.secret;
         if (!clientSecret) {
             return callback("The Authorization token was not found!");

--- a/collectors/sophossiem/collector.js
+++ b/collectors/sophossiem/collector.js
@@ -70,7 +70,8 @@ class SophossiemCollector extends PawsCollector {
         }
         // If from date > 24 hr api return invalid request , so set the date between 24 hr only. 
         if (moment().diff((moment.unix(parseInt(state.from_date))), 'hours') > 24) {
-            state.from_date = moment().subtract(23, 'hours').unix();
+            console.warn('Adjusted from date as api require date must be within last 24 hours');
+            state.from_date = moment().subtract(23.45, 'hours').unix();
         }
         const clientSecret = collector.secret;
         if (!clientSecret) {

--- a/collectors/sophossiem/collector.js
+++ b/collectors/sophossiem/collector.js
@@ -74,7 +74,12 @@ class SophossiemCollector extends PawsCollector {
             state.from_date = moment().subtract(23.75, 'hours').unix();
             console.warn(`Adjusted date from  ${moment.unix(parseInt(previuosDate)).format("YYYY-MM-DDTHH:mm:ssZ")} to ${moment.unix(parseInt(state.from_date)).format("YYYY-MM-DDTHH:mm:ssZ")} as api require date must be within last 24 hours`);
             const skipDuration = moment.unix(parseInt(state.from_date)).diff(moment.unix(parseInt(previuosDate)),'hours');
-            collector.reportDDMetric("adjust_collection_interval", 1, [`skip_hrs:${skipDuration}`]);
+            if (skipDuration > 24) {
+                collector.reportDDMetric("adjust_collection_interval", 1, [`skip_hrs:24h`]);
+            }
+            else {
+                collector.reportDDMetric("adjust_collection_interval", 1, [`skip_hrs:${skipDuration}h`]);
+            }
         }
         const clientSecret = collector.secret;
         if (!clientSecret) {

--- a/collectors/sophossiem/collector.js
+++ b/collectors/sophossiem/collector.js
@@ -70,8 +70,9 @@ class SophossiemCollector extends PawsCollector {
         }
         // If from date > 24 hr api return invalid request , so set the date between 24 hr only. 
         if (moment().diff((moment.unix(parseInt(state.from_date))), 'hours') > 24) {
-            console.warn('Adjusted from date as api require date must be within last 24 hours');
+            const previuosDate = state.from_date;
             state.from_date = moment().subtract(23.45, 'hours').unix();
+            console.warn(`Adjusted date from  ${moment.unix(parseInt(previuosDate)).format("YYYY-MM-DDTHH:mm:ssZ")} to ${moment.unix(parseInt(state.from_date)).format("YYYY-MM-DDTHH:mm:ssZ")} as api require date must be within last 24 hours`);
         }
         const clientSecret = collector.secret;
         if (!clientSecret) {

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,


### PR DESCRIPTION
### Problem Description

Sophos api retuning `INVALID_REQUEST` as from date grater than 24 hr. 
https://api3.central.sophos.com/gateway/siem/v1/events?from_date=1616582131&limit=1000

### Solution Description
Check if date is grater than 24 hr set new date which is within 24 hr in state object.
 
