### PR TITLE
Added Poll interval delay for paws collector

### DIFF
--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -80,6 +80,11 @@
             "Type": "Number",
             "Default": 60
         },
+        "PollingIntervalDelay": {
+            "Description": "Interval in seconds between two consecutive poll requests to avoid loss of any data",
+            "Type": "Number",
+            "Default": 600
+        },
         "PawsEndpoint": {
             "Description": "URL to poll",
             "Type": "String"
@@ -791,6 +796,9 @@
                   },
                   "paws_poll_interval": {
                       "Ref":"PollingInterval"
+                  },
+                  "paws_poll_interval_delay": {
+                    "Ref":"PollingIntervalDelay"
                   },
                   "paws_endpoint":{
                       "Ref":"PawsEndpoint"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_utils.js
+++ b/paws_utils.js
@@ -12,7 +12,7 @@
 const moment = require('moment');
 
 function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
-    const NEXT_POLL_INTERVAL_DELAY = process.env.paws_poll_interval_delay && process.env.paws_poll_interval_delay <= 900 ? process.env.paws_poll_interval_delay : 300;
+    const pollIntervalDelay = process.env.paws_poll_interval_delay && process.env.paws_poll_interval_delay <= 900 ? process.env.paws_poll_interval_delay : 300;
     const nowMoment = moment();
     const nextSinceMoment = curUntilMoment.isAfter(nowMoment) ?
         nowMoment : curUntilMoment;
@@ -71,14 +71,14 @@ function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
      * make next API call after 5 to 10 min to avoid any loss of data.
      */
     let nextPollInterval;
-    if (nowMoment.diff(nextUntilMoment, 'hours') > 1) {
+    if (nowMoment.diff(nextUntilMoment, 'minutes') > 30) {
         nextPollInterval = 1;
     }
-    else if (nowMoment.diff(nextUntilMoment, 'seconds') > NEXT_POLL_INTERVAL_DELAY) {
+    else if (nowMoment.diff(nextUntilMoment, 'seconds') > pollIntervalDelay) {
         nextPollInterval = pollInterval;
     }
     else {
-        nextPollInterval = NEXT_POLL_INTERVAL_DELAY;
+        nextPollInterval = pollIntervalDelay;
     }
 
     return { nextSinceMoment, nextUntilMoment, nextPollInterval };

--- a/paws_utils.js
+++ b/paws_utils.js
@@ -12,9 +12,9 @@
 const moment = require('moment');
 
 function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
-    const NEXT_POLL_INTERVAL_DELAY = process.env.paws_poll_interval_delay && process.env.paws_poll_interval_delay <= 900 ? process.env.paws_poll_interval_delay : 600;
+    const NEXT_POLL_INTERVAL_DELAY = process.env.paws_poll_interval_delay && process.env.paws_poll_interval_delay <= 900 ? process.env.paws_poll_interval_delay : 300;
     const nowMoment = moment();
-    let nextSinceMoment = curUntilMoment.isAfter(nowMoment) ?
+    const nextSinceMoment = curUntilMoment.isAfter(nowMoment) ?
         nowMoment : curUntilMoment;
     const daysDiff = nowMoment.diff(nextSinceMoment, 'days');
     const hoursDiff = nowMoment.diff(nextSinceMoment, 'hours');
@@ -67,17 +67,9 @@ function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
     }
 
     /**
-     * If current time and nextUntilMoment difference is less the NEXT_POLL_INTERVAL_DELAY seconds,
-     * then nextUntilMoment value will be given poll_interval_delay second ago;
-     * and if sinceMoment > UntilMoment then set both value to same so API will not pull any data.
+     * If current moment and nextUntilMoment difference is less than given poll_interval_delay then set nextPollInterval = poll_interval_delay;
+     * make next API call after 5 to 10 min to avoid any loss of data.
      */
-    if (nowMoment.diff(nextUntilMoment, 'seconds') < NEXT_POLL_INTERVAL_DELAY) {
-        nextUntilMoment = nowMoment.subtract(NEXT_POLL_INTERVAL_DELAY, 'seconds');
-        if (nextSinceMoment.isAfter(nextUntilMoment)) {
-            nextSinceMoment = nextUntilMoment;
-        }
-    }
-    // set nextPollInterval in seconds base on different scenario.
     let nextPollInterval;
     if (nowMoment.diff(nextUntilMoment, 'hours') > 1) {
         nextPollInterval = 1;
@@ -87,10 +79,6 @@ function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
     }
     else {
         nextPollInterval = NEXT_POLL_INTERVAL_DELAY;
-    }
-
-    if (nextSinceMoment === nextUntilMoment) {
-        console.info(`Since and untill moment is same and Next collection in ${nextPollInterval} seconds`);
     }
 
     return { nextSinceMoment, nextUntilMoment, nextPollInterval };


### PR DESCRIPTION
### Problem Description

Few  Paws collector missed the data.This issue we seen for Cisco duo collector.
Scenario : When we made the api call just within the 1 min( at 7.43.59 pm we try to fetch the data for duration of 7.41.27pm to 7.42.27pm.)  
There may be chance of complete data was not available at that time when we make api call within a min.

### Solution Description
Make the api call for the time stamp of 10 to 15 min ago.

Set the NEXT_POLL_INTERVAL_DELAY to 10 to 15 min If current time and nextUntilMoment difference is less the NEXT_POLL_INTERVAL_DELAY seconds. 

