### PR TITLE
Added the custom health check for Paws collector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.0.5",
+    "@alertlogic/al-aws-collector-js": "4.0.6",
     "datadog-lambda-js": "2.23.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -119,7 +119,7 @@ class PawsCollector extends AlAwsCollector {
     constructor(context, {aimsCreds, pawsCreds}, childVersion, healthChecks = [], statsChecks = []) {
         const version = childVersion ? childVersion : packageJson.version;
         const endpointDomain = process.env.paws_endpoint.replace(DOMAIN_REGEXP, '');
-        // add the customHealthCheck for all paws collectors
+        // add the customHealthCheck for those collectors which does not have its own health check.
         if (healthChecks.length === 0) {
             healthChecks.push(HealthChecks.customHealthCheck);
         }

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -19,6 +19,7 @@ const ddLambda = require('datadog-lambda-js');
 
 const AlAwsCollector = require('@alertlogic/al-aws-collector-js').AlAwsCollector;
 const AlAwsUtil = require('@alertlogic/al-aws-collector-js').Util;
+const AlAwsStatsTmpls = require('@alertlogic/al-aws-collector-js').Stats;
 const packageJson = require('./package.json');
 
 const CREDS_FILE_PATH = '/tmp/paws_creds';
@@ -116,6 +117,21 @@ class PawsCollector extends AlAwsCollector {
         }
     }
 
