### PR TITLE
[o365 Collector]: Handle the ingest error introduce due to deduplication changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.1.15",
+  "version": "2.1.16",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -42,11 +42,10 @@ const DDB_OPTIONS = {
     maxRetries: 10,
     ConsistentRead: true
 };
-
 const DDB_DELETE_BATCH_OPTIONS = {
     maxBatchSize: 25,
     maxBatchSizeBytes: 16 * 1024 * 1024
-}
+};
 const MAX_ERROR_RETRIES = 5;
 const MAX_LOG_BATCH_SIZE = 10000;
 function getPawsParamStoreParam(){
@@ -958,8 +957,7 @@ class PawsCollector extends AlAwsCollector {
         const cid = collector.cid ? collector.cid : 'none';
         const collectorId = collector._collectorId;
         const messageHash = collector.getHash(message);
-        const itemId = `${cid}_${collectorId}_${messageHash}`;
-        return itemId;
+        return `${cid}_${collectorId}_${messageHash}`;
     }
     /**
      * Delete the ddb items in batches


### PR DESCRIPTION
### Problem Description :
Collector get the data from api and stored the data in DDB before sending to ingest. if ingest send any error then collector tried the same , again after some time ; as data is already present in DDB ,so it mark all the data as duplicate. We are loosing data here.

### Solution Description

- Delete those entry from ddb which got error from ingest service while sending `/data/logmsgs`.
- Return the original error back to collector ,so that it will add same state in SQS message to retry again for fail state.
- Change the expire_ttl_hours to seconds ,so that it easy to set value in seconds from env variable rather than converting from hr to seconds.

 
