### PR TITLE
[o365 Collector]: Updated the Paws-lib latest version in o365 collector to handle ingest error

### DIFF
--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.54",
+  "version": "1.2.55",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -21,7 +21,7 @@
   "dependencies": {
     "@alertlogic/al-aws-collector-js": "4.1.15",
     "@alertlogic/al-collector-js": "^3.0.5",
-    "@alertlogic/paws-collector": "^2.1.15",
+    "@alertlogic/paws-collector": "^2.1.16",
     "@azure/ms-rest-azure-js": "2.0.1",
     "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-nodeauth": "3.1.1",


### PR DESCRIPTION
Handle the ingest error introduce due to deduplication changes [pr](https://github.com/alertlogic/paws-collector/pull/330)