### PR TITLE
[Cisco Duo collector ]: Increment the poll interval by 60 sec for throttling issue

### DIFF
--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoduo/test/ciscoduo_test.js
+++ b/collectors/ciscoduo/test/ciscoduo_test.js
@@ -272,7 +272,7 @@ describe('Unit Tests', function () {
                 collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
                     assert.equal(true, reportSpy.calledOnce);
                     assert.equal(logs.length, 0);
-                    assert.equal(newState.poll_interval_sec, 60);
+                    assert.equal(newState.poll_interval_sec, 120);
                     getAPILogs.restore();
                     getAPIDetails.restore();
                     done();


### PR DESCRIPTION
### Problem Description
Initially added 60  sec as poll interval if throttling issue occurs, But issue is not resolved completely .

### Solution Description
Incremented the poll interval sec by 60 sec every time until MAX_POLL_INTERVAL(900 sec) reached.

So first time it will add 120 second and later on it will add 60 sec every time till 15 min as poll interval.
