### PR TITLE
[o365]: Reduce the multiple SSM call to get credentials 

### DIFF
--- a/collectors/o365/healthcheck.js
+++ b/collectors/o365/healthcheck.js
@@ -12,13 +12,14 @@
 
 const o365_mgmnt = require('./lib/o365_mgmnt');
 const al_health = require('@alertlogic/al-aws-collector-js').Health
-
+const PawsCollector = require('@alertlogic/paws-collector').PawsCollector;
 /*
  * Checks the subscriptions against the configured content type. Starts the subscriptions if th
  */
 
 function checkO365Subscriptions(callback){
-    return o365_mgmnt.listSubscriptions()
+    return PawsCollector.load().then(({pawsCreds}) => {
+        return o365_mgmnt.listSubscriptions(pawsCreds)
         .then(filterSubscriptions)
         .then(filteredStreams => {
             if(filteredStreams.length > 0){
@@ -26,7 +27,7 @@ function checkO365Subscriptions(callback){
             } else{
                 console.info(`O365000102: No streams need restarted.`);
             }
-            const streamPromises = filteredStreams.map(stream => o365_mgmnt.startSubscription(stream));
+            const streamPromises = filteredStreams.map(stream => o365_mgmnt.startSubscription(stream, pawsCreds));
             return Promise.all(streamPromises);
         })
         .then(res => callback(null))
@@ -42,6 +43,7 @@ function checkO365Subscriptions(callback){
             }
             callback(al_health.errorMsg('O365000103', 'Bad O365 stream status: ' + errorString));
         });
+    });
 }
 
 function filterSubscriptions(result){

--- a/collectors/o365/healthcheck.js
+++ b/collectors/o365/healthcheck.js
@@ -12,14 +12,14 @@
 
 const o365_mgmnt = require('./lib/o365_mgmnt');
 const al_health = require('@alertlogic/al-aws-collector-js').Health
-const PawsCollector = require('@alertlogic/paws-collector').PawsCollector;
+
 /*
  * Checks the subscriptions against the configured content type. Starts the subscriptions if th
  */
 
-function checkO365Subscriptions(callback){
-    return PawsCollector.load().then(({pawsCreds}) => {
-        return o365_mgmnt.listSubscriptions(pawsCreds)
+function checkO365Subscriptions(callback) {
+    let collector = this;
+    return o365_mgmnt.listSubscriptions(collector.pawsCred)
         .then(filterSubscriptions)
         .then(filteredStreams => {
             if(filteredStreams.length > 0){
@@ -27,7 +27,7 @@ function checkO365Subscriptions(callback){
             } else{
                 console.info(`O365000102: No streams need restarted.`);
             }
-            const streamPromises = filteredStreams.map(stream => o365_mgmnt.startSubscription(stream, pawsCreds));
+            const streamPromises = filteredStreams.map(stream => o365_mgmnt.startSubscription(collector.pawsCred, stream));
             return Promise.all(streamPromises);
         })
         .then(res => callback(null))
@@ -43,7 +43,6 @@ function checkO365Subscriptions(callback){
             }
             callback(al_health.errorMsg('O365000103', 'Bad O365 stream status: ' + errorString));
         });
-    });
 }
 
 function filterSubscriptions(result){

--- a/collectors/o365/lib/o365_mgmnt/index.js
+++ b/collectors/o365/lib/o365_mgmnt/index.js
@@ -14,16 +14,16 @@ const m_o365mgmnt = require('./o365management');
 
 const {ApplicationTokenCredentials} = require('@azure/ms-rest-nodeauth');
 
-function getO365ManagmentClient(pawsCreds) {
+function getO365ManagmentClient(creds) {
     return new Promise((resolve, reject) => {
         const AzureTenantId = process.env.paws_collector_param_string_1;
         var g_appAdCreds = new ApplicationTokenCredentials(
-            pawsCreds.client_id,
+            creds.client_id,
             AzureTenantId,
-            pawsCreds.secret,
+            creds.secret,
             'https://manage.office.com'
         );
-        if (pawsCreds.client_id && pawsCreds.secret && AzureTenantId) {
+        if (creds.client_id && creds.secret && AzureTenantId) {
             resolve(new m_o365mgmnt.O365Management(g_appAdCreds, AzureTenantId));
         }
         else reject("Paws credential or AzureTenantId should not be empty")
@@ -39,8 +39,8 @@ function getO365ManagmentClient(pawsCreds) {
  * @returns {Promise}
  *
  */
-var _listSubscriptions = function(pawsCreds) {
-    return getO365ManagmentClient(pawsCreds).then((client) => {
+var _listSubscriptions = function(creds) {
+    return getO365ManagmentClient(creds).then((client) => {
         return client.listSubscriptions(null)
     });
 };
@@ -57,8 +57,8 @@ var _listSubscriptions = function(pawsCreds) {
  * @returns {Promise}
  *
  */
-var _startSubscription = function(contentType, pawsCreds) {
-    return getO365ManagmentClient(pawsCreds).then((client) => {
+var _startSubscription = function(creds, contentType) {
+    return getO365ManagmentClient(creds).then((client) => {
         return client.startSubscription(contentType, null)
     });
 };
@@ -77,8 +77,8 @@ var _startSubscription = function(contentType, pawsCreds) {
  * @returns {Promise}
  *
  */
-var _subscriptionsContent = function(contentType, startTs, endTs, pawsCreds) {
-    return getO365ManagmentClient(pawsCreds).then((client) => {
+var _subscriptionsContent = function(creds, contentType, startTs, endTs) {
+    return getO365ManagmentClient(creds).then((client) => {
         return client.subscriptionsContent(contentType, startTs, endTs, null)
     });
 };
@@ -94,8 +94,8 @@ var _subscriptionsContent = function(contentType, startTs, endTs, pawsCreds) {
  * @returns {Promise}
  *
  */
-var _getPreFormedUrl = function(contentUri, pawsCreds) {
-    return getO365ManagmentClient(pawsCreds).then((client) => {
+var _getPreFormedUrl = function(creds, contentUri) {
+    return getO365ManagmentClient(creds).then((client) => {
         return client.getPreFormedUrl(contentUri, null);
     });
 };

--- a/collectors/o365/lib/o365_mgmnt/index.js
+++ b/collectors/o365/lib/o365_mgmnt/index.js
@@ -9,25 +9,25 @@
  */
 
 const util = require('util');
-const PawsCollector = require('@alertlogic/paws-collector').PawsCollector;
 
 const m_o365mgmnt = require('./o365management');
 
 const {ApplicationTokenCredentials} = require('@azure/ms-rest-nodeauth');
 
-function getO365ManagmentClient(){
-    return PawsCollector.load().then(({pawsCreds}) => {
+function getO365ManagmentClient(pawsCreds) {
+    return new Promise((resolve, reject) => {
         const AzureTenantId = process.env.paws_collector_param_string_1;
-        
         var g_appAdCreds = new ApplicationTokenCredentials(
             pawsCreds.client_id,
             AzureTenantId,
             pawsCreds.secret,
             'https://manage.office.com'
         );
-
-        return new m_o365mgmnt.O365Management(g_appAdCreds, AzureTenantId)
-    })
+        if (pawsCreds.client_id && pawsCreds.secret && AzureTenantId) {
+            resolve(new m_o365mgmnt.O365Management(g_appAdCreds, AzureTenantId));
+        }
+        else reject("Paws credential or AzureTenantId should not be empty")
+    });
 }
 
 /**
@@ -39,8 +39,8 @@ function getO365ManagmentClient(){
  * @returns {Promise}
  *
  */
-var _listSubscriptions = function() {
-    return getO365ManagmentClient().then((client) => {
+var _listSubscriptions = function(pawsCreds) {
+    return getO365ManagmentClient(pawsCreds).then((client) => {
         return client.listSubscriptions(null)
     });
 };
@@ -57,8 +57,8 @@ var _listSubscriptions = function() {
  * @returns {Promise}
  *
  */
-var _startSubscription = function(contentType) {
-    return getO365ManagmentClient().then((client) => {
+var _startSubscription = function(contentType, pawsCreds) {
+    return getO365ManagmentClient(pawsCreds).then((client) => {
         return client.startSubscription(contentType, null)
     });
 };
@@ -77,8 +77,8 @@ var _startSubscription = function(contentType) {
  * @returns {Promise}
  *
  */
-var _subscriptionsContent = function(contentType, startTs, endTs) {
-    return getO365ManagmentClient().then((client) => {
+var _subscriptionsContent = function(contentType, startTs, endTs, pawsCreds) {
+    return getO365ManagmentClient(pawsCreds).then((client) => {
         return client.subscriptionsContent(contentType, startTs, endTs, null)
     });
 };
@@ -94,8 +94,8 @@ var _subscriptionsContent = function(contentType, startTs, endTs) {
  * @returns {Promise}
  *
  */
-var _getPreFormedUrl = function(contentUri) {
-    return getO365ManagmentClient().then((client) => {
+var _getPreFormedUrl = function(contentUri, pawsCreds) {
+    return getO365ManagmentClient(pawsCreds).then((client) => {
         return client.getPreFormedUrl(contentUri, null);
     });
 };

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.33",
+  "version": "1.2.34",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,


### PR DESCRIPTION
### Problem Description
Made the multiple call to SSM to get credentials and some time it will take time/face issue to return the credentials .
So we get error `Error: secret must be a non empty string` .

### Solution Description

1. Remove the PawsCollector.load() call from getO365ManagmentClient() to reduce the multiple call to SSM param.
2. Save the paws credentials in one object  when constructor get call and pass to O365 api from different  method (getPreFormedUrl, subscriptionsContent).



 
