### PR TITLE
[o365 Collector] Remove the duplicate logs for o365 collector

### DIFF
--- a/collectors/o365/o365_collector.js
+++ b/collectors/o365/o365_collector.js
@@ -167,8 +167,18 @@ class O365Collector extends PawsCollector {
             } else {
                 newState = this._getNextCollectionStateWithNextPage(state, nextPage);
             }
-
-            return callback(null, logs, newState, newState.poll_interval_sec);
+            let uniqueLogs = [];
+            collector.removeDuplicatedItem(logs, "Id", (err, res) => {
+                if (err) {
+                    return callback(err);
+                }
+                else {
+                    if (res.length > 0) {
+                        uniqueLogs = [...res];
+                    }
+                    return callback(null, uniqueLogs, newState, newState.poll_interval_sec);
+                }
+            });
         }).catch(err => {
             // set errorCode to showcase client error on DDMetric
             if (typeof err === 'object') {

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.51",
+  "version": "1.2.52",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -21,7 +21,7 @@
   "dependencies": {
     "@alertlogic/al-aws-collector-js": "4.1.15",
     "@alertlogic/al-collector-js": "^3.0.5",
-    "@alertlogic/paws-collector": "^2.1.13",
+    "@alertlogic/paws-collector": "^2.1.15",
     "@azure/ms-rest-azure-js": "2.0.1",
     "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-nodeauth": "3.1.1",

--- a/collectors/o365/test/o365_mock.js
+++ b/collectors/o365/test/o365_mock.js
@@ -19,6 +19,7 @@ process.env.al_application_id = 'o365';
 process.env.paws_poll_interval = 60;
 process.env.paws_max_pages_per_invocation = 2;
 process.env.paws_poll_interval_delay = 300;
+process.env.paws_dedup_logs_ddb_table_name = 'paws_de_dup_logs_ddb';
 
 const AIMS_TEST_CREDS = {
     access_key_id: 'test-access-key-id',
@@ -27,11 +28,13 @@ const AIMS_TEST_CREDS = {
 
 const LOG_EVENT = {
     CreationTime: new Date().toISOString(),
+    Id: "c5d8e7ea-90b0-4549-9746-f67c8f6c00",
     RecordType: "MockRecordType"
 };
 
 const MOCK_LOG = {
     CreationTime: new Date().toISOString(),
+    Id: "c5d8e7ea-90b0-4549-9746-f67c8f6c00",
     RecordType: "MockRecordType"
 };
 

--- a/collectors/o365/test/o365_test.js
+++ b/collectors/o365/test/o365_test.js
@@ -381,6 +381,16 @@ describe('O365 Collector Tests', function() {
             },
             succeed : function() {}
         };
+        beforeEach(function() {
+            const putItemStub = sinon.stub().callsFake(
+                function (_params, callback) {
+                    return callback(null, { data: null });
+                });
+            AWS.mock('DynamoDB', 'putItem', putItemStub);
+        });
+        afterEach(function() {
+            AWS.restore('DynamoDB');
+        });
 
         it('Updates a stale state', function(done) {
             O365Collector.load().then(function(creds) {


### PR DESCRIPTION
### Problem Description
o365 Management Api returning duplicate log which result in duplicate incident.

### Solution Description

- AL plan to handle duplication of logs for 24 hr window by default.
- If we have to modify the window for any collector then add the `expire_ttl_hours` in ambda environment variable and set the value in hrs.

Refer the main change in paws_lib -[pr](https://github.com/alertlogic/paws-collector/pull/326)

 
