### PR TITLE
Converted the time from second to milliseconds to get correct date and collection delay secs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -674,7 +674,7 @@ class PawsCollector extends AlAwsCollector {
     reportCollectionDelay(lastCollectedTs, callback) {
         const nowMoment = moment();
         // converting the time from seconds to milliseconds . 
-        const lastCollectedMoment = !isNaN(lastCollectedTs) && lastCollectedTs.toString().length < 13 ? moment(parseInt(lastCollectedTs * 1000))  :  moment(lastCollectedTs);
+        const lastCollectedMoment = !isNaN(lastCollectedTs) && lastCollectedTs.toString().length == 10 ? moment.unix(lastCollectedTs) : moment(lastCollectedTs);
         const delayDuration = moment.duration(nowMoment.diff(lastCollectedMoment));
         const collectionDelaySec = Math.floor(delayDuration.asSeconds());
         

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -673,7 +673,8 @@ class PawsCollector extends AlAwsCollector {
     
     reportCollectionDelay(lastCollectedTs, callback) {
         const nowMoment = moment();
-        const lastCollectedMoment = moment(lastCollectedTs);
+        // converting the time from seconds to milliseconds . 
+        const lastCollectedMoment = !isNaN(lastCollectedTs) && lastCollectedTs.toString().length < 13 ? moment(parseInt(lastCollectedTs * 1000))  :  moment(lastCollectedTs);
         const delayDuration = moment.duration(nowMoment.diff(lastCollectedMoment));
         const collectionDelaySec = Math.floor(delayDuration.asSeconds());
         


### PR DESCRIPTION
Cisco duo collector use epochs unix time stamp ,so converted it from seconds to milliseconds to get correct date and collection delay second. 