### PR TITLE
ENG-25186 : Send the lmcstats for cloud collectors (PAWS, s3-collector)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "3.0.9",
+    "@alertlogic/al-aws-collector-js": "4.0.1",
     "datadog-lambda-js": "2.23.0",
     "async": "3.1.0",
     "debug": "4.1.1",


### PR DESCRIPTION
Send the lmc stats for paws collector. Refer changes from [al-aws-collector](https://github.com/alertlogic/al-aws-collector-js/pull/64).
