### PR TITLE
Used httpErrorCode to show actual error on Ingest metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -629,10 +629,10 @@ class PawsCollector extends AlAwsCollector {
             Namespace: 'PawsCollectors'
         };
         let errorCode = 'unknown';
-        if (error && error.errorCode) {
+        if (error && error.httpErrorCode) {
+            errorCode = error.httpErrorCode;
+        } else if (error && error.errorCode) {
             errorCode = error.errorCode;
-        } else if (error && error.statusCode) {
-            errorCode = error.statusCode;
         }
         this.reportDDMetric("ingest_api", 1, [`result:error`, `error_code:${errorCode}`]);
         return cloudwatch.putMetricData(params, callback);


### PR DESCRIPTION
Currently PawsIngestApi metrics showing errorCode : 'unknown` for All PAWS collectors.

Solution Description
Extracting the http status code from ingest message and sending to PawsIngestApi . It help to check which all ingest error collector getting. [extract error code from ingest error message](https://github.com/alertlogic/al-aws-collector-js/pull/88)