### PR TITLE
Add collector id as Hostname in Okta collector

### DIFF
--- a/collectors/okta/okta_collector.js
+++ b/collectors/okta/okta_collector.js
@@ -116,6 +116,7 @@ class OktaCollector extends PawsCollector {
         sensitiveFields.forEach((path) => this.redactValue(path, msg));
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'OktaCollector',

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,


### PR DESCRIPTION
### Solution Description
Include `hostname` as `collector_id` into log messages in order to make incident deployment resolution work.
