### PR TITLE
Bump the all collector version to add custom health check and Poll interval delay

### DIFF
--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "auth0": "2.27.1",
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -21,7 +21,7 @@
   "dependencies": {
     "auth0": "2.27.1",
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/carbonblack/test/Carbonblack_test.js
+++ b/collectors/carbonblack/test/Carbonblack_test.js
@@ -173,7 +173,7 @@ describe('Unit Tests', function () {
                 };
                 let nextState = collector._getNextCollectionState(curState);
                 assert.equal(moment(nextState.until).diff(nextState.since, 'seconds'), collector.pollInterval);
-                assert.equal(nextState.poll_interval_sec, collector.pollInterval);
+                assert.equal(nextState.poll_interval_sec, 300);
                 done();
             });
         });

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/ciscoamp/test/ciscoamp_test.js
+++ b/collectors/ciscoamp/test/ciscoamp_test.js
@@ -354,7 +354,7 @@ describe('Unit Tests', function () {
                 };
                 let nextState = collector._getNextCollectionState(curState);
                 assert.equal(moment(nextState.until).diff(nextState.since, 'seconds'), collector.pollInterval);
-                assert.equal(nextState.poll_interval_sec, collector.pollInterval);
+                assert.equal(nextState.poll_interval_sec, 300);
                 done();
             });
         });

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "@duosecurity/duo_api": "1.2.1",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "@duosecurity/duo_api": "1.2.1",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/collectors/ciscoduo/test/ciscoduo_mock.js
+++ b/collectors/ciscoduo/test/ciscoduo_mock.js
@@ -18,6 +18,7 @@ process.env.paws_api_secret = "secret";
 process.env.paws_endpoint = "ciscoduo.com";
 process.env.collector_streams = "[\"Authentication\", \"Administrator\",\"Telephony\", \"OfflineEnrollment\"]";
 process.env.paws_api_client_id = "client-id";
+process.env.paws_poll_interval_delay = 300;
 
 const AIMS_TEST_CREDS = {
     access_key_id: 'test-access-key-id',

--- a/collectors/ciscoduo/test/ciscoduo_test.js
+++ b/collectors/ciscoduo/test/ciscoduo_test.js
@@ -257,7 +257,7 @@ describe('Unit Tests', function () {
                     poll_interval_sec: 1
                 };
                 let nextState = collector._getNextCollectionState(curState);
-                assert.equal(nextState.poll_interval_sec, collector.pollInterval);
+                assert.equal(nextState.poll_interval_sec, process.env.paws_poll_interval_delay);
                 done();
             });
         });
@@ -272,7 +272,7 @@ describe('Unit Tests', function () {
                     poll_interval_sec: 1
                 };
                 let nextState = collector._getNextCollectionState(curState);
-                assert.equal(nextState.poll_interval_sec, collector.pollInterval);
+                assert.equal(nextState.poll_interval_sec, process.env.paws_poll_interval_delay);
                 done();
             });
         });

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.13",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "@google-cloud/logging": "6.0.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "@google-cloud/logging": "6.0.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/collectors/googlestackdriver/test/test.js
+++ b/collectors/googlestackdriver/test/test.js
@@ -315,7 +315,7 @@ describe('Unit Tests', function() {
                 };
                 const newState = collector._getNextCollectionState(curState);
                 assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                assert.equal(newState.poll_interval_sec, 1);
+                assert.equal(newState.poll_interval_sec, collector.pollInterval);
                 done();
             });
         });
@@ -330,7 +330,7 @@ describe('Unit Tests', function() {
                 };
                 const newState = collector._getNextCollectionState(curState);
                 assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                assert.equal(newState.poll_interval_sec, collector.pollInterval);
+                assert.equal(newState.poll_interval_sec, 300);
                 done();
             });
         });

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "googleapis": "39.2.0",

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "googleapis": "39.2.0",

