### PR TITLE
Carbonblack : Updated the carbon black Themis template to assign the value from themis data object

### DIFF
--- a/collectors/carbonblack/themis-template/carbonblackaudit.json
+++ b/collectors/carbonblack/themis-template/carbonblackaudit.json
@@ -1,8 +1,8 @@
 {
     "method": "GET",
-    "url": "{{paws_endpoint}}/integrationServices/v3/event?searchWindow=1d&rows=1",
+    "url": "{{endpoint}}/integrationServices/v3/event?searchWindow=1d&rows=1",
     "headers": {
-        "X-Auth-Token": "{{paws_secret}}/{{paws_client_id}}"
+        "X-Auth-Token": "{{secret}}/{{client_id}}"
     },
     "body": "",
     "expect": {

--- a/collectors/carbonblack/themis-template/carbonblackevents.json
+++ b/collectors/carbonblack/themis-template/carbonblackevents.json
@@ -1,8 +1,8 @@
 {
     "method": "GET",
-    "url": "{{paws_endpoint}}/appservices/v6/orgs/{{collector_param_string2}}/alerts/search_suggestions?suggest.q=",
+    "url": "{{endpoint}}/appservices/v6/orgs/{{collector_param_string2}}/alerts/search_suggestions?suggest.q=",
     "headers": {
-        "X-Auth-Token": "{{paws_secret}}/{{paws_client_id}}"
+        "X-Auth-Token": "{{secret}}/{{client_id}}"
     },
     "body": "",
     "expect": {


### PR DESCRIPTION
### Problem Description
Getting the error while Validating the carbonblack collector using themis template.
ex. `error: function_clause, trace: [{lhttpc_lib,split_scheme,["/appservices/v6/orgs/N2MF5397/alerts/search_suggestions?suggest.q="],[{file,"/codebuild/output/src578981762/src/algithub.pd.alertlogic.net/defender/themis/_build/default/lib/lhttpc/src/lhttpc_lib.erl"}`

### Solution Description
Update the template to use correct field from themis data object and form the valid URL to authenticate the carbonblack credentials .
ex. data we get from themis data object is as below `data: #{<<"**client_id**">> => <<"J8KFCTQW74">>,<<"**collector_param_string2**">> => <<"N2MF5397">>,<<"collector_streams">> => <<"[\"SearchAlertsWatchlist\",\"SearchAlertsCBAnalytics\",\"SearchAlerts\"]">>,<<"collector_type_name">> => <<"carbonblack">>,<<"**endpoint**">> => <<"https://defense-prod05.conferdeploy.net">>}`


 
