### PR TITLE
Fix the status update in assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -169,10 +169,10 @@ class PawsCollector extends AlAwsCollector {
 
     done(error, pawsState, sendStatus = true) {
         // If stream exist in state then post the error status as part of stream specific ; 
-        // In check-in or self-update we don't get state ,so check collector_streams env variable and post error as part of paws_{applicationId}_status else post the error paws_logmsgs_status
+        // In check-in or self-update we don't get state ,so check collector_streams env variable and post error as part of paws_{applicationId}_status
         const streamType = pawsState && pawsState.priv_collector_state.stream ?
             process.env.al_application_id + "_" + pawsState.priv_collector_state.stream :
-            process.env.collector_streams ? process.env.al_application_id : null;
+            process.env.al_application_id;
         
         super.done(error, streamType, sendStatus);
     }


### PR DESCRIPTION
### Problem Description
In some event like check-in or self-update or intermittent  server error occurred in that case we don’t  get priv_collector_state  and so error posted as part of paws_logmsgs_status instated of  stream specific status and this type status not get clean up during check -in for those collector having stream(https://github.com/alertlogic/al-aws-collector-js/blob/master/al_aws_collector.js#L428). It will be visible as remediation and Customer can’t  take any action.

### Solution Description
If we don't  get priv_collector_state.stream then check collector_stream variable has some value and post the error message as paws_${applicationId}_status which will be get clean up during the check-in event. In case collector_stream is not defined the post the error as part of paws_logmsgs_status and get clean up during checkin(https://github.com/alertlogic/al-aws-collector-js/blob/master/al_aws_collector.js#L432)

 
