### PR TITLE
Process the logmsgs in batch if log messages size greater than 10K

### DIFF
--- a/paws_collector.js
+++ b/paws_collector.js
@@ -523,7 +523,7 @@ class PawsCollector extends AlAwsCollector {
                     });
                     await Promise.all(promises);
                     return callback(null, privCollectorState, nextInvocationTimeout);
-                } else if (err.statusCode && err.statusCode === 307 && process.env.paws_collection_interval && process.env.paws_collection_interval > 0) {
+                } else if (err.statusCode && err.statusCode === 307 && process.env.paws_collection_interval && process.env.paws_collection_interval > 1) {
                     const paws_collection_interval = Math.floor(process.env.paws_collection_interval / 2);
 
                     AlAwsUtil.setEnv({ paws_collection_interval: paws_collection_interval }, (err, res) => {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -523,7 +523,14 @@ class PawsCollector extends AlAwsCollector {
                     });
                     await Promise.all(promises);
                     return callback(null, privCollectorState, nextInvocationTimeout);
-                } else {
+                } else if (err.statusCode && err.statusCode === 307 && process.env.paws_collection_interval && process.env.paws_collection_interval > 0) {
+                    const paws_collection_interval = Math.floor(process.env.paws_collection_interval / 2);
+
+                    AlAwsUtil.setEnv({ paws_collection_interval: paws_collection_interval }, (err, res) => {
+                        return callback(null, privCollectorState, nextInvocationTimeout);
+                    });
+                }
+                else {
                     collector.reportErrorToIngestApi(err, () => {
                         return callback(err);
                     });

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -503,14 +503,11 @@ class PawsCollector extends AlAwsCollector {
     batchLogProcess(logs, privCollectorState, nextInvocationTimeout, callback) {
         let collector = this;
         let indexArray = [];
-        if (logs.length > MAX_LOG_BATCH_SIZE) {
-            const batches = Math.ceil(logs.length / MAX_LOG_BATCH_SIZE);
-            for (let i = 0; i < batches; i++) {
-                indexArray.push({ start: MAX_LOG_BATCH_SIZE * i, stop: MAX_LOG_BATCH_SIZE * (i + 1) });
-            }
-        } else {
-            indexArray = [{ start: 0, stop: logs.length }];
+        const batches = Math.ceil(logs.length / MAX_LOG_BATCH_SIZE);
+        for (let i = 0; i < batches; i++) {
+            indexArray.push({ start: MAX_LOG_BATCH_SIZE * i, stop: MAX_LOG_BATCH_SIZE * (i + 1) });
         }
+
         let promises = indexArray.map((logpart) => {
             return new Promise((resolve, reject) => {
                 collector.processLog(logs.slice(logpart.start, logpart.stop), collector.pawsFormatLog.bind(collector), null, (err, res) => {

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -8,7 +8,7 @@ const ddLambda = require('datadog-lambda-js');
 const pawsMock = require('./paws_mock');
 var m_alCollector = require('@alertlogic/al-collector-js');
 var PawsCollector = require('../paws_collector').PawsCollector;
-const m_al_aws = require('@alertlogic/al-aws-collector-js').Util;
+const m_al_aws = require('@alertlogic/al-aws-collector-js');
 
 var alserviceStub = {};
 var responseStub = {};
@@ -61,7 +61,7 @@ function restoreAlServiceStub() {
 
 
 function mockSetEnvStub() {
-    setEnvStub = sinon.stub(m_al_aws, 'setEnv').callsFake((vars, callback)=>{
+    setEnvStub = sinon.stub(m_al_aws.Util, 'setEnv').callsFake((vars, callback)=>{
         const {
             ingest_api,
             azcollect_api
@@ -637,15 +637,28 @@ describe('Unit Tests', function() {
             let ctx = {
                 invokedFunctionArn: pawsMock.FUNCTION_ARN,
                 fail: function (error) {
-                     assert.fail(error);
+                    assert.fail(error);
                     done();
                 },
                 succeed: function () {
-                   
+                    sinon.assert.calledThrice(mockSendLogmsgs);
+                    sinon.assert.calledThrice(mockSendLmcstats);
                     done();
                 }
             };
+            let mockSendLogmsgs = sinon.stub(m_alCollector.IngestC.prototype, 'sendLogmsgs').callsFake(
+                function fakeFn(data, callback) {
+                    return new Promise(function (resolve, reject) {
+                        resolve(null);
+                    });
+                });
 
+            let mockSendLmcstats = sinon.stub(m_alCollector.IngestC.prototype, 'sendLmcstats').callsFake(
+                function fakeFn(data, callback) {
+                    return new Promise(function (resolve, reject) {
+                        resolve(null);
+                    });
+                });
             const testEvent = {
                 Records: [
                     {


### PR DESCRIPTION
### Problem Description
For few o365 collector we found ingest error, max payload issue and other issues if data is huge . So process logs in batches.

### Solution Description
Split the data per 10K message size and create batch. Call the processLog to send Logmsgs to ingest. 
