### PR TITLE
CiscoAMP collector[1.0.34] : Refactor the code for Event stream and Throttle Error

### DIFF
--- a/collectors/ciscoamp/collector.js
+++ b/collectors/ciscoamp/collector.js
@@ -23,6 +23,7 @@ let typeIdPaths = [];
 let tsPaths = [];
 
 const Events = 'Events';
+const API_THROTTLING_ERROR = 429;
 
 class CiscoampCollector extends PawsCollector {
     constructor(context, creds) {
@@ -110,7 +111,7 @@ class CiscoampCollector extends PawsCollector {
             }).catch((error) => {
                 const errResponse = typeof error !== 'string' ? error.response : null;
 
-                if (errResponse && errResponse.body.errors[0].error_code == 429) {
+                if (errResponse && errResponse.body.errors[0].error_code === API_THROTTLING_ERROR) {
                     const rateLimitResetSecs = parseInt(errResponse['headers']['x-ratelimit-reset']);
                     const extraBufferSeconds = 60;
                     const resetSeconds = rateLimitResetSecs + extraBufferSeconds;

--- a/collectors/ciscoamp/collector.js
+++ b/collectors/ciscoamp/collector.js
@@ -120,7 +120,7 @@ class CiscoampCollector extends PawsCollector {
                     state.poll_interval_sec = resetSeconds;
                     // Reduce time interval to half till 60 sec and try to fetch data again.
                     const currentInterval = moment(state.until).diff(state.since, 'seconds');
-                    if (currentInterval > 60) {
+                    if (currentInterval > 120) {
                         state.until = moment(state.since).add(Math.ceil(currentInterval / 2), 'seconds').toISOString();
                     }
                     collector.reportApiThrottling(function () {

--- a/collectors/ciscoamp/collector.js
+++ b/collectors/ciscoamp/collector.js
@@ -92,67 +92,46 @@ class CiscoampCollector extends PawsCollector {
         let apiUrl = state.nextPage ? state.nextPage : resourceDetails.url;
 
         AlLogger.info(`CAMP000001 Collecting data for ${state.stream} from ${state.since} till ${state.until}`);
-
-        if (state.apiQuotaResetDate && moment().isBefore(state.apiQuotaResetDate)) {
-            AlLogger.info(`CAMP000002 API hourly Limit Exceeded. The quota will be reset at ${state.apiQuotaResetDate}`);
-            state.poll_interval_sec = 900;
-            // Reduce time interval to half till 60 sec and try to fetch data again.
-            const currentInterval = moment(state.until).diff(state.since, 'seconds');
-            if (currentInterval > 60) {
-                state.until = moment(state.since).add(Math.ceil(currentInterval / 2), 'seconds').toISOString();
-            }
-            collector.reportApiThrottling(function () {
-                return callback(null, [], state, state.poll_interval_sec);
-            });
-        }
-        else {
-
         utils.getAPILogs(baseUrl, base64EncodedString, apiUrl, state, [], process.env.paws_max_pages_per_invocation)
-            .then(({ accumulator, nextPage, resetSeconds, totalLogsCount, discardFlag }) => {
-                if (resetSeconds) {
-                    const extraBufferSeconds = 60;
-                    resetSeconds = resetSeconds + extraBufferSeconds;
-                    state.apiQuotaResetDate = moment().add(resetSeconds, "seconds").toISOString();
-                    AlLogger.info(`CAMP000003 API hourly Limit Exceeded. The quota will be reset at ${state.apiQuotaResetDate}`);
+            .then(({ accumulator, nextPage, newSince }) => {
+                state.apiQuotaResetDate = null;
+                if (!nextPage && state.stream == Events && newSince) {
+                    state.until = moment(newSince).toISOString();
                 }
-                else {
-                    state.apiQuotaResetDate = null;
-                }
-                if (discardFlag && state.stream === Events) {
 
-                    if (state.totalLogsCount === 0) {
-                        return callback(null, accumulator, state, state.poll_interval_sec);
-                    }
-                    const searchParams = querystring.parse(state.nextPage);
-                    let offset = searchParams.offset;
-
-                    offset = (parseInt(totalLogsCount) - parseInt(state.totalLogsCount)) + parseInt(offset);
-                    searchParams.offset = offset;
-
-                    let newOffsetURL = "";
-                    Object.entries(searchParams).forEach(([key, value]) => {
-                        newOffsetURL = newOffsetURL + (newOffsetURL === "" ? `${key}=${value}` : `&${key}=${value}`);
-                    });
-
-                    state.totalLogsCount = totalLogsCount;
-                    state.nextPage = newOffsetURL;
-
-                    return callback(null, accumulator, state, state.poll_interval_sec);
-                }
                 let newState;
                 if (nextPage === undefined) {
                     newState = this._getNextCollectionState(state);
                 } else {
-                    newState = this._getNextCollectionStateWithNextPage(state, nextPage, totalLogsCount);
+                    newState = this._getNextCollectionStateWithNextPage(state, nextPage, accumulator.length);
                 }
                 AlLogger.info(`CAMP000004 Next collection in ${newState.poll_interval_sec} seconds`);
                 return callback(null, accumulator, newState, newState.poll_interval_sec);
             }).catch((error) => {
-                // set errorCode if not available in error object to showcase client error on DDMetric
-                error.errorCode = error.statusCode;
-                return callback(error);
+                const errResponse = typeof error !== 'string' ? error.response : null;
+
+                if (errResponse && errResponse.body.errors[0].error_code == 429) {
+                    const rateLimitResetSecs = parseInt(errResponse['headers']['x-ratelimit-reset']);
+                    const extraBufferSeconds = 60;
+                    const resetSeconds = rateLimitResetSecs + extraBufferSeconds;
+                    state.apiQuotaResetDate = moment().add(resetSeconds, "seconds").toISOString();
+                    AlLogger.info(`CAMP000003 API hourly Limit Exceeded. The quota will be reset at ${state.apiQuotaResetDate}`);
+                    state.poll_interval_sec = resetSeconds;
+                    // Reduce time interval to half till 60 sec and try to fetch data again.
+                    const currentInterval = moment(state.until).diff(state.since, 'seconds');
+                    if (currentInterval > 60) {
+                        state.until = moment(state.since).add(Math.ceil(currentInterval / 2), 'seconds').toISOString();
+                    }
+                    collector.reportApiThrottling(function () {
+                        return callback(null, [], state, state.poll_interval_sec);
+                    });
+                }
+                else {
+                    // set errorCode if not available in error object to showcase client error on DDMetric    
+                    error.errorCode = errResponse && errResponse.body ? errResponse.body.errors[0].error_code : error.statusCode;
+                    return callback(error);
+                }
             });
-        }
     }
 
     _getNextCollectionState(curState) {

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoamp/test/ciscoamp_mock.js
+++ b/collectors/ciscoamp/test/ciscoamp_mock.js
@@ -31,6 +31,7 @@ const LOG_EVENT = {
     audit_log_id: 'b72fd5c0-1ec8-4b7a-b5aa-a500e64635f4',
     audit_log_user: '16db5cf986eec6f44422',
     created_at: '2020-04-20T05:30:18Z',
+    date: "2022-09-27T04:52:54+00:00",
     old_attributes:
     {
         name: null,

--- a/collectors/ciscoamp/test/ciscoamp_test.js
+++ b/collectors/ciscoamp/test/ciscoamp_test.js
@@ -149,7 +149,7 @@ describe('Unit Tests', function () {
             getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
                 function fakeFn(baseUrl, authorization, apiUrl, accumulator, maxPagesPerInvocation) {
                     return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [ciscoampMock.LOG_EVENT, ciscoampMock.LOG_EVENT], nextPage: "nextPageUrl", newSince: ciscoampMock.LOG_EVENT.date });
+                        return resolve({ accumulator: [ciscoampMock.LOG_EVENT, ciscoampMock.LOG_EVENT], nextPage: "nextPageUrl", newSince: undefined });
                     });
                 });
             getAPIDetails = sinon.stub(utils, 'getAPIDetails').callsFake(

--- a/collectors/ciscoamp/test/ciscoamp_test.js
+++ b/collectors/ciscoamp/test/ciscoamp_test.js
@@ -149,7 +149,7 @@ describe('Unit Tests', function () {
             getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
                 function fakeFn(baseUrl, authorization, apiUrl, accumulator, maxPagesPerInvocation) {
                     return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [ciscoampMock.LOG_EVENT, ciscoampMock.LOG_EVENT], nextPage: "nextPage", resetSeconds: 1000 });
+                        return resolve({ accumulator: [ciscoampMock.LOG_EVENT, ciscoampMock.LOG_EVENT], nextPage: "nextPageUrl", newSince: ciscoampMock.LOG_EVENT.date });
                     });
                 });
             getAPIDetails = sinon.stub(utils, 'getAPIDetails').callsFake(
@@ -164,7 +164,7 @@ describe('Unit Tests', function () {
                 var collector = new CiscoampCollector(ctx, creds, 'ciscoamp');
                 const startDate = moment().subtract(3, 'days');
                 const curState = {
-                    resource: "AuditLogs",
+                    stream: "AuditLogs",
                     since: startDate.toISOString(),
                     until: startDate.add(2, 'days').toISOString(),
                     nextPage: "nextPageUrl",
@@ -175,53 +175,19 @@ describe('Unit Tests', function () {
                 collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
                     assert.equal(logs.length, 2);
                     assert.equal(newState.poll_interval_sec, 1);
-                    assert.notEqual(newState.apiQuotaResetDate, null);
+                    assert.equal(newState.apiQuotaResetDate, null);
                     assert.ok(logs[0].audit_log_id);
                     done();
                 });
 
             });
         });
-        it('Paws Get Logs Success with Events discard Flag True', function (done) {
+        it('Paws Get Logs Success with Events and nextPage value is null', function (done) {
+            ciscoampMock.LOG_EVENT.date = moment();
             getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
                 function fakeFn(baseUrl, authorization, apiUrl, accumulator, maxPagesPerInvocation) {
                     return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [], nextPage: null, resetSeconds: null, totalLogsCount: 100, discardFlag: true });
-                    });
-                });
-            getAPIDetails = sinon.stub(utils, 'getAPIDetails').callsFake(
-                function fakeFn(state) {
-                    return {
-                        url: "api_url",
-                        typeIdPaths: [{ path: ["id"] }],
-                        tsPaths: [{ path: ["date"] }]
-                    };
-                });
-            CiscoampCollector.load().then(function (creds) {
-                var collector = new CiscoampCollector(ctx, creds, 'ciscoamp');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    resource: "Events",
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: null,
-                    totalLogsCount: 0,
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(logs.length, 0);
-                    assert.equal(newState.poll_interval_sec, 1);
-                    done();
-                });
-
-            });
-        });
-        it('Paws Get Logs Success with Events with Events discard Flag True and nextPage value is not null', function (done) {
-            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
-                function fakeFn(baseUrl, authorization, apiUrl, accumulator, maxPagesPerInvocation) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [], nextPage: "/v1/events?start_date=2020-04-01T00%3A00%3A00Z&limit=2&offset=4", resetSeconds: null, totalLogsCount: 100, discardFlag: true });
+                        return resolve({ accumulator: [ciscoampMock.LOG_EVENT, ciscoampMock.LOG_EVENT], nextPage: undefined, newSince: ciscoampMock.LOG_EVENT.date });
                     });
                 });
             getAPIDetails = sinon.stub(utils, 'getAPIDetails').callsFake(
@@ -239,44 +205,82 @@ describe('Unit Tests', function () {
                     stream: "Events",
                     since: startDate.toISOString(),
                     until: startDate.add(2, 'days').toISOString(),
-                    nextPage: "/v1/events?start_date=2020-04-01T00%3A00%3A00Z&limit=2&offset=2",
+                    nextPage: null,
                     apiQuotaResetDate: null,
-                    totalLogsCount: 50,
+                    totalLogsCount: 0,
                     poll_interval_sec: 1
                 };
                 collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(logs.length, 0);
-                    assert.equal(newState.nextPage, "/v1/events?start_date=2020-04-01T00:00:00Z&limit=2&offset=52");
-                    assert.equal(newState.poll_interval_sec, 1);
+                    assert.equal(logs.length, 2);
+                    assert.equal(newState.poll_interval_sec, newPollInterval);
+                    assert.equal(newState.nextPage, null);
+                    // checked  if nextpage is null then set since value from received data
+                    assert.equal(newState.since, moment(ciscoampMock.LOG_EVENT.date).toISOString());
                     done();
                 });
 
             });
         });
