### PR TITLE
Poll interval delay should not increased more than 15 min

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_utils.js
+++ b/paws_utils.js
@@ -12,6 +12,7 @@
 const moment = require('moment');
 
 function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
+    const INTERVAL_IN_MINUTES = 15;
     const pollIntervalDelay = process.env.paws_poll_interval_delay && process.env.paws_poll_interval_delay <= 900 ? process.env.paws_poll_interval_delay : 300;
     const nowMoment = moment();
     const nextSinceMoment = curUntilMoment.isAfter(nowMoment) ?
@@ -71,7 +72,7 @@ function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
      * make next API call after 5 to 10 min to avoid any loss of data.
      */
     let nextPollInterval;
-    if (nowMoment.diff(nextUntilMoment, 'minutes') > 15) {
+    if (nowMoment.diff(nextUntilMoment, 'minutes') > INTERVAL_IN_MINUTES) {
         nextPollInterval = 1;
     }
     else if (nowMoment.diff(nextUntilMoment, 'seconds') > pollIntervalDelay) {

--- a/paws_utils.js
+++ b/paws_utils.js
@@ -71,7 +71,7 @@ function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
      * make next API call after 5 to 10 min to avoid any loss of data.
      */
     let nextPollInterval;
-    if (nowMoment.diff(nextUntilMoment, 'minutes') > 30) {
+    if (nowMoment.diff(nextUntilMoment, 'minutes') > 15) {
         nextPollInterval = 1;
     }
     else if (nowMoment.diff(nextUntilMoment, 'seconds') > pollIntervalDelay) {

--- a/paws_utils.js
+++ b/paws_utils.js
@@ -12,7 +12,7 @@
 const moment = require('moment');
 
 function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
-    const INTERVAL_IN_MINUTES = 15;
+    const DELAY_IN_MINUTES = 15;
     const pollIntervalDelay = process.env.paws_poll_interval_delay && process.env.paws_poll_interval_delay <= 900 ? process.env.paws_poll_interval_delay : 300;
     const nowMoment = moment();
     const nextSinceMoment = curUntilMoment.isAfter(nowMoment) ?
@@ -72,7 +72,7 @@ function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
      * make next API call after 5 to 10 min to avoid any loss of data.
      */
     let nextPollInterval;
-    if (nowMoment.diff(nextUntilMoment, 'minutes') > INTERVAL_IN_MINUTES) {
+    if (nowMoment.diff(nextUntilMoment, 'minutes') > DELAY_IN_MINUTES) {
         nextPollInterval = 1;
     }
     else if (nowMoment.diff(nextUntilMoment, 'seconds') > pollIntervalDelay) {


### PR DESCRIPTION
### Problem Description
Currently  we keep minimum 10 min delay and it increase up to 30 min as we keep 60sec interval after each call.

### Solution Description
If interval increase more than 15 min then we make set 1secs interval for each call.


 
