### PR TITLE
Add collector id into formatted messages

### DIFF
--- a/collectors/auth0/auth0_collector.js
+++ b/collectors/auth0/auth0_collector.js
@@ -110,6 +110,7 @@ class Auth0Collector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'Auth0Collector',

--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.40",
+  "version": "1.1.41",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,

--- a/collectors/carbonblack/collector.js
+++ b/collectors/carbonblack/collector.js
@@ -153,6 +153,7 @@ class CarbonblackCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'CarbonblackCollector',

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoamp/collector.js
+++ b/collectors/ciscoamp/collector.js
@@ -172,6 +172,7 @@ class CiscoampCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'CiscoampCollector',

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoduo/collector.js
+++ b/collectors/ciscoduo/collector.js
@@ -202,6 +202,7 @@ class CiscoduoCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'CiscoduoCollector',

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/crowdstrike/collector.js
+++ b/collectors/crowdstrike/collector.js
@@ -129,6 +129,7 @@ class CrowdstrikeCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
         
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'CrowdstrikeCollector',

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/googlestackdriver/collector.js
+++ b/collectors/googlestackdriver/collector.js
@@ -192,6 +192,7 @@ timestamp < "${state.until}"`;
 
         let formattedMsg = {
             // TODO: figure out if this TS is always a string or if they API is goofy...
+            hostname: collector.collector_id,
             messageTs: parseInt(ts.seconds),
             priority: 11,
             progName: 'GooglestackdriverCollector',

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.1.42",
+  "version": "1.1.43",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/gsuite/collector.js
+++ b/collectors/gsuite/collector.js
@@ -177,6 +177,7 @@ class GsuiteCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: "GsuiteCollector",

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.35",
+  "version": "1.2.36",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/mimecast/collector.js
+++ b/collectors/mimecast/collector.js
@@ -189,6 +189,7 @@ class MimecastCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'MimecastCollector',

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/salesforce/collector.js
+++ b/collectors/salesforce/collector.js
@@ -210,6 +210,7 @@ class SalesforceCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'SalesforceCollector',

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.39",
+  "version": "1.1.40",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sentinelone/collector.js
+++ b/collectors/sentinelone/collector.js
@@ -108,6 +108,7 @@ class SentineloneCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'SentineloneCollector',

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sophos/collector.js
+++ b/collectors/sophos/collector.js
@@ -169,6 +169,7 @@ class SophosCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'SophosCollector',

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sophossiem/collector.js
+++ b/collectors/sophossiem/collector.js
@@ -177,6 +177,7 @@ class SophossiemCollector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
 
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: 'SophossiemCollector',

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/template/collector.js.template
+++ b/collectors/template/collector.js.template
@@ -83,6 +83,7 @@ class {{Type}}Collector extends PawsCollector {
         const typeId = parse.getMsgTypeId(msg, typeIdPaths);
         
         let formattedMsg = {
+            hostname: collector.collector_id,
             messageTs: ts.sec,
             priority: 11,
             progName: '{{Type}}Collector',


### PR DESCRIPTION
### Solution Description
Include `hostname` as `collector_id` into log messages in order to make incident deployment resolution work.