### PR TITLE
[Paws lib]: Bump the paws version to fix Lambda.updateFunctionConfiguration failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.0.7",
+    "@alertlogic/al-aws-collector-js": "4.0.8",
     "datadog-lambda-js": "2.23.0",
     "async": "3.1.0",
     "debug": "4.1.1",


### PR DESCRIPTION
### Problem Description
All paws deployment failed as updateFunctionConfiguration calls may fail if Lambda status is InProgress.


### Solution Description
Fix in al-aws-collector-js. [pr](https://github.com/alertlogic/al-aws-collector-js/pull/72 ) 