### PR TITLE
Fix PAWS shared cfn to allow existing collectors upgrade to it

### DIFF
--- a/cfn/paws-collector-shared.template
+++ b/cfn/paws-collector-shared.template
@@ -166,7 +166,7 @@
         }
     },
     "Resources":{
-        "EncryptSecretKeyCustomResource": {
+        "EncryptSecretKeySharedCustomResource": {
             "Type": "AWS::CloudFormation::CustomResource",
             "Properties": {
                 "ServiceToken": {"Ref": "ExistingEncryptLambdaArn"},
@@ -176,14 +176,14 @@
                 }
             }
         },
-        "StorePawsSecretInSsm": {
+        "StorePawsSecretInSsmSharedCustomResource": {
             "Type": "AWS::CloudFormation::CustomResource",
             "Properties": {
                 "ServiceToken": {"Ref": "ExistingSsmParamLambdaArn"},
                 "Name": {"Fn::Join": [
                     "",
                     [
-                        "PAWS-SECRET-",
+                        "PAWS-SECRET-V1-",
                         {"Ref": "PawsCollectorTypeName"},
                         "-",
                         {"Ref": "AWS::StackName"}
@@ -234,8 +234,8 @@
       "CollectLambdaFunction":{
          "Type":"AWS::Lambda::Function",
          "DependsOn":[
-            "EncryptSecretKeyCustomResource",
-            "StorePawsSecretInSsm",
+            "EncryptSecretKeySharedCustomResource",
+            "StorePawsSecretInSsmSharedCustomResource",
             "PawsPollStateQueue"
          ],
          "Properties":{
@@ -263,7 +263,7 @@
                       "Ref":"AlertlogicAccessKeyId"
                   },
                   "aims_secret_key":{
-                      "Fn::GetAtt": ["EncryptSecretKeyCustomResource", "EncryptedText"]
+                      "Fn::GetAtt": ["EncryptSecretKeySharedCustomResource", "EncryptedText"]
                   },
                   "aws_lambda_s3_bucket":{"Fn::Join" : ["", [
                       {"Ref":"PackagesBucketPrefix"}, "-",
@@ -328,7 +328,7 @@
                       "Ref": "ExistingKmsKeyArn"
                   },
                   "paws_secret_param_name":{
-                      "Fn::GetAtt": ["StorePawsSecretInSsm", "PawsSecretParamName"]
+                      "Fn::GetAtt": ["StorePawsSecretInSsmSharedCustomResource", "PawsSecretParamName"]
                   },
                   "paws_secret_param_tier": {
                       "Ref": "PawsSecretParamTier"


### PR DESCRIPTION
### Problem Description
Existing collector were unable to run `paws-shared-temaplate` therefore `Azcollect` service would have to operate both CFNs: for old and new collectors with shared resources.

### Solution Description
Fix `paws-collector-shared.template`:
  - Rename custom resources in order existing collectors recreate it.
  - Use new name for SSM parameters. This is required for existing collectors to successfully update to the new template and SSM parameter will be recreated.