--- a/collectors/gsuite/test/gsuite_test.js
+++ b/collectors/gsuite/test/gsuite_test.js
@@ -309,7 +309,7 @@ describe('Unit Tests', function () {
                 };
                 const newState = collector._getNextCollectionState(curState);
                 assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                assert.equal(newState.poll_interval_sec, 1);
+                assert.equal(newState.poll_interval_sec, collector.pollInterval);
                 done();
             });
         });
@@ -325,7 +325,7 @@ describe('Unit Tests', function () {
                 };
                 const newState = collector._getNextCollectionState(curState);
                 assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                assert.equal(newState.poll_interval_sec, collector.pollInterval);
+                assert.equal(newState.poll_interval_sec, 300);
                 done();
             });
         });

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0",

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0",

--- a/collectors/mimecast/test/mimecast_test.js
+++ b/collectors/mimecast/test/mimecast_test.js
@@ -235,7 +235,7 @@ describe('Unit Tests', function() {
                     poll_interval_sec: 1
                 };
                 let nextState = collector._getNextCollectionState(curState);
-                assert.equal(nextState.poll_interval_sec, collector.pollInterval);
+                assert.equal(nextState.poll_interval_sec, 300);
                 assert.equal(nextState.stream, "AttachmentProtectLogs");
                 done();
             });

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.28",
+  "version": "1.2.29",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -21,7 +21,7 @@
   "dependencies": {
     "@alertlogic/al-aws-collector-js": "^4.0.2",
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "@azure/ms-rest-azure-js": "2.0.1",
     "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-nodeauth": "2.0.5",

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@alertlogic/al-aws-collector-js": "^4.0.2",
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "@azure/ms-rest-azure-js": "2.0.1",
     "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-nodeauth": "2.0.5",

--- a/collectors/o365/test/o365_mock.js
+++ b/collectors/o365/test/o365_mock.js
@@ -18,6 +18,7 @@ process.env.collector_id = 'collector-id';
 process.env.al_application_id = 'o365';
 process.env.paws_poll_interval = 60;
 process.env.paws_max_pages_per_invocation = 2;
+process.env.paws_poll_interval_delay = 300;
 
 const AIMS_TEST_CREDS = {
     access_key_id: 'test-access-key-id',

--- a/collectors/o365/test/o365_test.js
+++ b/collectors/o365/test/o365_test.js
@@ -321,7 +321,7 @@ describe('O365 Collector Tests', function() {
                 };
                 const newState = collector._getNextCollectionState(curState);
                 assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                assert.equal(newState.poll_interval_sec, 1);
+                assert.equal(newState.poll_interval_sec, collector.pollInterval);
                 done();
             });
         });
@@ -352,7 +352,7 @@ describe('O365 Collector Tests', function() {
                 };
                 const newState = collector._getNextCollectionState(curState);
                 assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                assert.equal(newState.poll_interval_sec, collector.pollInterval);
+                assert.equal(newState.poll_interval_sec, process.env.paws_poll_interval_delay);
                 done();
             });
         });
@@ -431,7 +431,7 @@ describe('O365 Collector Tests', function() {
                 collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
                     assert.equal(logs.length, 0);
                     assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                    assert.equal(newState.poll_interval_sec, collector.pollInterval);
+                    assert.equal(newState.poll_interval_sec, process.env.paws_poll_interval_delay);
                     restoreO365ManagemntStub();
                     done();
                 });
