### PR TITLE
Added paws_collection_interval to customise the collection interval

### DIFF
--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -80,6 +80,11 @@
             "Type": "Number",
             "Default": 60
         },
+        "CollectionInterval": {
+            "Description": "Collection interval in seconds to set end/until date value in SQS state",
+            "Type": "Number",
+            "Default": 0
+        },
         "PawsEndpoint": {
             "Description": "URL to poll",
             "Type": "String"
@@ -791,6 +796,9 @@
                   },
                   "paws_poll_interval": {
                       "Ref":"PollingInterval"
+                  },
+                  "paws_collector_interval": {
+                    "Ref": "CollectionInterval"
                   },
                   "paws_endpoint":{
                       "Ref":"PawsEndpoint"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
For few o365 collector getting issue while collecting the data for 1hr interval as data is huge(>10Mb);

### Solution Description
Added the paws_collection_interval variable in environment variable to customise the collection interval.

### Acceptance Criteria for Contributors
- [ ] No errors / warnings on build (including linter)
- [ ] 100% automated test coverage
- [ ] Source layout followed from other collectors
- [ ] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [ ] Logging of main steps in the collector’s code
- [ ] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [ ] API throttling errors are understood and and properly handled
- [ ] Registration/update/deregistration validated
- [ ] Stats and status validated
- [ ] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [ ] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [ ] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [ ] Links to API documentation
- [ ] At least temporary access to an environment where RCS can validate collector implementation
- [ ] Contact details in case access to this environment is needed in the future
 