-        it('Paws Get Logs with API Quota Reset Date', function (done) {
+        
+        it('Paws Get Logs with throttle error and set apiQuotaResetDate', function (done) {
+            let errorObj = {
+                statusCode: 429,
+                response: {
+                    body: {
+                        version: null,
+                        data: {},
+                        errors: [
+                            {
+                                error_code: 429,
+                                description: "RateLimitExceed",
+                                details: [
+                                    "API hourly Limit Exceeded"
+                                ]
+                            }
+                        ]
+                    },
+                    headers: {
+                        "x-ratelimit-limit": "200",
+                        "x-ratelimit-reset": "59"
+                    }
+                }
+            };
+
+            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
+                function fakeFn(baseUrl, authorization, apiUrl, accumulator, maxPagesPerInvocation) {
+                    return new Promise(function (resolve, reject) {
+                        return reject(errorObj);
+                    });
+                });
+            getAPIDetails = sinon.stub(utils, 'getAPIDetails').callsFake(
+                function fakeFn(state) {
+                    return {
+                        url: "api_url",
+                        typeIdPaths: [{ path: ["id"] }],
+                        tsPaths: [{ path: ["date"] }]
+                    };
+                });
             CiscoampCollector.load().then(function (creds) {
                 var collector = new CiscoampCollector(ctx, creds, 'ciscoamp');
                 const startDate = moment().subtract(3, 'days');
                 const curState = {
-                    stream: "AuditLogs",
+                    stream: "Events",
                     since: startDate.toISOString(),
                     until: startDate.add(2, 'days').toISOString(),
-                    nextPage: "nextPageUrl",
-                    apiQuotaResetDate: moment().add(1000, 'seconds').toISOString(),
+                    nextPage: null,
+                    apiQuotaResetDate: null,
                     totalLogsCount: 0,
-                    poll_interval_sec: 900
+                    poll_interval_sec: 1
                 };
-
                 var reportSpy = sinon.spy(collector, 'reportApiThrottling');
-
                 collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
+                    assert.equal(err, null);
                     assert.equal(true, reportSpy.calledOnce);
                     assert.equal(logs.length, 0);
-                    assert.equal(moment(newState.until).diff(newState.since, 'days'), 1);
-                    assert.equal(newState.poll_interval_sec, 900);
+                    assert.notEqual(newState.apiQuotaResetDate, null);
+                    assert.equal(newState.poll_interval_sec, newPollInterval);
                     done();
                 });
-
             });
         });
         it('Get client error', function (done) {

--- a/collectors/ciscoamp/utils.js
+++ b/collectors/ciscoamp/utils.js
@@ -32,8 +32,11 @@ function getAPILogs(baseUrl, authorization, apiUrl, state, accumulator, maxPages
                     }
                     else {
                         if (state.stream === Events && accumulator.length > 0) {
-                            //Api return the data in desending order, so set new start date fom first record.
-                            newSince = accumulator[0].date;
+                            // Api return the data in desending order, so set new start date form first record if not available pull date from fallup records.
+                            newSince = accumulator[0].date ? accumulator[0].date : accumulator[1].date ? accumulator[1].date : accumulator[2].date;
+                            if (!newSince) {
+                                reject(`CAMP000005 Date is not available in Events api response`);
+                            }
                         }
                         resolve({ accumulator, nextPage: undefined, newSince });
                     }

--- a/collectors/ciscoamp/utils.js
+++ b/collectors/ciscoamp/utils.js
@@ -7,9 +7,7 @@ const Events = 'Events';
 function getAPILogs(baseUrl, authorization, apiUrl, state, accumulator, maxPagesPerInvocation) {
     let pageCount = 0;
     let nextPage;
-    let resetSeconds = null;
-    let totalLogsCount = state.totalLogsCount;
-    let discardFlag = false;
+    let newSince = null;
 
     let restServiceClient = new RestServiceClient(baseUrl);
 
@@ -22,31 +20,22 @@ function getAPILogs(baseUrl, authorization, apiUrl, state, accumulator, maxPages
                         "authorization": `Basic ${authorization}`
                     },
                     resolveWithFullResponse: true
-                }).then(({ headers, body }) => {
+                }).then(({ body }) => {
                     pageCount++;
-                    if (parseInt(headers['x-ratelimit-remaining']) < 200) {
-                        resetSeconds = parseInt(headers['x-ratelimit-reset']);
+
+                    if (body.data) {
+                        accumulator.push(...body.data);
                     }
-                    if (state.stream === Events && totalLogsCount !== 0 && totalLogsCount !== body.metadata.results.total) {
-                        discardFlag = true;
-                        totalLogsCount = body.metadata.results.total;
-                        resolve({ accumulator: [], nextPage, resetSeconds, totalLogsCount, discardFlag });
+                    if (body.metadata.links.next) {
+                        apiUrl = url.parse(body.metadata.links.next).path;
+                        getData();
                     }
                     else {
-                        if (state.stream === Events && totalLogsCount === 0) {
-                            //This condition works when first time call 
-                            totalLogsCount = body.metadata.results.total;
+                        if (state.stream === Events && accumulator.length > 0) {
+                            //Api return the data in desending order, so set new start date fom first record.
+                            newSince = accumulator[0].date;
                         }
-                        if (body.data) {
-                            accumulator.push(...body.data);
-                        }
-                        if (body.metadata.links.next) {
-                            apiUrl = url.parse(body.metadata.links.next).path;
-                            getData();
-                        }
-                        else {
-                            resolve({ accumulator, nextPage, resetSeconds, totalLogsCount, discardFlag });
-                        }
+                        resolve({ accumulator, nextPage, newSince });
                     }
                 }).catch(err => {
                     reject(err);
@@ -54,7 +43,7 @@ function getAPILogs(baseUrl, authorization, apiUrl, state, accumulator, maxPages
             }
             else {
                 nextPage = apiUrl;
-                resolve({ accumulator, nextPage, resetSeconds, totalLogsCount, discardFlag });
+                resolve({ accumulator, nextPage, newSince });
             }
         }
     });

--- a/collectors/ciscoamp/utils.js
+++ b/collectors/ciscoamp/utils.js
@@ -35,7 +35,7 @@ function getAPILogs(baseUrl, authorization, apiUrl, state, accumulator, maxPages
                             //Api return the data in desending order, so set new start date fom first record.
                             newSince = accumulator[0].date;
                         }
-                        resolve({ accumulator, nextPage, newSince });
+                        resolve({ accumulator, nextPage: undefined, newSince });
                     }
                 }).catch(err => {
                     reject(err);
@@ -43,7 +43,7 @@ function getAPILogs(baseUrl, authorization, apiUrl, state, accumulator, maxPages
             }
             else {
                 nextPage = apiUrl;
-                resolve({ accumulator, nextPage, newSince });
+                resolve({ accumulator, nextPage, newSince: undefined });
             }
         }
     });


