### PR TITLE
Fix the status which form under reportErrorstatus method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -495,7 +495,7 @@ class PawsCollector extends AlAwsCollector {
     reportErrorStatus(error, pawsState, callback) {
         const streamType = pawsState && pawsState.priv_collector_state.stream ?
                 process.env.al_application_id + "_" + pawsState.priv_collector_state.stream :
-                null;
+                process.env.al_application_id;
         const errorString = this.stringifyError(error);
         const status = this.prepareErrorStatus(errorString, 'none', streamType);
         // Send the error status to assets only if retry count reached to 5. 


### PR DESCRIPTION
Error status are send from two place i.e. [Done method](https://github.com/alertlogic/paws-collector/blob/master/paws_collector.js#L170) and other from reportErrorstatus . Post the error either as stream specific or as part of `paws_{applicationId}_status` and not under [paws_logsmsgs_status](https://github.com/alertlogic/paws-collector/blob/master/paws_collector.js#L498). 
If streamType value is null it form paws_logsmsg_status but we need  `paws_{applicationId}_status` so updated the code and return streamType as application id.

Already fix in Done method [pr](https://github.com/alertlogic/paws-collector/pull/227) and  now fixing in reportErrorStatus 


 
