### PR TITLE
[Cisco Duo collector] Increase the poll Interval secs from 1 to 60 sec

### DIFF
--- a/collectors/ciscoduo/collector.js
+++ b/collectors/ciscoduo/collector.js
@@ -140,13 +140,13 @@ class CiscoduoCollector extends PawsCollector {
             const untilMoment = moment(parseInt(curState.maxtime));
              // Used hour-cap instead of making api call for 1 min interval, may help to reduce throtling issue.
             const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-cap', untilMoment, this.pollInterval);
-
+            const nextPollIntervalSec = nextPollInterval > 1 ? nextPollInterval : 60;
             return {
                 stream: curState.stream,
                 mintime: nextSinceMoment.valueOf(),
                 maxtime: nextUntilMoment.valueOf(),
                 nextPage: null,
-                poll_interval_sec: nextPollInterval
+                poll_interval_sec: nextPollIntervalSec
             };
         }
         else {

--- a/collectors/ciscoduo/collector.js
+++ b/collectors/ciscoduo/collector.js
@@ -140,7 +140,7 @@ class CiscoduoCollector extends PawsCollector {
             const untilMoment = moment(parseInt(curState.maxtime));
              // Used hour-cap instead of making api call for 1 min interval, may help to reduce throtling issue.
             const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-cap', untilMoment, this.pollInterval);
-            const nextPollIntervalSec = nextPollInterval > 1 ? nextPollInterval : 60;
+            const nextPollIntervalSec = nextPollInterval >= 60 ? nextPollInterval : 60;
             return {
                 stream: curState.stream,
                 mintime: nextSinceMoment.valueOf(),

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoduo/test/ciscoduo_test.js
+++ b/collectors/ciscoduo/test/ciscoduo_test.js
@@ -135,7 +135,7 @@ describe('Unit Tests', function () {
                 };
                 collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
                     assert.equal(logs.length, 2);
-                    assert.equal(newState.poll_interval_sec, 1);
+                    assert.equal(newState.poll_interval_sec, 60);
                     assert.ok(logs[0].txid);
                     getAPILogs.restore();
                     getAPIDetails.restore();
@@ -320,7 +320,7 @@ describe('Unit Tests', function () {
                     poll_interval_sec: 1
                 };
                 let nextState = collector._getNextCollectionState(curState);
-                 assert.equal(nextState.poll_interval_sec, 1);
+                 assert.equal(nextState.poll_interval_sec, 60);
                 assert.equal(moment(parseInt(nextState.maxtime)).diff(parseInt(nextState.mintime), 'minutes'), 60);
                 done();
             });


### PR DESCRIPTION
### Problem Description
Customer still able to see a couple of Rate limit error in every 15 min.
{
    "code": 42901,
    "level": "warn",
    "message": "CDUO000003 API Request Limit Exceeded Too Many Requests",
    "requestId": "8113cfaf-1017-5472-934f-94007e9d9c91",
    "stat": "FAIL",
    "timestamp": "2022-09-29T09:59:48.937Z"
}


RootCouse:
If collector is lacking behind more than 15 min it will make a api call every secs.

### Solution Description
AS per [doc](https://duo.com/docs/adminapi#authentication-logs)(`We recommend requesting logs no more than once per minute`.)  i.e make api call one pr minutes .
So updated the poll interval sec to 60sec from 1sec.
 
