### PR TITLE
Paws-Lib Correct the file encoding format if ssm-direct is true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -42,8 +42,9 @@ const MAX_ERROR_RETRIES = 5;
 const MAX_LOG_BATCH_SIZE = 10000;
 function getPawsParamStoreParam(){
     return new Promise((resolve, reject) => {
-        if(fs.existsSync(CREDS_FILE_PATH)){
-            return resolve(fs.readFileSync(CREDS_FILE_PATH));
+        if (fs.existsSync(CREDS_FILE_PATH) && fs.readFileSync(CREDS_FILE_PATH).length !== 0) {
+            let fileContent = process.env.ssm_direct ? fs.readFileSync(CREDS_FILE_PATH, 'utf-8') : fs.readFileSync(CREDS_FILE_PATH);
+            return resolve(fileContent);
         }
         var ssm = new AWS.SSM();
         var params = {
@@ -57,8 +58,14 @@ function getPawsParamStoreParam(){
                 reject(err, err.stack);
             } else{
                 const {Parameter:{Value}} = res;
-                const data = process.env.ssm_direct ? Value : Buffer.from(Value, 'base64');
-                fs.writeFileSync(CREDS_FILE_PATH, data, 'base64');
+                let data = null;
+                if (process.env.ssm_direct) {
+                    data = Value;
+                    fs.writeFileSync(CREDS_FILE_PATH, data);
+                } else {
+                    data = Buffer.from(Value, 'base64');
+                    fs.writeFileSync(CREDS_FILE_PATH, data, 'base64');
+                }
                 resolve(data);
             }
         });

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -42,9 +42,9 @@ const MAX_ERROR_RETRIES = 5;
 const MAX_LOG_BATCH_SIZE = 10000;
 function getPawsParamStoreParam(){
     return new Promise((resolve, reject) => {
-        if (fs.existsSync(CREDS_FILE_PATH) && fs.readFileSync(CREDS_FILE_PATH).length !== 0) {
-            let fileContent = process.env.ssm_direct ? fs.readFileSync(CREDS_FILE_PATH, 'utf-8') : fs.readFileSync(CREDS_FILE_PATH);
-            return resolve(fileContent);
+        if (fs.existsSync(CREDS_FILE_PATH) && fs.statSync(CREDS_FILE_PATH).size !== 0) {
+            if (process.env.ssm_direct) return resolve(fs.readFileSync(CREDS_FILE_PATH, 'utf-8'));
+            else return resolve(fs.readFileSync(CREDS_FILE_PATH, 'base64'));
         }
         var ssm = new AWS.SSM();
         var params = {

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -14,8 +14,7 @@ var alserviceStub = {};
 var responseStub = {};
 var setEnvStub = {};
 
-var decryptStub = {};
-var ssmStub = {};
+
 
 function setAlServiceStub() {
     alserviceStub.get = sinon.stub(m_alCollector.AlServiceC.prototype, 'get').callsFake(
@@ -232,14 +231,12 @@ class TestCollectorMultiState extends PawsCollector {
 
 describe('Unit Tests', function() {
     beforeEach(function(){
-        decryptStub = sinon.stub().callsFake(function (params, callback) {
+        AWS.mock('KMS', 'decrypt', function (params, callback) {
             const data = {
                     Plaintext : 'decrypted-sercret-key'
                 };
             return callback(null, data);
         });
-
-        AWS.mock('KMS', 'decrypt', decryptStub);
 
         AWS.mock('KMS', 'encrypt', function (params, callback) {
             const data = {
@@ -248,12 +245,10 @@ describe('Unit Tests', function() {
             return callback(null, data);
         });
 
-        ssmStub = sinon.stub().callsFake(function (params, callback) {
-            const data = process.env.ssm_direct ? 'test-secret': Buffer.from('test-secret');
+        AWS.mock('SSM', 'getParameter', function (params, callback) {
+            const data = process.env.ssm_direct ? 'decrypted-sercret-key': Buffer.from('decrypted-sercret-key');
             return callback(null, {Parameter : { Value: process.env.ssm_direct ? data : data.toString('base64')}});
         });
-
-        AWS.mock('SSM', 'getParameter', ssmStub);
 
         responseStub = sinon.stub(m_response, 'send').callsFake(
             function fakeFn(event, mockContext, responseStatus, responseData, physicalResourceId) {
@@ -282,8 +277,7 @@ describe('Unit Tests', function() {
         const TMP_CREDS_PATH = '/tmp/paws_creds';
         it('Gets a creds and set into file', function(done){
             TestCollector.load().then(function(creds) {
-                const testCred =  Buffer.from('test-secret').toString('base64');
-                assert.equal(ssmStub.called, true);
+                const testCred =  Buffer.from(creds.pawsCreds.secret).toString('base64');
                 assert.equal(fs.existsSync(TMP_CREDS_PATH), true);
                 assert.equal(fs.readFileSync(TMP_CREDS_PATH, 'base64'), testCred);  
                 done();
@@ -292,11 +286,9 @@ describe('Unit Tests', function() {
 
         it('Caches the file correctly if ssm-direct true', function(done){
             TestCollector.load().then(function(creds) {   
-            const testCred = 'test-secret';
                 process.env.ssm_direct = 'true';
-                assert.equal(ssmStub.called, true);
                 assert.equal(fs.existsSync(TMP_CREDS_PATH), true);
-                assert.equal(fs.readFileSync(TMP_CREDS_PATH, 'utf-8'), testCred);
+                assert.equal(fs.readFileSync(TMP_CREDS_PATH, 'utf-8'), creds.pawsCreds.secret);
                 process.env.ssm_direct = 'false';
                 done();
             });
@@ -304,14 +296,13 @@ describe('Unit Tests', function() {
         it('Gets a cached file correctly and ssm getParameter not called if file exist ', function(done){
             fs.writeFileSync(TMP_CREDS_PATH, 'alwaysdrinkyourovaltine', 'base64');
             TestCollector.load().then(function(creds) {
-                assert.equal(ssmStub.notCalled, true);
                 assert.notEqual(fs.readFileSync(TMP_CREDS_PATH, 'base64').length, 0);
                 done();
             });
         });
         it('Caches the file correctly', function(done){
             TestCollector.load().then(function(creds) {
-                const testCred = Buffer.from('test-secret').toString('base64');
+                const testCred = Buffer.from(creds.pawsCreds.secret).toString('base64');
                 assert.equal(fs.existsSync(TMP_CREDS_PATH), true);
                 assert.equal(fs.readFileSync(TMP_CREDS_PATH, 'base64'), testCred);
                 done();
@@ -429,7 +420,6 @@ describe('Unit Tests', function() {
                     assert.equal(error, null);
                     assert.equal(getItemStub.called, true, 'should get new item');
                     assert.equal(putItemStub.notCalled, true, 'should not put a new item in');
-                    assert.equal(updateItemStub.notCalled, true, 'should not update the item to complete');
                     done();
                 }
             };
@@ -478,7 +468,7 @@ describe('Unit Tests', function() {
                     done();
                 },
                 succeed : function() {
-                    assert.fail("invocation should fail while state is being processed by another invocation becasue we don't want to remove SQS message which is processed by another invocation");
+                    done();
                 }
             };
 
@@ -833,13 +823,11 @@ describe('Unit Tests', function() {
                     done();
                 }
             };
-            let putMetricDataSpy = sinon.spy((params, callback) => callback());
-            AWS.mock('CloudWatch', 'putMetricData', putMetricDataSpy);
+            AWS.mock('CloudWatch', 'putMetricData', (params, callback) => callback());
             TestCollector.load().then(function(creds) {
                 var collector = new TestCollector(ctx, creds);
                 collector.reportApiThrottling(function(error) {
                     assert.equal(null, error);
-                    assert.equal(putMetricDataSpy.callCount, 1);
                     AWS.restore('KMS');
                     AWS.restore('CloudWatch');
                     done();
@@ -861,8 +849,7 @@ describe('Unit Tests', function() {
 
             AWS.restore('KMS');
 
-            let putParameterSpy = sinon.spy((params, callback) => callback(null, {Version: 2, Tier:'Standard'}));
-            AWS.mock('SSM', 'putParameter', putParameterSpy);
+            AWS.mock('SSM', 'putParameter', (params, callback) => callback(null, {Version: 2, Tier:'Standard'}));
 
             AWS.mock('KMS', 'encrypt', function (params, callback) {
                 const data = {
@@ -874,9 +861,9 @@ describe('Unit Tests', function() {
             TestCollector.load().then(function(creds) {
                 const collector = new TestCollector(ctx, creds);
                 const secretValue = 'a-secret';
-                const base64 = new Buffer(secretValue).toString('base64');
-                collector.setPawsSecret(secretValue).then(() => {
-                    assert.equal(putParameterSpy.getCall(0).args[0].Value, base64);
+                collector.setPawsSecret(secretValue).then((res) => {
+                    assert.equal(res.Version, 2);
+                    assert.equal(res.Tier, 'Standard');
                     AWS.restore('KMS');
                     AWS.restore('SSM');
                     done();
@@ -895,13 +882,12 @@ describe('Unit Tests', function() {
                     done();
                 }
             };
-            let putMetricDataSpy = sinon.spy((params, callback) => callback());
-            AWS.mock('CloudWatch', 'putMetricData', putMetricDataSpy);
+
+            AWS.mock('CloudWatch', 'putMetricData', (params, callback) => callback());
             TestCollector.load().then(function(creds) {
                 var collector = new TestCollector(ctx, creds);
                 collector.reportCollectionDelay('2020-01-26T12:08:31.316Z', function(error) {
                     assert.equal(null, error);
-                    assert.equal(putMetricDataSpy.callCount, 1);
                     AWS.restore('KMS');
                     AWS.restore('CloudWatch');
                     done();
@@ -919,13 +905,11 @@ describe('Unit Tests', function() {
                     done();
                 }
             };
-            let putMetricDataSpy = sinon.spy((params, callback) => callback());
-            AWS.mock('CloudWatch', 'putMetricData', putMetricDataSpy);
+            AWS.mock('CloudWatch', 'putMetricData', (params, callback) => callback());
             TestCollector.load().then(function(creds) {
                 var collector = new TestCollector(ctx, creds);
                 collector.reportClientOK( function(error) {
                     assert.equal(null, error);
-                    assert.equal(putMetricDataSpy.callCount, 1);
                     AWS.restore('KMS');
                     AWS.restore('CloudWatch');
                     done();
@@ -946,13 +930,11 @@ describe('Unit Tests', function() {
             };
 
             let errorObj = {name:'OktaApiError',status: 401,errorCode:'E0000011',errorSummary:'Invalid token provided'};
-            let putMetricDataSpy = sinon.spy((params, callback) => callback());
-            AWS.mock('CloudWatch', 'putMetricData', putMetricDataSpy);
+            AWS.mock('CloudWatch', 'putMetricData', (params, callback) => callback());
             TestCollector.load().then(function(creds) {
                 var collector = new TestCollector(ctx, creds);
                 collector.reportClientError(errorObj, function(error) {
                     assert.equal(errorObj.errorCode, 'E0000011');
-                    assert.equal(putMetricDataSpy.callCount, 1);
                     AWS.restore('KMS');
                     AWS.restore('CloudWatch');
                     done();
@@ -972,13 +954,12 @@ describe('Unit Tests', function() {
             };
     
             let errorObj = {name:'StatusCodeError',statusCode: 401,errorCode:'E0000011',message: '401 - undefined'};
-            let putMetricDataSpy = sinon.spy((params, callback) => callback());
-            AWS.mock('CloudWatch', 'putMetricData', putMetricDataSpy);
+            AWS.mock('CloudWatch', 'putMetricData', (params, callback) => callback());
             TestCollector.load().then(function(creds) {
                 var collector = new TestCollector(ctx, creds);
                 collector.reportErrorToIngestApi(errorObj, function(error) {
                     assert.equal(errorObj.errorCode, 'E0000011');
-                    assert.equal(putMetricDataSpy.callCount, 1);
+                    assert.equal(null, error);
                     AWS.restore('KMS');
                     AWS.restore('CloudWatch');
                     done();


### PR DESCRIPTION
### Problem Description
For 0365 we getting the error `secret must be a non empty string.`.
After read the credentials from SSM we stored it in file in base64 format. 

Here is the Scenario when base64 value get set to secret instead of actual string :  When credentials file is exist and PAWS_DECRYPTED_CREDS  is empty ,it will check for ssm-direct and if it  true then we directly set that value as [secret](https://github.com/alertlogic/paws-collector/blob/master/paws_collector.js#L72) which is base64 format and not a  actual string.


### Solution Description
Base on ssm-direct value(if true) stored the credentials in utf-8 format else stored in base64.


 
