### PR TITLE
Fix CarbonBlack credential validate endpoint

### DIFF
--- a/collectors/carbonblack/themis-template/carbonblackaudit.json
+++ b/collectors/carbonblack/themis-template/carbonblackaudit.json
@@ -1,6 +1,6 @@
 {
     "method": "GET",
-    "url": "{{endpoint}}/integrationServices/v3/event?searchWindow=1d&rows=1",
+    "url": "{{endpoint}}/integrationServices/v3/auditlogs?rows=0",
     "headers": {
         "X-Auth-Token": "{{secret}}/{{client_id}}"
     },


### PR DESCRIPTION
### Problem Description
CarbonBlack credential validation fails due to deprecated `/events` endpoint

### Solution Description
Update CB endpoint we use for credential validation