### PR TITLE
Add collector id as hostname into o365

### DIFF
--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -220,6 +220,7 @@ class O365Collector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'O365Collector',

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.46",
+  "version": "1.2.47",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,


### PR DESCRIPTION
### Solution Description
Include `hostname` as `collector_id` into log messages in order to make incident deployment resolution work.
