### PR TITLE
Adjust the collection interval for o365 

### DIFF
--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -98,16 +98,10 @@ class O365Collector extends PawsCollector {
             return callback(null, [], state, state.poll_interval_sec);
         }
 
-        if ((process.env.paws_collection_interval && process.env.paws_collection_interval > 0 ) && state ) {
-            state.until = moment(state.since).add(process.env.paws_collection_interval, 'seconds').toISOString();
-        }
-        console.info(`O365000001 Collecting data from ${state.since} till ${state.until} for stream ${state.stream}`);
-
         if(moment().diff(state.since, 'days', true) > 7){
             const newStart = moment().subtract(PARTIAL_WEEK_HOURS, 'hours');
             state.since = newStart.toISOString();
-            state.until = process.env.paws_collection_interval && process.env.paws_collection_interval > 0 ? newStart.add(process.env.paws_collection_interval, 'seconds').toISOString()
-                : newStart.add(1, 'hours').toISOString();
+            state.until = newStart.add(1, 'hours').toISOString();
             // remove next page token if the state is out of date as well.
             state.nextPage = null;
             console.warn(
@@ -117,6 +111,11 @@ class O365Collector extends PawsCollector {
                 `Now collecting data from ${state.since} till ${state.until} for stream ${state.stream}`
             );
         }
+
+        if ((process.env.paws_collection_interval && process.env.paws_collection_interval > 0 ) && state ) {
+            state.until = moment(state.since).add(process.env.paws_collection_interval, 'seconds').toISOString();
+        }
+        console.info(`O365000001 Collecting data from ${state.since} till ${state.until} for stream ${state.stream}`);
 
         let pageCount = 0;
 

--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -49,10 +49,7 @@ class O365Collector extends PawsCollector {
             startTs = moment().subtract(PARTIAL_WEEK_HOURS, 'hours').toISOString();
             console.info("O365000004 Start timestamp is more than 7 days in the past. This is not allowed in the MS managment API. setting the start time to 7 days in the past");
         }
-        if (process.env.paws_collection_interval && process.env.paws_collection_interval > 0) {
-            endTs = moment(startTs).add(process.env.paws_collection_interval, 'seconds').toISOString();
-        }
-        else if (moment().diff(startTs, 'hours') > 1) {
+        if (moment().diff(startTs, 'hours') > 1) {
             endTs = moment(startTs).add(1, 'hours').toISOString();
         }
         else {
@@ -101,12 +98,16 @@ class O365Collector extends PawsCollector {
             return callback(null, [], state, state.poll_interval_sec);
         }
 
+        if ((process.env.paws_collection_interval && process.env.paws_collection_interval > 0 ) && state ) {
+            state.until = moment(state.since).add(process.env.paws_collection_interval, 'seconds').toISOString();
+        }
         console.info(`O365000001 Collecting data from ${state.since} till ${state.until} for stream ${state.stream}`);
 
         if(moment().diff(state.since, 'days', true) > 7){
             const newStart = moment().subtract(PARTIAL_WEEK_HOURS, 'hours');
             state.since = newStart.toISOString();
-            state.until = (process.env.paws_collection_interval && process.env.paws_collection_interval > 0) ? newStart.add(process.env.paws_collection_interval, 'seconds').toISOString() : newStart.add(1, 'hours').toISOString();
+            state.until = process.env.paws_collection_interval && process.env.paws_collection_interval > 0 ? newStart.add(process.env.paws_collection_interval, 'seconds').toISOString()
+                : newStart.add(1, 'hours').toISOString();
             // remove next page token if the state is out of date as well.
             state.nextPage = null;
             console.warn(
@@ -194,8 +195,7 @@ class O365Collector extends PawsCollector {
     _getNextCollectionState(curState) {
         const untilMoment = moment(curState.until);
 
-        const { nextUntilMoment, nextSinceMoment, nextPollInterval } = (process.env.paws_collection_interval && process.env.paws_collection_interval > 0) ? this.calcNextCustomCollectionInterval(process.env.paws_collection_interval, untilMoment, this.pollInterval)
-            : calcNextCollectionInterval('hour-cap', untilMoment, this.pollInterval);
+        const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-cap', untilMoment, this.pollInterval);
 
         return  {
             stream: curState.stream,
@@ -291,22 +291,6 @@ class O365Collector extends PawsCollector {
         } catch (exception) {
             return err;
         }
-    }
-
-    calcNextCustomCollectionInterval(pawsCollectionInterval, curUntilMoment, pollInterval) {
-        const nowMoment = moment();
-        const nextSinceMoment = curUntilMoment.isAfter(nowMoment) ? nowMoment : curUntilMoment;
-        let nextUntilMoment;
-
-        if (nowMoment.diff(nextSinceMoment, 'hours') > 1) {
-            nextUntilMoment = moment(nextSinceMoment).add(pawsCollectionInterval, 'seconds');
-        }
-        else {
-            nextUntilMoment = moment(nextSinceMoment).add(pollInterval, 'seconds');
-        }
-        const nextPollInterval = nowMoment.diff(nextUntilMoment, 'seconds') > pollInterval ?
-            1 : pollInterval;
-        return { nextSinceMoment, nextUntilMoment, nextPollInterval };
     }
 }
 

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,


### PR DESCRIPTION
### Problem Description
For few o365 collectors getting issue while collecting the data for 1hr interval as data is huge(>10Mb);
ex: lambdaError: Runtime exited with error: signal: killed; even we set memory to 2048 and time to 15 min 


### Solution Description
Adjust the collection interval if paws_collection_interval variable exist in environment variables

### Acceptance Criteria for Contributors
- [ ] No errors / warnings on build (including linter)
- [ ] 100% automated test coverage
- [ ] Source layout followed from other collectors
- [ ] No unnecessary code (debug logs, redundant comments, unused blocks of code, etc.)
- [ ] Logging of main steps in the collector’s code
- [ ] Logging of any requests that cause the collector to fail / throw an exception, with reason for failure / debugging info
- [ ] API throttling errors are understood and and properly handled
- [ ] Registration/update/deregistration validated
- [ ] Stats and status validated
- [ ] CloudFormation template specific to setting up the collector, with documentation of any template parameters
- [ ] Collector README, including any set up caveats (both when installed in AL account and in customer’s account) – the user/team should be able to successfully set up, update, remove a collector following the README only
- [ ] Demo of set up, update, removal of a collector, with data shown to be correctly parsed in AL console search
- [ ] Links to API documentation
- [ ] At least temporary access to an environment where RCS can validate collector implementation
- [ ] Contact details in case access to this environment is needed in the future
 