### PR DESCRIPTION
### Problem Description

1. Customer having CiscoAMP collector and its Event stream not moving collection windows(lacking behind almost 1 and half month)

Root Cause :

-  When we make the api call for particular timestamp(`Events from 2022-07-30T00:00:00.000Z till 2022-07-30T00:00:57.000Z`),every time total log counts are different for same time interval. As per previous code we are discarding the logs if it not match with previous count stored in state object. So collection window not get updated .

 "results": {
            **"total": 131625,**
            "current_item_count": 500,
            "index": 500,
            "items_per_page": 500
        }


### Solution Description

1. Cisco AMP API only have startDate (https://api.amp.cisco.com/v1/events?**start_date**=2022-09-19T00%3A00%3A00.000Z) and not end time stand, so total count will vary. APIs return the data in descending order by default . Handle how to start next collection as below

- If Api return next link value in metadata use for next collection .
- Else pick the date from first logs message and set new start value.

"links": {
            "self": "https://api.amp.cisco.com/v1/events?start_date=2022-09-19T00%3A00%3A00.000Z&offset=500",
            "prev": "https://api.amp.cisco.com/v1/events?start_date=2022-09-19T00%3A00%3A00.000Z&offset=0",
            "next": "https://api.amp.cisco.com/v1/events?start_date=2022-09-19T00%3A00%3A00.000Z&offset=1000"
        },

2. Also Handle the RateLimit error properly.