### PR TITLE
[paws-collector] Review collector remediations / status for Sophos

### DIFF
--- a/collectors/sophos/local/sam-template.yaml
+++ b/collectors/sophos/local/sam-template.yaml
@@ -6,7 +6,7 @@ Resources:
   LocalLambda:
     Type: AWS::Serverless::Function
     Properties:
-      KmsKeyArn: your-arn-here
+      KmsKeyArn: 
       Environment:
         Variables:
           AWS_LAMBDA_FUNCTION_NAME:
@@ -14,7 +14,7 @@ Resources:
           aims_access_key_id:
           al_api:
           stack_name:
-          azollect_api:
+          azcollect_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -26,7 +26,10 @@ Resources:
           paws_api_client_id:
           paws_max_pages_per_invocation:
           collector_id:
-      Runtime: nodejs10.x
+          paws_ddb_table_name:
+          customer_id:
+      CodeUri:      
+      Runtime: nodejs12.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sophos/test/sophos_test.js
+++ b/collectors/sophos/test/sophos_test.js
@@ -212,6 +212,62 @@ describe('Unit Tests', function () {
             });
         });
 
+        it('Paws Get Logs checking invalid client secret error', function (done) {
+            authenticate = sinon.stub(utils, 'authenticate').callsFake(
+                function fakeFn(hostName, clientId, clientSecret) {
+                    return new Promise(function (resolve, reject) {
+                        return reject({ "statusCode": 401, "message": `{ "errorCode": "oauth.invalid_client_secret" }` });
+                    });
+                });
+           
+            SophosCollector.load().then(function (creds) {
+                var collector = new SophosCollector(ctx, creds, 'sophos');
+                const startDate = moment().subtract(3, 'days');
+                const curState = {
+                    since: startDate.toISOString(),
+                    until: startDate.add(2, 'days').toISOString(),
+                    nextPage: null,
+                    apiQuotaResetDate: null,
+                    poll_interval_sec: 1
+                };
+                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
+                    assert.ok(err);
+                    assert.equal(err,"Error code [401]. Invalid client secret is provided.");
+                    authenticate.restore();
+                    done();
+                });
+
+            });
+        });
+
+        it('Paws Get Logs checking invalid client ID error', function (done) {
+            authenticate = sinon.stub(utils, 'authenticate').callsFake(
+                function fakeFn(hostName, clientId, clientSecret) {
+                    return new Promise(function (resolve, reject) {
+                        return reject({ "statusCode": 401, "message": `{ "errorCode": "oauth.client_app_does_not_exist" }` });
+                    });
+                });
+           
+            SophosCollector.load().then(function (creds) {
+                var collector = new SophosCollector(ctx, creds, 'sophos');
+                const startDate = moment().subtract(3, 'days');
+                const curState = {
+                    since: startDate.toISOString(),
+                    until: startDate.add(2, 'days').toISOString(),
+                    nextPage: null,
+                    apiQuotaResetDate: null,
+                    poll_interval_sec: 1
+                };
+                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
+                    assert.ok(err);
+                    assert.equal(err,"Error code [401]. Invalid client ID is provided.");
+                    authenticate.restore();
+                    done();
+                });
+
+            });
+        });
+
         it('Paws Get Logs testing throttling error', function (done) {
             authenticate = sinon.stub(utils, 'authenticate').callsFake(
                 function fakeFn(hostName, clientId, clientSecret) {


### PR DESCRIPTION
### Problem Description
Sophos collector should show same error message on UI which we can see in cloud watch logs.
For below customer it showing error  `Alert Logic collector Sophos-Group hasn't sent logs to Alert Logic for the past 24 hours.' on UI, But actually it getting below error message on cloud watch logs
Customer Id :68582699 
Region : eu-west-1
Collector : Sophos
Collector Id :F31E634F-68D7-42FF-B55B-90CDFF109236
Error message : "Please generate credentials for the tenant. Currently we do not support credentials for Organization and Partner.

### Solution Description
I have tested this error message and it's showing on remediations page. Also added new remediations for invalid credentials.
