### PR TITLE
Refresh state

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.0.2",
+    "@alertlogic/al-aws-collector-js": "4.0.5",
     "datadog-lambda-js": "2.23.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -460,7 +460,7 @@ class PawsCollector extends AlAwsCollector {
                 collector.done(null, pawsState, false);
             } else {
                const ddbStatus = handleError ? STATE_RECORD_FAILED : STATE_RECORD_COMPLETE;
-                collector.updateStateDBEntry(stateSqsMsg, ddbStatus, function(e) {
+                collector.updateStateDBEntry(stateSqsMsg, ddbStatus, function() {
                     if(handleError) {
                         // If collector failed to handle poll state we'd like to refresh the state message in SQS
                         // in order to avoid expiration of that message due to retention period.

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -27,9 +27,16 @@ const DEFAULT_PAWS_SECRET_PARAM_TIER = 'Standard';
 const DOMAIN_REGEXP = /^[htps]*:\/\/|\/$/gi;
 
 const STATE_RECORD_COMPLETE = "COMPLETE";
-const STATE_RECORD_INCOMPLETE ="INCOMPLETE";
+const STATE_RECORD_INCOMPLETE = "INCOMPLETE";
+const STATE_RECORD_FAILED = "FAILED";
+const ERROR_CODE_DUPLICATE_STATE = 'DUPLICATE_STATE';
+const ERROR_CODE_COMPLETED_STATE = 'COMPLETED_STATE';
 const SQS_VISIBILITY_TIMEOUT = 900;
 const DDB_TTL_DAYS = 14;
+const DDB_OPTIONS = {
+    maxRetries: 10,
+    ConsistentRead: true
+};
 
 function getPawsParamStoreParam(){
     return new Promise((resolve, reject) => {
@@ -155,6 +162,14 @@ class PawsCollector extends AlAwsCollector {
         return this._pawsHttpsEndpoint;
     };
 
+    done(error, pawsState, sendStatus = true) {
+        const streamType = pawsState && pawsState.priv_collector_state.stream ?
+            process.env.al_application_id + "_" + pawsState.priv_collector_state.stream :
+            null;
+        
+        super.done(error, streamType, sendStatus);
+    }
+    
     reportDDMetric(name, value, tags = []) {
         // check if the API key is present. This will be a good proxy for if the handler is working
         if (!process.env.DD_API_KEY){
@@ -229,7 +244,7 @@ class PawsCollector extends AlAwsCollector {
         let pawsRegisterProps = this.getProperties();
         collector.pawsGetRegisterParameters(event, function(err, customRegister) {
             if (err) {
-                console.err('PAWS000101 Error during registration', err);
+                console.error('PAWS000101 Error during registration', err);
                 return callback(err);
             } else {
                 let registerProps = Object.assign(pawsRegisterProps, customRegister);
@@ -288,7 +303,7 @@ class PawsCollector extends AlAwsCollector {
     // there is a lot of logic here. not sur eif there is a better way of deduping. trying for an MVP
     checkStateSqsMessage(stateSqsMsg, asyncCallback) {
         const collector = this;
-        const DDB = new AWS.DynamoDB();
+        const DDB = new AWS.DynamoDB(DDB_OPTIONS);
 
         const params = {
             Key: {
@@ -308,11 +323,11 @@ class PawsCollector extends AlAwsCollector {
                 // check to see if record was updated within the visibility timeout of the SQS queue.
                 // if it is within that limit, then it likely to be processed by another invocation and this is a duplicate
                 if(Item.Status.S === STATE_RECORD_INCOMPLETE && moment().unix() - parseInt(Item.Updated.N) < SQS_VISIBILITY_TIMEOUT) {
-                    console.info(`Duplicate state: ${Item.MessageId.S}, already in progress. skipping`);
-                    return asyncCallback('State is currently being processed by another invocation');
+                    console.info(`PAWS000400 Duplicate state: ${Item.MessageId.S}, already in progress. skipping`);
+                    return asyncCallback({errorCode: ERROR_CODE_DUPLICATE_STATE});
                 } else if (Item.Status.S === STATE_RECORD_COMPLETE){
-                    console.info(`Duplicate state: ${Item.MessageId.S}, already processed. skipping`);
-                    return collector.done();
+                    console.info(`PAWS000401 Duplicate state: ${Item.MessageId.S}, already processed. skipping`);
+                    return asyncCallback({errorCode: ERROR_CODE_COMPLETED_STATE});
                 } else {
                     return collector.updateStateDBEntry(stateSqsMsg, STATE_RECORD_INCOMPLETE, asyncCallback);
                 }
@@ -344,7 +359,7 @@ class PawsCollector extends AlAwsCollector {
 
     updateStateDBEntry(stateSqsMsg, Status, asyncCallback) {
         const collector = this;
-        const DDB = new AWS.DynamoDB();
+        const DDB = new AWS.DynamoDB(DDB_OPTIONS);
 
         const updateParams = {
             Key: {
@@ -434,18 +449,51 @@ class PawsCollector extends AlAwsCollector {
             },
             function(privCollectorState, nextInvocationTimeout, asyncCallback) {
                 return collector._storeCollectionState(pawsState, privCollectorState, nextInvocationTimeout, asyncCallback);
-            },
-            function(_results, asyncCallback) {
-                return collector.updateStateDBEntry(stateSqsMsg, STATE_RECORD_COMPLETE, asyncCallback);
             }
-        ], function(error) {
-            if (pawsState.priv_collector_state.stream) {
-                collector.done(error, process.env.al_application_id + "_" + pawsState.priv_collector_state.stream);
+        ], function(handleError) {
+            console.log('#####handleError: ', handleError);
+            if( handleError && handleError.errorCode === ERROR_CODE_DUPLICATE_STATE) {
+                // We need to fail invocation for duplicate state handling
+                // because we don't want delete SQS message which is being handled by another invocation
+                collector.done(handleError, pawsState, false);
+            } else if (handleError && handleError.errorCode === ERROR_CODE_COMPLETED_STATE) {
+                // For already completed states we need to just remove the state message from SQS
+                collector.done(null, pawsState, false);
             } else {
-                collector.done(error);
+                let ddbStatus = error ? STATE_RECORD_FAILED : STATE_RECORD_COMPLETE;
+                collector.updateStateDBEntry(stateSqsMsg, ddbStatus, function() {
+                    if(handleError) {
+                        // If collector failed to handle poll state we'd like to refresh the state message in SQS
+                        // in order to avoid expiration of that message due to retention period.
+                        // Here we just upload same state messaged into SQS and  send error status to the backend.
+                        // The invocation is marked as succeed in order to clean up current state message in SQS.
+                        collector._storeCollectionState(pawsState, pawsState.priv_collector_state, 300, function(storeError){
+                            if (!storeError){
+                                collector.reportErrorStatus(handleError, pawsState, (statusSendError, handleErrorString) => {
+                                    console.error('PAWS000304 Error handling poll request: ', handleErrorString);
+                                    collector.done(null, pawsState);
+                                });
+                            } else {
+                                collector.done(storeError);
+                            }
+                        });
+                    }
+                    collector.done(null, pawsState);
+                });
             }
         });
     };
+    
+    reportErrorStatus(error, pawsState, callback) {
+        const streamType = pawsState && pawsState.priv_collector_state.stream ?
+                process.env.al_application_id + "_" + pawsState.priv_collector_state.stream :
+                null;
+        const errorString = this.stringifyError(error);
+        const status = this.prepareErrorStatus(errorString, 'none', streamType);
+        this.sendStatus(status, (sendError) => {
+            return callback(sendError, errorString);
+        });
+    }
 
     reportApiThrottling(callback) {
         // TODO: report collector status via Ingest/agentstatus
@@ -680,7 +728,7 @@ class PawsCollector extends AlAwsCollector {
         let collectorStreams = { collector_streams: streams };
         return AlAwsUtil.setEnv(collectorStreams, (err) => {
             if (err) {
-                console.error('Paws error while adding collector_streams in environment variable')
+                console.error('PAWS000301 Paws error while adding collector_streams in environment variable')
             }
         });
     }

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -287,10 +287,12 @@ describe('Unit Tests', function() {
             let ctx = {
                 invokedFunctionArn : pawsMock.FUNCTION_ARN,
                 fail : function(error) {
+                    console.log('!!!Error', error);
                     assert.fail(error);
                     done();
                 },
                 succeed : function() {
+                    console.log('!!!OK');
                     const putItemArgs = putItemStub.args[0][0];
                     const updateItemArgs = updateItemStub.args[0][0];
                     assert.equal(putItemStub.called, true, 'should put a new item in');
@@ -342,14 +344,16 @@ describe('Unit Tests', function() {
             let ctx = {
                 invokedFunctionArn : pawsMock.FUNCTION_ARN,
                 fail : function(error) {
-                    assert.fail(error);
-                    done();
-                },
-                succeed : function() {
                     assert.equal(getItemStub.called, true, 'should get new item');
                     assert.equal(putItemStub.notCalled, true, 'should not put a new item in');
                     assert.equal(updateItemStub.notCalled, true, 'should not update the item to complete');
-                    
+                    if (error === '{"errorCode":"DUPLICATE_STATE"}')
+                        done();
+                    else
+                        assert.fail("invocation have another error code");
+                },
+                succeed : function() {
+                    assert.fail("invocation should fail");
                     done();
                 }
             };
@@ -394,11 +398,10 @@ describe('Unit Tests', function() {
                     assert.equal(getItemStub.called, true, 'should get new item');
                     assert.equal(putItemStub.notCalled, true, 'should not put a new item in');
                     assert.equal(updateItemStub.notCalled, true, 'should not update the item to complete');
-                   
                     done();
                 },
                 succeed : function() {
-                    assert.fail("invocation should not succeed while state is being processed by another invocation");
+                    assert.fail("invocation should fail while state is being processed by another invocation becasue we don't want to remove SQS message which is processed by another invocation");
                 }
             };
 

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -113,12 +113,20 @@ class TestCollector extends PawsCollector {
         super(ctx, creds);
     }
     
+    set mockGetLogsError(msg = null) {
+        this._mockGetLogsError = msg;
+    }
+    
+    get mockGetLogsError() {
+        return this._mockGetLogsError;
+    }
+    
     pawsInitCollectionState(event, callback) {
         return callback(null, {state: 'initial-state'}, 900);
     }   
     
     pawsGetLogs(state, callback) {
-        return callback(null, ['log1', 'log2'], {state: 'new-state'}, 900);
+        return callback(this.mockGetLogsError, ['log1', 'log2'], {state: 'new-state'}, 900);
     }
     
     pawsGetRegisterParameters(event, callback) {
@@ -287,12 +295,10 @@ describe('Unit Tests', function() {
             let ctx = {
                 invokedFunctionArn : pawsMock.FUNCTION_ARN,
                 fail : function(error) {
-                    console.log('!!!Error', error);
                     assert.fail(error);
                     done();
                 },
                 succeed : function() {
-                    console.log('!!!OK');
                     const putItemArgs = putItemStub.args[0][0];
                     const updateItemArgs = updateItemStub.args[0][0];
                     assert.equal(putItemStub.called, true, 'should put a new item in');
@@ -344,6 +350,8 @@ describe('Unit Tests', function() {
             let ctx = {
                 invokedFunctionArn : pawsMock.FUNCTION_ARN,
                 fail : function(error) {
+                    assert.fail("invocation should fail");
+                    done();
                     assert.equal(getItemStub.called, true, 'should get new item');
                     assert.equal(putItemStub.notCalled, true, 'should not put a new item in');
                     assert.equal(updateItemStub.notCalled, true, 'should not update the item to complete');
@@ -352,8 +360,11 @@ describe('Unit Tests', function() {
                     else
                         assert.fail("invocation have another error code");
                 },
-                succeed : function() {
-                    assert.fail("invocation should fail");
+                succeed : function(error) {
+                    assert.equal(error, null);
+                    assert.equal(getItemStub.called, true, 'should get new item');
+                    assert.equal(putItemStub.notCalled, true, 'should not put a new item in');
+                    assert.equal(updateItemStub.notCalled, true, 'should not update the item to complete');
                     done();
                 }
             };


### PR DESCRIPTION
### Problem Description
Error state messages are expired in SQS due to retention period.
Failed invocations are not retried because wrong DDB state handling.

### Solution Description
Refresh SQS state message every invocation even if poll request for logs failed.
Add new DDB record state `FAILED` in order to retry failed invocations instead of treating them as duplicates.