@@ -452,7 +452,7 @@ describe('O365 Collector Tests', function() {
                 collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
                     assert.equal(logs.length, 0);
                     assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                    assert.equal(newState.poll_interval_sec, collector.pollInterval);
+                    assert.equal(newState.poll_interval_sec, process.env.paws_poll_interval_delay);
                     restoreO365ManagemntStub();
                     done();
                 });

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@okta/okta-sdk-nodejs": "3.1.0",
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -22,7 +22,7 @@
   "dependencies": {
     "@okta/okta-sdk-nodejs": "3.1.0",
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/okta/test/okta_test.js
+++ b/collectors/okta/test/okta_test.js
@@ -139,7 +139,7 @@ describe('Unit Tests', function() {
         
         it('sets up intial state (now - pollInterval < startDate < now)', function(done) {
             OktaCollector.load().then(function(creds) {
-                const testPollInterval = 60;
+                const testPollInterval = 300;
                 var collector = new OktaCollector(ctx, creds);
                 const startDate = moment().subtract(20, 'seconds').toISOString();
                 process.env.paws_collection_start_ts = startDate;
@@ -157,7 +157,7 @@ describe('Unit Tests', function() {
         
         it('sets up intial state (startDate = now)', function(done) {
             OktaCollector.load().then(function(creds) {
-                const testPollInterval = 60;
+                const testPollInterval = 300;
                 var collector = new OktaCollector(ctx, creds);
                 const startDate = moment().toISOString();
                 process.env.paws_collection_start_ts = startDate;
@@ -280,7 +280,7 @@ describe('Unit Tests', function() {
                 poll_interval_sec: 1
             };
             OktaCollector.load().then(function(creds) {
-                const testPollInterval = 55;
+                const testPollInterval = 300;
                 var collector = new OktaCollector(ctx, creds, 'okta');
                 collector.pollInterval = testPollInterval;
                 const newState = collector._getNextCollectionState(curState);

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "jsforce": "^1.9.3",

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "jsforce": "^1.9.3",

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/sentinelone/test/sentinelone_mock.js
+++ b/collectors/sentinelone/test/sentinelone_mock.js
@@ -16,6 +16,7 @@ process.env.paws_poll_interval = 60;
 process.env.paws_type_name = "sentinelone";
 process.env.paws_api_secret = "secret";
 process.env.paws_endpoint = "https://sentinelone.com";
+process.env.paws_poll_interval_delay = 300;
 
 const AIMS_TEST_CREDS = {
     access_key_id: 'test-access-key-id',

--- a/collectors/sentinelone/test/sentinelone_test.js
+++ b/collectors/sentinelone/test/sentinelone_test.js
@@ -162,7 +162,7 @@ describe('Unit Tests', function () {
                 };
                 let nextState = collector._getNextCollectionState(curState);
                 assert.equal(moment(nextState.until).diff(nextState.since, 'seconds'), collector.pollInterval);
-                assert.equal(nextState.poll_interval_sec, collector.pollInterval);
+                assert.equal(nextState.poll_interval_sec, process.env.paws_poll_interval_delay);
                 done();
             });
         });

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/sophos/test/sophos_mock.js
+++ b/collectors/sophos/test/sophos_mock.js
@@ -18,6 +18,7 @@ process.env.paws_api_secret = "secret";
 process.env.paws_endpoint = "sophos.com";
 process.env.paws_api_client_id = "client-id";
 process.env.AWS_LAMBDA_FUNCTION_NAME = "test";
+process.env.paws_poll_interval_delay = 300;
 
 const AIMS_TEST_CREDS = {
     access_key_id: 'test-access-key-id',

--- a/collectors/sophos/test/sophos_test.js
+++ b/collectors/sophos/test/sophos_test.js
@@ -408,7 +408,7 @@ describe('Unit Tests', function () {
                 };
                 let nextState = collector._getNextCollectionState(curState);
                 assert.equal(moment(nextState.until).diff(nextState.since, 'seconds'), collector.pollInterval);
-                assert.equal(nextState.poll_interval_sec, collector.pollInterval);
+                assert.equal(nextState.poll_interval_sec, process.env.paws_poll_interval_delay);
                 done();
             });
         });

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.15",
+    "@alertlogic/paws-collector": "^2.0.16",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.14",
+    "@alertlogic/paws-collector": "^2.0.15",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"


### PR DESCRIPTION
- Bump the PAWS collectors version to add the custom health check for those  collector which does not having it own health check .[pr](https://github.com/alertlogic/paws-collector/pull/213) 
- Added the poll interval delay while calculating NextCollectionInterval if collector collecting data within last 10 min interval [pr](https://github.com/alertlogic/paws-collector/pull/216).
