### PR TITLE
Configure the DLQ in SQS for new deployed collectors

### DIFF
--- a/cfn/paws-collector-shared.template
+++ b/cfn/paws-collector-shared.template
@@ -167,6 +167,10 @@
         "ExistingControlSnsArn" :{
             "Description": "SNS topic ARN used for triggering collector checkins an updates",
             "Type": "String"
+        },
+        "ExistingDeadLetterQueueArn":{
+            "Description": "Dead-letter queue to collect failed message",
+            "Type": "String"
         }
     },
     "Resources":{
@@ -248,20 +252,7 @@
             "MessageRetentionPeriod": 1209600,
             "RedrivePolicy": {
                 "deadLetterTargetArn": {
-                    "Fn::Join": [
-                        "",
-                        [
-                            "arn:aws:sqs:",
-                            {
-                                "Ref": "AWS::Region"
-                            },
-                            ":",
-                            {
-                                "Ref": "AWS::AccountId"
-                            },
-                            ":Paws-shared-deadLetterQueue"
-                        ]
-                    ]
+                    "Ref": "ExistingDeadLetterQueueArn"
                 },
                 "maxReceiveCount": 10
             },

--- a/cfn/paws-collector-shared.template
+++ b/cfn/paws-collector-shared.template
@@ -254,7 +254,7 @@
                 "deadLetterTargetArn": {
                     "Ref": "ExistingDeadLetterQueueArn"
                 },
-                "maxReceiveCount": 10
+                "maxReceiveCount": 3
             },
             "Tags": [
                 {

--- a/cfn/paws-collector-shared.template
+++ b/cfn/paws-collector-shared.template
@@ -246,6 +246,25 @@
          "Properties":{
             "VisibilityTimeout": 900,
             "MessageRetentionPeriod": 1209600,
+            "RedrivePolicy": {
+                "deadLetterTargetArn": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:aws:sqs:",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            ":",
+                            {
+                                "Ref": "AWS::AccountId"
+                            },
+                            ":Paws-shared-deadLetterQueue"
+                        ]
+                    ]
+                },
+                "maxReceiveCount": 10
+            },
             "Tags": [
                 {
                     "Key": "QueueName",

--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -144,6 +144,11 @@
             "Type": "String",
             "Default": "true",
             "AllowedValues":["true"]
+        },
+        "ExistingDeadLetterQueueArn":{
+            "Description": "Dead-letter queue to collect failed message",
+            "Type": "String",
+            "Default": ""
         }
     },
     "Conditions":{
@@ -687,20 +692,7 @@
             "MessageRetentionPeriod": 1209600,
             "RedrivePolicy": {
                 "deadLetterTargetArn": {
-                    "Fn::Join": [
-                        "",
-                        [
-                            "arn:aws:sqs:",
-                            {
-                                "Ref": "AWS::Region"
-                            },
-                            ":",
-                            {
-                                "Ref": "AWS::AccountId"
-                            },
-                            ":Paws-shared-deadLetterQueue"
-                        ]
-                    ]
+                    "Ref": "ExistingDeadLetterQueueArn"
                 },
                 "maxReceiveCount": 10
             },

--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -685,6 +685,25 @@
          "Properties":{
             "VisibilityTimeout": 900,
             "MessageRetentionPeriod": 1209600,
+            "RedrivePolicy": {
+                "deadLetterTargetArn": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:aws:sqs:",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            ":",
+                            {
+                                "Ref": "AWS::AccountId"
+                            },
+                            ":Paws-shared-deadLetterQueue"
+                        ]
+                    ]
+                },
+                "maxReceiveCount": 10
+            },
             "Tags": [
                 {
                     "Key": "QueueName",

--- a/cfn/paws-collector.template
+++ b/cfn/paws-collector.template
@@ -144,11 +144,6 @@
             "Type": "String",
             "Default": "true",
             "AllowedValues":["true"]
-        },
-        "ExistingDeadLetterQueueArn":{
-            "Description": "Dead-letter queue to collect failed message",
-            "Type": "String",
-            "Default": ""
         }
     },
     "Conditions":{
@@ -690,12 +685,6 @@
          "Properties":{
             "VisibilityTimeout": 900,
             "MessageRetentionPeriod": 1209600,
-            "RedrivePolicy": {
-                "deadLetterTargetArn": {
-                    "Ref": "ExistingDeadLetterQueueArn"
-                },
-                "maxReceiveCount": 10
-            },
             "Tags": [
                 {
                     "Key": "QueueName",

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -686,6 +686,13 @@ class PawsCollector extends AlAwsCollector {
     };
 
     _storeCollectionState(pawsState, privCollectorState, invocationTimeout, callback) {
+        // Added extra parameter to identify the message from which collector in case it failed and went into DLQ
+        let extraParam = {
+            lambda_function_name: process.env.AWS_LAMBDA_FUNCTION_NAME,
+            customer_id: process.env.customer_id,
+            account_id: this._awsAccountId
+        };
+        pawsState = Object.assign(pawsState, extraParam);
         if (Array.isArray(privCollectorState)) {
             return this._storeCollectionStateArray(pawsState, privCollectorState, invocationTimeout, callback);
         } else {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -688,9 +688,8 @@ class PawsCollector extends AlAwsCollector {
     _storeCollectionState(pawsState, privCollectorState, invocationTimeout, callback) {
         // Added extra parameter to identify the message from which collector in case it failed and went into DLQ
         let extraParam = {
-            lambda_function_name: process.env.AWS_LAMBDA_FUNCTION_NAME,
             customer_id: process.env.customer_id,
-            account_id: this._awsAccountId
+            collector_id: this._collectorId
         };
         pawsState = Object.assign(pawsState, extraParam);
         if (Array.isArray(privCollectorState)) {


### PR DESCRIPTION
### Problem Description
Few collector facing collection delay because ingest service returning 400-'body encoding invalid'.

### Solution Description

1. Create DLQ in each region using shared resource template -https://algithub.pd.alertlogic.net/defender/paws-collectors-deploy-pipeline/pull/410

2. Map the shared dead-letter queue ARN in azcollect and set the value of ExistingDeadLetterQueueArn - https://algithub.pd.alertlogic.net/defender/azcollect/pull/257

3. Added below parameter to differentiate the DLQ message and identify the message from which collector.
- lambda_function_name
- customer_id
- account_id

4. Configured the existing DLQ for each collector using CFN template while deploying the new collector. 

5. Move the failed message to DLQ to avoid collection delay and we can investigate the data later to improve if any formatting or other issue found.
