### PR TITLE
VTT-3058 : Change the hour-day-progression to hour_cap to handle the huge paged response

### DIFF
--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -90,7 +90,7 @@ class O365Collector extends PawsCollector {
         }
 
         if (!moment(state.since).isValid() || !moment(state.until).isValid() || state.since === undefined || state.until === undefined) {
-            const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-day-progression', moment(), this.pollInterval);
+            const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-cap', moment(), this.pollInterval);
             state.since = nextSinceMoment.toISOString();
             state.until = nextUntilMoment.toISOString();
             state.nextPage = null;
@@ -173,7 +173,7 @@ class O365Collector extends PawsCollector {
                 // set errorCode if not available in error object to showcase client error on DDMetric
                 try {
                     let error = JSON.parse(message.slice(message.indexOf('{'), message.lastIndexOf('}') + 1));
-                    err.errorCode = error.error;
+                    err.errorCode = error.error ? error.error : error.error_codes[0];
                     if (error.error_codes) {
                         if (error.error_codes[0] === 7000215) {
                             return callback("Error code [7000215]. Invalid client secret is provided.");
@@ -198,7 +198,7 @@ class O365Collector extends PawsCollector {
     _getNextCollectionState(curState) {
         const untilMoment = moment(curState.until);
 
-        const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-day-progression', untilMoment, this.pollInterval);
+        const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-cap', untilMoment, this.pollInterval);
 
         return  {
             stream: curState.stream,

--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -49,8 +49,8 @@ class O365Collector extends PawsCollector {
             console.info("O365000004 Start timestamp is more than 7 days in the past. This is not allowed in the MS managment API. setting the start time to 7 days in the past");
         }
 
-        if(moment().diff(startTs, 'hours') > 24){
-            endTs = moment(startTs).add(24, 'hours').toISOString();
+        if(moment().diff(startTs, 'hours') > 1){
+            endTs = moment(startTs).add(1, 'hours').toISOString();
         }
         else {
             endTs = moment(startTs).add(this.pollInterval, 'seconds').toISOString();

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/o365/test/o365_test.js
+++ b/collectors/o365/test/o365_test.js
@@ -236,7 +236,7 @@ describe('O365 Collector Tests', function() {
                 collector.pawsInitCollectionState(o365Mock.LOG_EVENT, (err, initialStates, nextPoll) => {
                     initialStates.forEach((state) => {
                         assert.notEqual(state.since, startDate, "Date is more than 7 days in the past");
-                        assert.equal(moment(state.until).diff(state.since, 'hours'), 24);
+                        assert.equal(moment(state.until).diff(state.since, 'hours'), 1);
                     });
                     done();
                 });
@@ -264,7 +264,7 @@ describe('O365 Collector Tests', function() {
 
                 collector.pawsInitCollectionState(o365Mock.LOG_EVENT, (err, initialStates, nextPoll) => {
                     initialStates.forEach((state) => {
-                        assert.equal(moment(state.until).diff(state.since, 'hours'), 24);
+                        assert.equal(moment(state.until).diff(state.since, 'hours'), 1);
                     });
                     done();
                 });


### PR DESCRIPTION

### Problem Description
For few collectors , it was observed that the collector takes so long to handle the huge paged response from MS Management API when collector state.since timestamp stored in SQS becomes older than 7 days ; in this case ,we reset the state and get the [1hr](https://github.com/alertlogic/paws-collector/blob/master/collectors/o365/o365_collector.js#L106) data but when it goes for [nextCollection](https://github.com/alertlogic/paws-collector/blob/master/collectors/o365/o365_collector.js#L164) and now the pull time duration is 24hr as we are using `hour-day-progression` to calculate the next duration.  Below are the listed cases which reporting issues :

- Case 1.  Time :5min and Memory : 256 MB
  The data is so huge for 24hr duration ,so we get `Task time out ` from lambda.
- Case 2. By increasing Time :15min and Memory : 2048 MB
 Now we getting the error from MS api that 'Maximum payload size exceeded: 45003809'.


### Solution Description
Now we calculating the `nextCollection` state based on `hour_cap'.  So it will pull the data at an interval of 1hr.
