### PR TITLE
[Paws Utility] : Collection start date gt than 30 days, then adjust the date to last 30 days

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_utils.js
+++ b/paws_utils.js
@@ -17,7 +17,7 @@ function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
     const nowMoment = moment();
     // If collection start date gt than 30 days, ingest will not accept data, so adjust the date to last 30 days.
     const nextSinceMoment = curUntilMoment.isAfter(nowMoment) ?
-        nowMoment : nowMoment.diff(curUntilMoment, 'days') > 30 ? moment().subtract(30, 'days') : curUntilMoment;
+        nowMoment : nowMoment.diff(curUntilMoment, 'days') > 30 ? moment(nowMoment).subtract(30, 'days') : curUntilMoment;
     const daysDiff = nowMoment.diff(nextSinceMoment, 'days');
     const hoursDiff = nowMoment.diff(nextSinceMoment, 'hours');
     let nextUntilMoment;

--- a/paws_utils.js
+++ b/paws_utils.js
@@ -15,8 +15,9 @@ function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
     const DELAY_IN_MINUTES = 15;
     const pollIntervalDelay = process.env.paws_poll_interval_delay && process.env.paws_poll_interval_delay <= 900 ? process.env.paws_poll_interval_delay : 300;
     const nowMoment = moment();
+    // If collection start date gt than 30 days, ingest will not accept data, so adjust the date to last 30 days.
     const nextSinceMoment = curUntilMoment.isAfter(nowMoment) ?
-        nowMoment : curUntilMoment;
+        nowMoment : nowMoment.diff(curUntilMoment, 'days') > 30 ? moment().subtract(30, 'days') : curUntilMoment;
     const daysDiff = nowMoment.diff(nextSinceMoment, 'days');
     const hoursDiff = nowMoment.diff(nextSinceMoment, 'hours');
     let nextUntilMoment;


### PR DESCRIPTION
### Problem Description
DD show collection delay increase for couple of collector. Below is the one of the reason to increase the collection delay.
Customer can add the  any collection start date from UI, so seen some customer added the long back date(year ago). 
But ingest will accept only last 30 days data. We are unnecessary making the so many API call .

### Solution Description
If collection start date greater than 30 days, So adjust the start collection to last 30 days.
