### PR TITLE
[Googlestack driver] : Handle the GCP throttling error with max message size 4MB 

### DIFF
--- a/collectors/googlestackdriver/collector.js
+++ b/collectors/googlestackdriver/collector.js
@@ -19,6 +19,7 @@ const packageJson = require('./package.json');
 
 const API_THROTTLING_ERROR = 8;
 const MAX_POLL_INTERVAL = 900;
+const MAX_PAGE_SIZE = 1000;
 
 const typeIdPaths = [
     {path: ['jsonPayload', 'fields', 'event_type', 'stringValue']},
@@ -99,7 +100,7 @@ timestamp < "${state.until}"`;
             }
         };
 
-        const pageSize = state.pageSize > 0 ? state.pageSize : 1000;
+        const pageSize = state.pageSize > 0 ? state.pageSize : MAX_PAGE_SIZE;
         let params = state.nextPage ?
             state.nextPage:
             {
@@ -161,10 +162,10 @@ timestamp < "${state.until}"`;
 
     _getNextCollectionState(curState, nextPage) {
         // Reset the page size for next collection as log collection completed for throttling interval
-        if (nextPage && nextPage.pageSize && nextPage.pageSize < 1000) {
-            nextPage.pageSize = 1000;
-        } else if (curState.pageSize && curState.pageSize < 1000) {
-            curState.pageSize = 1000;
+        if (nextPage && nextPage.pageSize && nextPage.pageSize < MAX_PAGE_SIZE) {
+            nextPage.pageSize = MAX_PAGE_SIZE;
+        } else if (curState.pageSize && curState.pageSize < MAX_PAGE_SIZE) {
+            curState.pageSize = MAX_PAGE_SIZE;
         }
         const {stream} = curState;
 

--- a/collectors/googlestackdriver/collector.js
+++ b/collectors/googlestackdriver/collector.js
@@ -18,6 +18,7 @@ const logging = require('@google-cloud/logging');
 const packageJson = require('./package.json');
 
 const API_THROTTLING_ERROR = 8;
+const MAX_POLL_INTERVAL = 900;
 
 const typeIdPaths = [
     {path: ['jsonPayload', 'fields', 'event_type', 'stringValue']},
@@ -98,11 +99,12 @@ timestamp < "${state.until}"`;
             }
         };
 
+        const pageSize = state.pageSize > 0 ? state.pageSize : 1000;
         let params = state.nextPage ?
             state.nextPage:
             {
                 filter,
-                pageSize: 1000,
+                pageSize: pageSize,
                 resourceNames:[state.stream]
             };
 
@@ -119,16 +121,24 @@ timestamp < "${state.until}"`;
 
                 // Stackdriver Logging api has some rate limits that we might run into.
                 // If we run inot a rate limit error, instead of returning the error,
-                // we return the state back to the queue with an additional second added, up to 10
+                // we return the state back to the queue with an additional second added, up to 15 min
                 // https://cloud.google.com/logging/quotas
                 // Error: 8 RESOURCE_EXHAUSTED: Received message larger than max (4518352 vs. 4194304),
-                // so half the given interval and if interval is less than 15 sec then try again with same interval.
+                // so half the given interval and if interval is less than 15 sec then reduce the page size to half.
+
                 if(err.code === API_THROTTLING_ERROR){
-                    const nextPollInterval = state.poll_interval_sec < 10 ?
-                        state.poll_interval_sec + 1:
-                        10;
+                    const interval = state.poll_interval_sec < 60 ? 60 : state.poll_interval_sec;
+                    const nextPollInterval = state.poll_interval_sec < MAX_POLL_INTERVAL ?
+                        interval + 60 : MAX_POLL_INTERVAL;
                     const currentInterval = moment(state.until).diff(state.since, 'seconds');
-                    if (currentInterval <= 15) {
+                    if (currentInterval <= 15 && err.details.includes('Received message larger than max')) {
+                        // Reduce the page size to half to pull the data for throttling interval
+                        if (state.nextPage && state.nextPage.pageSize) {
+                            state.nextPage.pageSize = Math.ceil(state.nextPage.pageSize / 2);
+                        }
+                        else {
+                            state.pageSize = Math.ceil(params.pageSize / 2)
+                        }
                         AlLogger.warn(`RESOURCE_EXHAUSTED for ${currentInterval} sec time interval`);
                     }
                     else {
@@ -150,6 +160,12 @@ timestamp < "${state.until}"`;
     }
 
     _getNextCollectionState(curState, nextPage) {
+        // Reset the page size for next collection as log collection completed for throttling interval
+        if (nextPage && nextPage.pageSize && nextPage.pageSize < 1000) {
+            nextPage.pageSize = 1000;
+        } else if (curState.pageSize && curState.pageSize < 1000) {
+            curState.pageSize = 1000;
+        }
         const {stream} = curState;
 
         const untilMoment = moment(curState.until);

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.25",
+    "@alertlogic/paws-collector": "^2.0.26",
     "@google-cloud/logging": "6.0.0",
     "async": "3.1.0",
     "debug": "4.1.1",

--- a/collectors/googlestackdriver/test/test.js
+++ b/collectors/googlestackdriver/test/test.js
@@ -368,7 +368,6 @@ describe('Unit Tests', function() {
                 };
                 const nextPage = {"filter":"timestamp >= \"2022-01-21T00:00:15.000Z\"\ntimestamp < \"2022-01-22T00:00:15.000Z\"","pageSize":500,"resourceNames":["projects/test"],"pageToken":"EAA46o"};
                 const newState = collector._getNextCollectionState(curState, nextPage);
-                console.log('newState',newState);
                 assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
                 assert.equal(newState.poll_interval_sec, 1);
                 assert.equal(newState.nextPage.pageSize, 1000);


### PR DESCRIPTION
### Problem Description
Getting the Throttling error  with message size greater than 4 MB from GCP collector.
` Error: 8 RESOURCE_EXHAUSTED: Received message larger than max (4518352 vs. 4194304)`

### Solution Description
First reduce the interval into half and if not resolved for less than 15 sec then reduce the page size to half and pull the data.

 
