### PR TITLE
[All PAWS Collectors]Bump the package version to handle collection delay due to ingest bad encoding error

### DIFF
--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.41",
+  "version": "1.1.42",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "auth0": "2.27.1",
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "make": "^0.8.1",

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "@duosecurity/duo_api": "1.2.1",
     "async": "3.2.2",
     "debug": "4.1.1",

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.1.43",
+  "version": "1.1.44",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "@google-cloud/logging": "6.0.0",
     "async": "3.2.2",
     "debug": "4.1.1",

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
     "moment": "2.29.2"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "googleapis": "39.2.0",

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "adm-zip": "0.5.9",
     "async": "3.2.2",
     "debug": "4.1.1",

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.48",
+  "version": "1.2.49",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -19,9 +19,9 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.9",
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-aws-collector-js": "4.1.14",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "@azure/ms-rest-azure-js": "2.0.1",
     "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-nodeauth": "3.1.1",

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@okta/okta-sdk-nodejs": "4.1.0",
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.40",
+  "version": "1.1.41",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "jsforce": "^1.9.3",

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -21,8 +21,8 @@
     "mockserver": "^3.1.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.4",
-    "@alertlogic/paws-collector": "^2.1.10",
+    "@alertlogic/al-collector-js": "^3.0.5",
+    "@alertlogic/paws-collector": "^2.1.12",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"


### PR DESCRIPTION
- Upload the body encoding invalid data to s3 bucket and collector continue for next collection without any delay.[pr](https://github.com/alertlogic/paws-collector/pull/316)
- Used httpErrorCode to show actual error on Ingest metrics . [pr](https://github.com/alertlogic/paws-collector/pull/317)