### PR TITLE
ENG-26751 : Removed the SearchAlertsVmware stream from CB as alert api not supported

### DIFF
--- a/collectors/carbonblack/README.md
+++ b/collectors/carbonblack/README.md
@@ -3,7 +3,7 @@ Alert Logic Carbonblack AWS Based API Poll (PAWS) Log Collector Library.
 
 # Overview
 This repository contains the AWS JavaScript Lambda function and CloudFormation 
-Template (CFT) for deploying a log collector in AWS which will poll Carbonblack (Audit Log Events, Search Alerts, Search Alerts CBAnalytics, Search Alerts Vmware, Search Alerts Watchlist) service API to collect and 
+Template (CFT) for deploying a log collector in AWS which will poll Carbonblack (Audit Log Events, Search Alerts, Search Alerts CBAnalytics, Search Alerts Watchlist) service API to collect and 
 forward logs to the Alert Logic CloudInsight backend services.
 
 # Installation

--- a/collectors/carbonblack/README.md
+++ b/collectors/carbonblack/README.md
@@ -127,3 +127,7 @@ make sam-local
 ```
   4. Please see `local/event.json` for the event payload used for local invocation.
 Please write your readme here
+
+### 5. Removed Search alert vmware 
+1. Carbon black search alert api not supporting the vmware api.
+2. One new api (i.e devicecontrol) get added in CB search alert api [doc](https://developer.carbonblack.com/reference/carbon-black-cloud/platform/latest/alerts-api/#alert-search), but we are not yet supporting this.

--- a/collectors/carbonblack/local/env.json.tmpl
+++ b/collectors/carbonblack/local/env.json.tmpl
@@ -16,7 +16,7 @@
     "paws_secret_param_name": "secret-param-name",
     "paws_api_client_id":"client-id",
     "paws_endpoint": paws-endpoint",
-    "collector_streams": "[\"AuditLogEvents\", \"SearchAlerts\", \"SearchAlertsCBAnalytics\", \"SearchAlertsVmware\", \"SearchAlertsWatchlist\"]",
+    "collector_streams": "[\"AuditLogEvents\", \"SearchAlerts\", \"SearchAlertsCBAnalytics\",\"SearchAlertsWatchlist\"]",
     "paws_collector_param_string_2": "Carbonblack-Org-Key",
     "sample-custom-var": "https://some-endpoint.com/",
     "collector_id": "557D90CB-0BA2-40EC-8A9D-94184612C084"

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/carbonblack/test/Carbonblack_test.js
+++ b/collectors/carbonblack/test/Carbonblack_test.js
@@ -107,7 +107,7 @@ describe('Unit Tests', function () {
                 const sampleEvent = { ResourceProperties: { StackName: 'a-stack-name' } };
                 collector.pawsGetRegisterParameters(sampleEvent, (err, regValues) => {
                     const expectedRegValues = {
-                        carbonblackAPINames: '["AuditLogEvents", "SearchAlerts","SearchAlertsCBAnalytics", "SearchAlertsVmware", "SearchAlertsWatchlist"]',
+                        carbonblackAPINames: '["AuditLogEvents", "SearchAlerts","SearchAlertsCBAnalytics", "SearchAlertsWatchlist"]',
                         carbonblackOrgKey: 'carbonblackOrgKey'
                     };
                     assert.deepEqual(regValues, expectedRegValues);

--- a/collectors/carbonblack/test/carbonblack_mock.js
+++ b/collectors/carbonblack/test/carbonblack_mock.js
@@ -16,7 +16,7 @@ process.env.paws_poll_interval = 60;
 process.env.paws_type_name = "carbonblack";
 process.env.paws_api_client_id = "client-id";
 process.env.paws_api_secret = "api-secret";
-process.env.collector_streams = "[\"AuditLogEvents\", \"SearchAlerts\",\"SearchAlertsCBAnalytics\", \"SearchAlertsVmware\", \"SearchAlertsWatchlist\"]";
+process.env.collector_streams = "[\"AuditLogEvents\", \"SearchAlerts\",\"SearchAlertsCBAnalytics\", \"SearchAlertsWatchlist\"]";
 process.env.paws_collector_param_string_2 = "carbonblackOrgKey";
 process.env.paws_endpoint = "https://api-url.conferdeploy.net";
 

--- a/collectors/carbonblack/utils.js
+++ b/collectors/carbonblack/utils.js
@@ -3,7 +3,6 @@ const RestServiceClient = require('@alertlogic/al-collector-js').RestServiceClie
 const Audit_Log_Events = 'AuditLogEvents';
 const Search_Alerts = 'SearchAlerts';
 const Search_Alerts_CB_Analytics = 'SearchAlertsCBAnalytics';
-const Search_Alerts_Vmware = 'SearchAlertsVmware';
 const Search_Alerts_Watchlist = 'SearchAlertsWatchlist';
 
 function getAPILogs(apiDetails, accumulator, apiEndpoint, state, clientSecret, clientId, maxPagesPerInvocation) {
@@ -95,22 +94,6 @@ function getAPIDetails(state, orgKey) {
             break;
         case Search_Alerts_CB_Analytics:
             url = `/appservices/v6/orgs/${orgKey}/alerts/cbanalytics/_search`;
-            typeIdPaths = [{ path: ["id"] }];
-            tsPaths = [{ path: ["last_update_time"] }];
-            method = "POST";
-            requestBody = {
-                "criteria": {
-                    "create_time": {
-                        "end": state.until,
-                        "start": state.since
-                    },
-                },
-                "rows": 0,
-                "start": 0
-            };
-            break;
-        case Search_Alerts_Vmware:
-            url = `/appservices/v6/orgs/${orgKey}/alerts/vmware/_search`;
             typeIdPaths = [{ path: ["id"] }];
             tsPaths = [{ path: ["last_update_time"] }];
             method = "POST";


### PR DESCRIPTION
### Problem Description
Getting 404-undefined error for CB vmware search stream for below api .
`<cbc-hostname>/appservices/v6/orgs/${orgKey}/alerts/vmware/_search`. [CB search alert  api document](https://developer.carbonblack.com/reference/carbon-black-cloud/platform/latest/alerts-api/#api-calls) not supporting this api.

### Solution Description
Remove Search_Alerts_Vmware stream from api_names. So , now it pull data for rest of 3 streams.
Also removed stream from catlog.json of [Applications pr](https://algithub.pd.alertlogic.net/defender/applications/pull/133).