+    /**
+    * To fetch the custom metrics data
+    * @param {*} asyncCallback 
+    * @returns 
+    */
+    static customStats(asyncCallback) {
+        const customDimentions =
+        {
+            Name: 'CollectorType',
+            Value: this._pawsCollectorType
+        }
+        return AlAwsStatsTmpls.getCustomMetrics(
+            process.env.AWS_LAMBDA_FUNCTION_NAME, 'PawsClientError', 'PawsCollectors', customDimentions, asyncCallback
+        );
+    }
     constructor(context, {aimsCreds, pawsCreds}, childVersion, healthChecks = [], statsChecks = []) {
         const version = childVersion ? childVersion : packageJson.version;
         const endpointDomain = process.env.paws_endpoint.replace(DOMAIN_REGEXP, '');

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -120,7 +120,9 @@ class PawsCollector extends AlAwsCollector {
         const version = childVersion ? childVersion : packageJson.version;
         const endpointDomain = process.env.paws_endpoint.replace(DOMAIN_REGEXP, '');
         // add the customHealthCheck for all paws collectors
-        healthChecks.push(HealthChecks.customHealthCheck);
+        if (healthChecks.length === 0) {
+            healthChecks.push(HealthChecks.customHealthCheck);
+        }
         let collectorStreams = process.env.collector_streams && Array.isArray(JSON.parse(process.env.collector_streams)) ? JSON.parse(process.env.collector_streams) : [];
         super(context, 'paws',
               AlAwsCollector.IngestTypes.LOGMSGS,

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -19,7 +19,7 @@ const ddLambda = require('datadog-lambda-js');
 
 const AlAwsCollector = require('@alertlogic/al-aws-collector-js').AlAwsCollector;
 const AlAwsUtil = require('@alertlogic/al-aws-collector-js').Util;
-const AlAwsStatsTmpls = require('@alertlogic/al-aws-collector-js').Stats;
+const HealthChecks = require('./paws_health_checks');
 const packageJson = require('./package.json');
 
 const CREDS_FILE_PATH = '/tmp/paws_creds';
@@ -116,25 +116,11 @@ class PawsCollector extends AlAwsCollector {
             return handlerFunc;
         }
     }
-
-    /**
-    * To fetch the custom metrics data
-    * @param {*} asyncCallback 
-    * @returns 
-    */
-    static customStats(asyncCallback) {
-        const customDimentions =
-        {
-            Name: 'CollectorType',
-            Value: this._pawsCollectorType
-        }
-        return AlAwsStatsTmpls.getCustomMetrics(
-            process.env.AWS_LAMBDA_FUNCTION_NAME, 'PawsClientError', 'PawsCollectors', customDimentions, asyncCallback
-        );
-    }
     constructor(context, {aimsCreds, pawsCreds}, childVersion, healthChecks = [], statsChecks = []) {
         const version = childVersion ? childVersion : packageJson.version;
         const endpointDomain = process.env.paws_endpoint.replace(DOMAIN_REGEXP, '');
+        // add the customHealthCheck for all paws collectors
+        healthChecks.push(HealthChecks.customHealthCheck);
         let collectorStreams = process.env.collector_streams && Array.isArray(JSON.parse(process.env.collector_streams)) ? JSON.parse(process.env.collector_streams) : [];
         super(context, 'paws',
               AlAwsCollector.IngestTypes.LOGMSGS,

--- a/paws_health_checks.js
+++ b/paws_health_checks.js
@@ -28,7 +28,7 @@ function customHealthCheck(asyncCallback) {
         process.env.AWS_LAMBDA_FUNCTION_NAME, 'PawsClientError', 'PawsCollectors', customDimentions, (err, res) => {
             const datapointSum = res && res.Datapoints.length > 0 && res.Datapoints[0].Sum ? res.Datapoints[0].Sum : 0;
             if (datapointSum > 0) {
-                return asyncCallback(al_health.errorMsg('PAWS000403', 'Paws client errors'));
+                return asyncCallback(al_health.errorMsg('PAWS000403','Something wrong with streams or client configuration'));
             }
             return asyncCallback(null);
         }

--- a/paws_health_checks.js
+++ b/paws_health_checks.js
@@ -1,0 +1,40 @@
+/** -----------------------------------------------------------------------------
+ * @copyright (C) 2021, Alert Logic, Inc
+ * @doc
+ *
+ * Health checks functions for PAWS collector
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+'use strict';
+const AlAwsStatsTmpls = require('@alertlogic/al-aws-collector-js').Stats;
+const al_health = require('@alertlogic/al-aws-collector-js').Health
+
+/**
+    * To fetch the custom metrics data and return the error if PawsClientError metrics show errors. 
+    * @param {*} asyncCallback 
+    * @returns 
+    */
+function customHealthCheck(asyncCallback) {
+    const customDimentions =
+    {
+        Name: 'CollectorType',
+        Value: process.env.paws_type_name
+    }
+
+    AlAwsStatsTmpls.getCustomMetrics(
+        process.env.AWS_LAMBDA_FUNCTION_NAME, 'PawsClientError', 'PawsCollectors', customDimentions, (err, res) => {
+            const datapointSum = res && res.Datapoints.length > 0 && res.Datapoints[0].Sum ? res.Datapoints[0].Sum : 0;
+            if (datapointSum > 0) {
+                return asyncCallback(al_health.errorMsg('PAWS000403', 'Paws client errors'));
+            }
+            return asyncCallback(null);
+        }
+    );
+}
+
+module.exports = {
+    customHealthCheck: customHealthCheck
+}

--- a/paws_health_checks.js
+++ b/paws_health_checks.js
@@ -28,7 +28,7 @@ function customHealthCheck(asyncCallback) {
         process.env.AWS_LAMBDA_FUNCTION_NAME, 'PawsClientError', 'PawsCollectors', customDimentions, (err, res) => {
             const datapointSum = res && res.Datapoints.length > 0 && res.Datapoints[0].Sum ? res.Datapoints[0].Sum : 0;
             if (datapointSum > 0) {
-                return asyncCallback(al_health.errorMsg('PAWS000403','Something wrong with streams or client configuration'));
+                return asyncCallback(al_health.errorMsg('PAWS000403','Please check stream status errors and collector configuration'));
             }
             return asyncCallback(null);
         }

--- a/test/paws_health_test.js
+++ b/test/paws_health_test.js
@@ -1,0 +1,37 @@
+const m_al_aws = require('@alertlogic/al-aws-collector-js');
+const sinon = require('sinon');
+const assert = require('assert');
+const PawsHealthCheck = require('../paws_health_checks');
+
+describe('Paws Health Checks', function () {
+    it('Check custom health check return the error if custom metrics show errors ', function (done) {
+        let spyCustomMetrics = sinon.stub(m_al_aws.Stats, 'getCustomMetrics').callsFake(
+            function fakeFn(functionName, metricName, namespace, customDimesions, callback) {
+                return callback(null, { 'Label': 'PawsClientError', 'Datapoints': [{ 'Timestamp': '2017-11-21T16:40:00Z', 'Sum': 1, 'Unit': 'Count' }] });
+            });
+        process.env.paws_type_name = 'okta';
+        process.env.AWS_LAMBDA_FUNCTION_NAME = 'test-function-name';
+        PawsHealthCheck.customHealthCheck((err, res) => {
+            assert.equal(err.status, 'error');
+            assert.equal(err.code, 'PAWS000403');
+            assert.equal(err.details, 'Please check stream status errors and collector configuration');
+            sinon.assert.calledOnce(spyCustomMetrics);
+            spyCustomMetrics.restore();
+            done();
+        });
+    });
+    it('Check custom health check return the null if custom metrics did not show any errors ', function (done) {
+        let spyCustomMetrics = sinon.stub(m_al_aws.Stats, 'getCustomMetrics').callsFake(
+            function fakeFn(functionName, metricName, namespace, customDimesions, callback) {
+                return callback(null, { 'Label': 'PawsClientError', 'Datapoints': [] });
+            });
+        process.env.paws_type_name = 'okta';
+        process.env.AWS_LAMBDA_FUNCTION_NAME = 'test-function-name';
+        PawsHealthCheck.customHealthCheck((err, res) => {
+            assert.equal(err, null);
+            sinon.assert.calledOnce(spyCustomMetrics);
+            spyCustomMetrics.restore();
+            done();
+        });
+    });
+});


### PR DESCRIPTION
### Problem Description
Checkin function update the status to ok if there is no error on Lambda Error metrics.
Paws collector not sending error to Lambda error metrics in few scenario ;so Checkin function update the status to 'ok' even we have error for collector. But paws collector send the error to custom metrics like [PawsClientError](https://github.com/alertlogic/paws-collector/blob/master/paws_collector.js#L414)/[PawsIngestError](https://github.com/alertlogic/paws-collector/blob/master/paws_collector.js#L537) .


### Solution Description
Fetch the data from `PawsClientError` metrics using getCustomMetrics and send as health check to [al-aws-collector.js](https://github.com/alertlogic/al-aws-collector-js/blob/master/al_aws_collector.js#L128) which will check the status in [ checkin function ](https://github.com/alertlogic/al-aws-collector-js/blob/master/al_aws_collector.js#L423).
If lambda error metrics and PawsClientError metrics both did not show any error then only we will send the status ok to assets.
