### PR TITLE
[Auth0 and Cisco Duo Collectors] : Handle the Throttling/ Rate limit error

### DIFF
--- a/collectors/auth0/auth0_collector.js
+++ b/collectors/auth0/auth0_collector.js
@@ -66,6 +66,7 @@ class Auth0Collector extends PawsCollector {
                 if (error.statusCode && error.statusCode === API_THROTTLING_ERROR) {
                     state.poll_interval_sec = state.poll_interval_sec < 10 ?
                         10 : state.poll_interval_sec + 1;
+                    AlLogger.warn(`AUTZ000003 API Request Limit Exceeded`, error);
                     collector.reportApiThrottling(function () {
                         return callback(null, [], state, state.poll_interval_sec);
                     });

--- a/collectors/auth0/auth0_collector.js
+++ b/collectors/auth0/auth0_collector.js
@@ -27,7 +27,7 @@ const tsPaths = [
 ];
 
 const HOSTNAME_REGEXP = /^[htps]*:\/\/|\/$/gi;
-
+const API_THROTTLING_ERROR = 429;
 
 class Auth0Collector extends PawsCollector {
 
@@ -58,9 +58,23 @@ class Auth0Collector extends PawsCollector {
                 AlLogger.info(`AUTZ000002 Next collection in ${newState.poll_interval_sec} seconds`);
                 return callback(null, accumulator, newState, newState.poll_interval_sec);
             }).catch((error) => {
-                // set error code for DDMetrics
-                error.errorCode = error.statusCode;
-                return callback(error);
+                // Auth0 Logging api has some rate limits that we might run into.
+                // If we run into a rate limit error, instead of returning the error,
+                // we return the state back to the queue with an additional 10 second added.
+                // https://auth0.com/docs/support/policies/rate-limit-policy/management-api-endpoint-rate-limits
+                // Rate Limit GET /api/v2/logs 10 call per sec
+                if (error.statusCode && error.statusCode === API_THROTTLING_ERROR) {
+                    state.poll_interval_sec = state.poll_interval_sec < 10 ?
+                        10 : state.poll_interval_sec + 1;
+                    collector.reportApiThrottling(function () {
+                        return callback(null, [], state, state.poll_interval_sec);
+                    });
+                }
+                else {
+                    // set error code for DDMetrics
+                    error.errorCode = error.statusCode;
+                    return callback(error);
+                }
             });
     }
 

--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,

--- a/collectors/ciscoduo/collector.js
+++ b/collectors/ciscoduo/collector.js
@@ -120,7 +120,7 @@ class CiscoduoCollector extends PawsCollector {
                 if (error.code && error.code === API_THROTTLING_ERROR) {
                     state.poll_interval_sec = state.poll_interval_sec < 60 ?
                         60 : state.poll_interval_sec + 1;
-                    AlLogger.warn(`The account has made too many requests of this type recently. Try again after ${state.poll_interval_sec} sec `)
+                    AlLogger.warn(`CDUO000003 API Request Limit Exceeded`, error);
                     collector.reportApiThrottling(function () {
                         return callback(null, [], state, state.poll_interval_sec);
                     });

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,


### PR DESCRIPTION
### Problem Description
Throttling error for Cisco duo and Auth0.
Error sample from Cisco duo collectors :
`PAWS000304 Error handling poll request: {\"code\":42901,\"message\":\"Too Many Requests\",\"stat\":\"FAIL\",\"errorCode\":42901}`

### Solution Description
 If we run into a rate limit/throttling error, instead of returning the error, we return the state back to the queue with an additional second.

1. Auth0 : Reference documents  for [ Auth0 Management API Endpoint Rate Limits](https://auth0.com/docs/support/policies/rate-limit-policy/management-api-endpoint-rate-limits). As per doc 10 api call per sec , but still added the 10 sec interval for safer side.
2. CiscoDuo : There is no proper document ,so refer the [ Cisco community doc](https://community.duo.com/t/429-too-many-requests-after-a-request-every-20-seconds/6863)  and added 60 sec poll interval as per comments mentioned on this.
