### PR TITLE
Cipher text should be in buffer string format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -44,7 +44,7 @@ function getPawsParamStoreParam(){
     return new Promise((resolve, reject) => {
         if (fs.existsSync(CREDS_FILE_PATH) && fs.statSync(CREDS_FILE_PATH).size !== 0) {
             if (process.env.ssm_direct) return resolve(fs.readFileSync(CREDS_FILE_PATH, 'utf-8'));
-            else return resolve(fs.readFileSync(CREDS_FILE_PATH, 'base64'));
+            else return resolve(fs.readFileSync(CREDS_FILE_PATH));
         }
         var ssm = new AWS.SSM();
         var params = {


### PR DESCRIPTION
### Problem Description
If file read in bas64 encoding format and pass the value for decryption it will return invalid cipher-text error.

### Solution Description
Read buffer string and pass to kms decrypt to get actual value.


 
