### PR TITLE
 Reduce the fluctuations rate of collector status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -463,7 +463,7 @@ class PawsCollector extends AlAwsCollector {
                             // Here we just upload same state messaged into SQS and  send error status to the backend.
                             // The invocation is marked as succeed in order to clean up current state message in SQS.
                             // Increment/reset the retry count if error occured. 
-                            pawsState.retry_count = (!pawsState.retry_count || pawsState.retry_count >= 5) ? 1 : pawsState.retry_count + 1;
+                            pawsState.retry_count = (!pawsState.retry_count || pawsState.retry_count >= MAX_ERROR_RETRIES) ? 1 : pawsState.retry_count + 1;
                             collector._storeCollectionState(pawsState, pawsState.priv_collector_state, 300, function(storeError){
                                 if (!storeError){
                                     collector.reportErrorStatus(handleError, pawsState, (statusSendError, handleErrorString) => {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -37,7 +37,7 @@ const DDB_OPTIONS = {
     maxRetries: 10,
     ConsistentRead: true
 };
-
+const MAX_ERROR_RETRIES = 5;
 const MAX_LOG_BATCH_SIZE = 10000;
 function getPawsParamStoreParam(){
     return new Promise((resolve, reject) => {
@@ -442,6 +442,8 @@ class PawsCollector extends AlAwsCollector {
                     }
                 },
                 function(privCollectorState, nextInvocationTimeout, asyncCallback) {
+                    // Reset the retry count to 0 on successful log processing. 
+                    pawsState.retry_count = 0;
                     return collector._storeCollectionState(pawsState, privCollectorState, nextInvocationTimeout, asyncCallback);
                 }
             ], function(handleError) {
@@ -460,6 +462,8 @@ class PawsCollector extends AlAwsCollector {
                             // in order to avoid expiration of that message due to retention period.
                             // Here we just upload same state messaged into SQS and  send error status to the backend.
                             // The invocation is marked as succeed in order to clean up current state message in SQS.
+                            // Increment/reset the retry count if error occured. 
+                            pawsState.retry_count = (!pawsState.retry_count || pawsState.retry_count >= 5) ? 1 : pawsState.retry_count + 1;
                             collector._storeCollectionState(pawsState, pawsState.priv_collector_state, 300, function(storeError){
                                 if (!storeError){
                                     collector.reportErrorStatus(handleError, pawsState, (statusSendError, handleErrorString) => {
@@ -488,9 +492,15 @@ class PawsCollector extends AlAwsCollector {
                 null;
         const errorString = this.stringifyError(error);
         const status = this.prepareErrorStatus(errorString, 'none', streamType);
-        this.sendStatus(status, (sendError) => {
-            return callback(sendError, errorString);
-        });
+        // Send the error status to assets only if retry count reached to 5. 
+        // To reduce the status fluctuation from healthy  to unhealthy.
+        if (pawsState.retry_count === MAX_ERROR_RETRIES) {
+            this.sendStatus(status, (sendError) => {
+                return callback(sendError, errorString);
+            });
+        } else {
+            return callback(null, errorString);
+        }
     }
     /**
      * Split data per 10K messages batch.

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -674,6 +674,85 @@ describe('Unit Tests', function() {
             });
         });
 
+        it('Check sendStatus method call only after Five failed attempt', function (done) {
+            mockDDB();
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: function (error) {
+                    assert.fail(error);
+                    done();
+                },
+                succeed: function () {
+                    sinon.assert.callCount(mockSendStatus, 1);
+                    sinon.assert.calledOnce(mockPawsGetLogs);
+                    mockPawsGetLogs.restore();
+                    mockSendStatus.restore();
+                    done();
+                }
+            };
+            let mockSendStatus = sinon.stub(m_al_aws.AlAwsCollector.prototype, 'sendStatus').callsFake(
+                function fakeFn(status, callback) {
+                    return callback(null);
+                });
+
+            let mockPawsGetLogs = sinon.stub(TestCollector.prototype, "pawsGetLogs").callsFake(
+                function fakeFn(state, callback) {
+                    return callback({ name: 'OktaApiError', status: 401, errorCode: 'E0000011', errorSummary: 'Invalid token provided' });
+                });
+            const testEvent = {
+                Records: [
+                    {
+                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"2021-07-01T02:37:37.617Z\",\n    \"until\": \"2021-07-01T03:37:37.617Z\"\n  }\n, \"retry_count\":4}",
+                        "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
+                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
+                    }
+                ]
+            };
+            TestCollector.load().then(function (creds) {
+                var collector = new TestCollector(ctx, creds);
+                collector.handleEvent(testEvent);
+            });
+        });
+
+        it('Check sendStatus method not call if failed attempt less < 5', function (done) {
+            mockDDB();
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: function (error) {
+                    assert.fail(error);
+                    done();
+                },
+                succeed: function () {
+                    sinon.assert.callCount(mockSendStatus, 0);
+                    sinon.assert.calledOnce(mockPawsGetLogs);
+                    mockPawsGetLogs.restore();
+                    mockSendStatus.restore();
+                    done();
+                }
+            };
+            let mockSendStatus = sinon.stub(m_al_aws.AlAwsCollector.prototype, 'sendStatus').callsFake(
+                function fakeFn(status, callback) {
+                    return callback(null);
+                });
+
+            let mockPawsGetLogs = sinon.stub(TestCollector.prototype, "pawsGetLogs").callsFake(
+                function fakeFn(state, callback) {
+                    return callback({ name: 'OktaApiError', status: 401, errorCode: 'E0000011', errorSummary: 'Invalid token provided' });
+                });
+            const testEvent = {
+                Records: [
+                    {
+                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"2021-07-01T02:37:37.617Z\",\n    \"until\": \"2021-07-01T03:37:37.617Z\"\n  }\n, \"retry_count\":3}",
+                        "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
+                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
+                    }
+                ]
+            };
+            TestCollector.load().then(function (creds) {
+                var collector = new TestCollector(ctx, creds);
+                collector.handleEvent(testEvent);
+            });
+        });
         it('reportApiThrottling', function(done) {
             let ctx = {
                 invokedFunctionArn : pawsMock.FUNCTION_ARN,


### PR DESCRIPTION
### Problem Description
If there is intermediate  errors then collector status fluctuating from healthy to unhealthy and vice versa

### Solution Description
Added the retry_count in SQS state and increment the value if error occurred . If retry_count reached to 5 then only send the error status to assets to reduce the fluctuations of collector status.

 
