### PR TITLE
[Okta] Add shared SNS trigger support

### DIFF
--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.1.33",
+  "version": "1.2.0",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -22,7 +22,7 @@
   "dependencies": {
     "@okta/okta-sdk-nodejs": "4.1.0",
     "@alertlogic/al-collector-js": "^2.0.4",
-    "@alertlogic/paws-collector": "^2.0.28",
+    "@alertlogic/paws-collector": "^2.1.0",
     "async": "3.1.0",
     "debug": "4.1.1",
     "moment": "2.24.0"


### PR DESCRIPTION
### Solution Description
Update dependencies to support shared SNS triggers for checkins and updates. Please note old CW events triggers will continue to work until  (`paws-collector-shared.temaplte`)[https://github.com/alertlogic/paws-collector/blob/master/cfn/paws-collector-shared.template] is changed to support SNS triggers.
