### PR TITLE
ENG-25186 :  Send lmcstats for cloud collectors(Paws)

### DIFF
--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "auth0": "2.27.1",
-    "@alertlogic/al-collector-js": "^2.0.0",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "@duosecurity/duo_api": "1.2.1",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "@google-cloud/logging": "6.0.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
     "moment": "2.24.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "async": "3.1.0",
     "debug": "4.1.1",
     "googleapis": "39.2.0",

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -19,9 +19,9 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "^3.0.6",
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-aws-collector-js": "^4.0.1",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "@azure/ms-rest-azure-js": "2.0.1",
     "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-nodeauth": "2.0.5",

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@okta/okta-sdk-nodejs": "3.1.0",
-    "@alertlogic/al-collector-js": "^2.0.0",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "async": "3.1.0",
     "debug": "4.1.1",
     "jsforce": "^1.9.3",

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -21,8 +21,8 @@
     "mockserver": "^3.1.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^1.4.5",
-    "@alertlogic/paws-collector": "^2.0.7",
+    "@alertlogic/al-collector-js": "^2.0.4",
+    "@alertlogic/paws-collector": "^2.0.8",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"


### PR DESCRIPTION
When log get process , we send the logsmsgs and lmcstats to ingest .
When we call the processLog method from [al-aws-collector-js](https://github.com/alertlogic/al-aws-collector-js/blob/master/al_aws_collector.js#L722),  it  will send both (logmsgs and lmcstats) to ingest.
