### PR TITLE
Upload the body encoding invalid data to s3 bucket and collector continue for next collection without any delay

### DIFF
--- a/cfn/paws-collector-shared.template
+++ b/cfn/paws-collector-shared.template
@@ -167,6 +167,10 @@
         "ExistingControlSnsArn" :{
             "Description": "SNS topic ARN used for triggering collector checkins an updates",
             "Type": "String"
+        },
+        "ExistingDLS3BucketArn": {
+            "Description": "Bucket that contains incorrect data rejected by Ingest service.",
+            "Type": "String"
         }
     },
     "Resources":{
@@ -393,6 +397,9 @@
                   },
                   "ssm_direct": {
                     "Ref": "SsmDirect"
+                },
+                "dl_s3_bucket_name": {
+                    "Ref": "ExistingDLS3BucketArn"
                 }
                }
             },

--- a/cfn/paws-collector-shared.template
+++ b/cfn/paws-collector-shared.template
@@ -168,7 +168,7 @@
             "Description": "SNS topic ARN used for triggering collector checkins an updates",
             "Type": "String"
         },
-        "ExistingDLS3BucketArn": {
+        "ExistingDLS3BucketName": {
             "Description": "Bucket that contains incorrect data rejected by Ingest service.",
             "Type": "String"
         }
@@ -399,7 +399,7 @@
                     "Ref": "SsmDirect"
                 },
                 "dl_s3_bucket_name": {
-                    "Ref": "ExistingDLS3BucketArn"
+                    "Ref": "ExistingDLS3BucketName"
                 }
                }
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.9",
+    "@alertlogic/al-aws-collector-js": "4.1.10",
     "datadog-lambda-js": "2.23.0",
     "async": "3.2.2",
     "debug": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "yargs": "^15.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.10",
+    "@alertlogic/al-aws-collector-js": "4.1.14",
     "datadog-lambda-js": "2.23.0",
     "async": "3.2.2",
     "debug": "4.1.1",

--- a/test/paws_mock.js
+++ b/test/paws_mock.js
@@ -22,6 +22,7 @@ process.env.paws_secret_param_name = 'PAWS-SECRET-paws';
 process.env.paws_api_client_id = 'api-client-id';
 process.env.al_application_id = 'paws';
 process.env.paws_ddb_table_name = 'asampletable';
+process.env.dl_s3_bucket_name = 'dl_s3_bucket';
 
 const AIMS_TEST_CREDS = {
     access_key_id: 'test-access-key-id',

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -835,8 +835,8 @@ describe('Unit Tests', function() {
                     return callback(ingestError);
                 });
 
-            let uploadS3ObjectMock = sinon.stub(m_al_aws.Util.prototype, 'uploadS3Object').callsFake(
-                function fakeFn(messages, formatFun, hostmetaElems, callback) {
+            let uploadS3ObjectMock = sinon.stub(m_al_aws.Util, 'uploadS3Object').callsFake(
+                function fakeFn(params, callback) {
                     return callback(null);
                 });
 


### PR DESCRIPTION
Problem Description
Few collector facing collection delay because ingest service returning 400-'body encoding invalid'.

### Solution Description
If ingest return body encoding invalid error then collector store the data in s3 bucket and allow collector to collect data for next collection window.

- This will help collector to avoid collection delay .
- We can also analyse the data later and accordingly we can take action if need.

Code changes :

1. Created new s3 bucket  to upload the file and Required write permission to upload/add file in s3 bucket. Added permission in alertlogic-collector-lambda-policy  of paws shared resources template. Reference [pr paws-collectors-deployment-pipeline](https://algithub.pd.alertlogic.net/defender/paws-collectors-deploy-pipeline/pull/413)
2. Mapped the dlS3bucket ARN in azcollect- https://algithub.pd.alertlogic.net/defender/azcollect/pull/257
3. Function to add the file in s3 bucket . Reference [pr al-aws-collector.js lib
 ](https://github.com/alertlogic/al-aws-collector-js/pull/87)
4. Extract the http error Code from ingest error message - Reference [pr al-aws-collector.js lib](https://github.com/alertlogic/al-aws-collector-js/pull/88)
5. Base on httpErrorCode and error message , if it body encoding invalid error then upload the data in s3 bucket and move the collection window.

