### PR TITLE
update sentinelone endpoint, remove docs from readme

### DIFF
--- a/collectors/sentinelone/README.md
+++ b/collectors/sentinelone/README.md
@@ -17,13 +17,7 @@ forward logs to the Alert Logic CloudInsight backend services.
 
 ![ScreenShot](./docs/sentinelone_credentials.jpg)
 
-### 2. API Docs
-
-For API docs, You need to login your Management Console. After login, you can access the following links.
-1. [Authentication](https://usea1-swprd1.sentinelone.net/apidoc/#!/Accounts/get_web_api_v2_0_private_accounts_name_available)
-2. [Activities](https://usea1-swprd1.sentinelone.net/apidoc/#!/Activities/get_web_api_v2_0_activities) 
-
-### 3. CloudFormation Template (CFT) 
+### 2. CloudFormation Template (CFT) 
 
 Refer to [CF template readme](./cfn/README-SENTINELONE.md) for installation instructions.
 
@@ -107,4 +101,3 @@ make sam-local
 ```
   4. Please see `local/event.json` for the event payload used for local invocation.
 Please write your readme here
-

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sentinelone/utils.js
+++ b/collectors/sentinelone/utils.js
@@ -11,7 +11,7 @@ function getAPILogs(baseUrl, token, params, accumulator, maxPagesPerInvocation) 
         getData(params);
         function getData(params) {
             if (pageCount < maxPagesPerInvocation) {
-                return restServiceClient.get(`/web/api/v2.0/activities?${querystring.stringify(params)}`, {
+                return restServiceClient.get(`/web/api/v2.1/activities?${querystring.stringify(params)}`, {
                     headers: {
                         "Authorization": `ApiToken ${token}`
                     }


### PR DESCRIPTION
### Problem Description
SentinelOne api minor version changed, 2.0 no longer supported (seemingly)

### Solution Description
Change api endpoint in `getAPILogs` for SentinelOne to the new 2.1 version

### Acceptance Criteria for Contributors
- [ ] No errors / warnings on build (including linter)
- [ ] 100% automated test coverage
- [ ] Source layout followed from other collectors
- [ ] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [ ] Logging of main steps in the collector’s code
- [ ] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [ ] API throttling errors are understood and and properly handled
- [ ] Registration/update/deregistration validated
- [ ] Stats and status validated
- [ ] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [ ] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [ ] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [ ] Links to API documentation
- [ ] At least temporary access to an environment where RCS can validate collector implementation
- [ ] Contact details in case access to this environment is needed in the future
 
