### PR TITLE
Remove PawsClientOK metric as unused

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -429,9 +429,7 @@ class PawsCollector extends AlAwsCollector {
                                 return asyncCallback(err);
                             });
                         } else {
-                            collector.reportClientOK(() => {
-                                return asyncCallback(null, ...remainingParams)
-                            });
+                            return asyncCallback(null, ...remainingParams);
                         }
                     });
                 },
@@ -649,38 +647,6 @@ class PawsCollector extends AlAwsCollector {
         };
         let errorCode = typeof (error) === 'object' && error.errorCode ? error.errorCode : 'unknown';
         this.reportDDMetric("client", 1, [`result:error`,`error_code:${errorCode}`]);
-        return cloudwatch.putMetricData(params, callback);
-    };
-
-    /**
-    * Collector to report client execute successfully, 
-    * So we can check how often 3rd party APIs get called.
-    * @param callback 
-    */
-    reportClientOK( callback) {
-        var cloudwatch = new AWS.CloudWatch({apiVersion: '2010-08-01'});
-        const params = {
-            MetricData: [
-              {
-                MetricName: "PawsClientOK",
-                Dimensions: [
-                  {
-                    Name: 'CollectorType',
-                    Value: this._pawsCollectorType
-                  },
-                  {
-                    Name: 'FunctionName',
-                    Value: process.env.AWS_LAMBDA_FUNCTION_NAME
-                  }
-                ],
-                Timestamp: new Date(),
-                Unit: 'Count',
-                Value: 1
-              }
-            ],
-            Namespace: 'PawsCollectors'
-        };
-        this.reportDDMetric("client", 1, [`result:ok`]);
         return cloudwatch.putMetricData(params, callback);
     };
     

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -894,28 +894,6 @@ describe('Unit Tests', function() {
                 });
             });
         });
-        it('reportClientOK', function(done) {
-            let ctx = {
-                invokedFunctionArn : pawsMock.FUNCTION_ARN,
-                fail : function(error) {
-                    assert.fail(error);
-                    done();
-                },
-                succeed : function() {
-                    done();
-                }
-            };
-            AWS.mock('CloudWatch', 'putMetricData', (params, callback) => callback());
-            TestCollector.load().then(function(creds) {
-                var collector = new TestCollector(ctx, creds);
-                collector.reportClientOK( function(error) {
-                    assert.equal(null, error);
-                    AWS.restore('KMS');
-                    AWS.restore('CloudWatch');
-                    done();
-                });
-            });
-        });
 
         it('reportClientError', function(done) {
             let ctx = {


### PR DESCRIPTION
### Problem Description
Cost saving.

### Solution Description
Remove unused `PawsClientOK` metric.To some extent it can we replaces with successful lambda invocation metrics.