### PR TITLE
Bump the paws collector to get proper assets status while check-in event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.0.6",
+    "@alertlogic/al-aws-collector-js": "4.0.7",
     "datadog-lambda-js": "2.23.0",
     "async": "3.1.0",
     "debug": "4.1.1",


### PR DESCRIPTION
Bump the Paws version to take latest changes from [al-aws-collector.js](https://github.com/alertlogic/al-aws-collector-js/pull/71)
 
