### PR TITLE
Reduce length of initial collection interval when start_ts > 7d

### DIFF
--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -50,7 +50,7 @@ class O365Collector extends PawsCollector {
         }
 
         if(moment().diff(startTs, 'hours') > 24){
-            endTs = moment(startTs).add(24, 'hours').toISOString();
+            endTs = moment(startTs).add(3, 'hours').toISOString();
         }
         else {
             endTs = moment(startTs).add(this.pollInterval, 'seconds').toISOString();
@@ -103,7 +103,7 @@ class O365Collector extends PawsCollector {
         if(moment().diff(state.since, 'days', true) > 7){
             const newStart = moment().subtract(PARTIAL_WEEK, 'days');
             state.since = newStart.toISOString();
-            state.until = newStart.add(1, 'hours').toISOString();
+            state.until = newStart.add(15, 'minutes').toISOString();
             // remove next page token if the state is out of date as well.
             state.nextPage = null;
             console.warn(

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/o365/test/o365_test.js
+++ b/collectors/o365/test/o365_test.js
@@ -236,7 +236,7 @@ describe('O365 Collector Tests', function() {
                 collector.pawsInitCollectionState(o365Mock.LOG_EVENT, (err, initialStates, nextPoll) => {
                     initialStates.forEach((state) => {
                         assert.notEqual(state.since, startDate, "Date is more than 7 days in the past");
-                        assert.equal(moment(state.until).diff(state.since, 'hours'), 24);
+                        assert.equal(moment(state.until).diff(state.since, 'hours'), 3);
                     });
                     done();
                 });
@@ -264,7 +264,7 @@ describe('O365 Collector Tests', function() {
 
                 collector.pawsInitCollectionState(o365Mock.LOG_EVENT, (err, initialStates, nextPoll) => {
                     initialStates.forEach((state) => {
-                        assert.equal(moment(state.until).diff(state.since, 'hours'), 24);
+                        assert.equal(moment(state.until).diff(state.since, 'hours'), 3);
                     });
                     done();
                 });
@@ -368,7 +368,7 @@ describe('O365 Collector Tests', function() {
 
                     assert.equal(callArgs[0], curState.stream);
                     assert.equal(moment().diff(callArgs[1], 'days'), 7);
-                    assert.equal(moment(callArgs[2]).diff(callArgs[1], 'hours'), 1);
+                    assert.equal(moment(callArgs[2]).diff(callArgs[1], 'minutes'), 15);
                     restoreO365ManagemntStub();
                     done();
                 });
@@ -393,7 +393,7 @@ describe('O365 Collector Tests', function() {
 
                     assert.equal(callArgs[0], curState.stream);
                     assert.equal(moment().diff(callArgs[1], 'days'), 7);
-                    assert.equal(moment(callArgs[2]).diff(callArgs[1], 'hours'), 1);
+                    assert.equal(moment(callArgs[2]).diff(callArgs[1], 'minutes'), 15);
                     assert.equal(getPreFormedUrlStub.calledWith(curState.nextPage), false);
                     restoreO365ManagemntStub();
                     done();


### PR DESCRIPTION
### Problem Description
For at least one collector it was observed that the interval was too large - the collector takes so long to handle the paged response from MS Management API that by the time it gets to the end, the `state.since` timestamp stored in SQS becomes older than 7 days; in this case, the collector resets `state.since` to `now - 7d` and sets `state.until` to `state.since + 1h`.  This results in a paged response which takes too long too handle, and... you get the idea. 

### Solution Description
Shrink all of the intervals so that (hopefully) the collector can get through the paged responses more quickly. 