### PR TITLE
[Paws lib]: Updated the al-aws-collector.js version to send the time in milliseconds for collector_status service

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -32,7 +32,7 @@
     "yargs": "^17.6.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.16",
+    "@alertlogic/al-aws-collector-js": "4.1.17",
     "async": "^3.2.4",
     "datadog-lambda-js": "^6.85.0",
     "debug": "^4.3.4",


### PR DESCRIPTION
Set the time stamp in milliseconds to avoid 409(time conflict) error from collector_status service.https://github.com/alertlogic/al-aws-collector-js/pull/94