### PR TITLE
ENG-25186: Bump the paws collector version to fix time out issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.0.1",
+    "@alertlogic/al-aws-collector-js": "4.0.2",
     "datadog-lambda-js": "2.23.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -9,7 +9,6 @@ const pawsMock = require('./paws_mock');
 var m_alCollector = require('@alertlogic/al-collector-js');
 var PawsCollector = require('../paws_collector').PawsCollector;
 const m_al_aws = require('@alertlogic/al-aws-collector-js').Util;
-const alAwsCollector = require('@alertlogic/al-aws-collector-js');
 
 
 var alserviceStub = {};
@@ -19,7 +18,6 @@ var setEnvStub = {};
 var decryptStub = {};
 var ssmStub = {};
 
-var alAwsCollectorStub = {};
 function setAlServiceStub() {
     alserviceStub.get = sinon.stub(m_alCollector.AlServiceC.prototype, 'get').callsFake(
         function fakeFn(path, extraOptions) {
@@ -62,14 +60,6 @@ function restoreAlServiceStub() {
     alserviceStub.del.restore();
 }
 
-function setAlAwsCollectorStub() {
-    const processLogfakeFun = function (messages, formatFun, hostmetaElems, callback) { return callback(null, { data: null }); };
-    alAwsCollectorStub.processLog = sinon.stub(alAwsCollector.AlAwsCollector.prototype, 'processLog').callsFake(processLogfakeFun);
-}
-
-function restoreAlAwsCollectorStub() {
-    alAwsCollectorStub.processLog.restore();
-}
 
 function mockSetEnvStub() {
     setEnvStub = sinon.stub(m_al_aws, 'setEnv').callsFake((vars, callback)=>{
@@ -283,11 +273,9 @@ describe('Unit Tests', function() {
     });
     describe('State Deduplicationt Tests', function(){
         beforeEach(function () {
-            setAlAwsCollectorStub();
         });
         afterEach(function () {
             AWS.restore('DynamoDB');
-            restoreAlAwsCollectorStub();
         });
         it('creates a new DDB item when the states does not exist', function(done){
             const fakeFun = function(_params, callback){return callback(null, {data:null});};
@@ -465,7 +453,6 @@ describe('Unit Tests', function() {
     describe('Poll Request Tests', function() {
         it('poll request success, single state', function(done) {
             mockDDB();
-            setAlAwsCollectorStub();
             let ctx = {
                 invokedFunctionArn : pawsMock.FUNCTION_ARN,
                 fail : function(error) {
@@ -474,7 +461,6 @@ describe('Unit Tests', function() {
                 },
                 succeed : function() {
                     AWS.restore('DynamoDB');
-                    restoreAlAwsCollectorStub();
                     done();
                 }
             };
@@ -496,7 +482,6 @@ describe('Unit Tests', function() {
         
         it('poll request success, multiple state', function(done) {
             mockDDB();
-            setAlAwsCollectorStub();
 
             let ctx = {
                 invokedFunctionArn : pawsMock.FUNCTION_ARN,
@@ -506,7 +491,6 @@ describe('Unit Tests', function() {
                 },
                 succeed : function() {
                     AWS.restore('DynamoDB');
-                    restoreAlAwsCollectorStub();
                     done();
                 }
             };


### PR DESCRIPTION
After lmcstats changes timeout issue get introduce and to fix that updated the al-aws-collector-js version to [4.0.2](https://github.com/alertlogic/al-aws-collector-js/pull/66).
Also reverted  the  test case changes added in last [pr](https://github.com/alertlogic/paws-collector/pull/185/files) .