### PR TITLE
[Paws lib] : Encoded the stream and handle the duplication of sqs message issue due to lambda timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -32,7 +32,7 @@
     "yargs": "^17.6.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.17",
+    "@alertlogic/al-aws-collector-js": "4.1.18",
     "async": "^3.2.4",
     "datadog-lambda-js": "^6.85.0",
     "debug": "^4.3.4",

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -9,6 +9,8 @@ const pawsMock = require('./paws_mock');
 var m_alCollector = require('@alertlogic/al-collector-js');
 var PawsCollector = require('../paws_collector').PawsCollector;
 const m_al_aws = require('@alertlogic/al-aws-collector-js');
+const moment = require('moment');
+const AlLogger = require('@alertlogic/al-aws-collector-js').Logger;
 
 var alserviceStub = {};
 var responseStub = {};
@@ -583,6 +585,9 @@ describe('Unit Tests', function() {
                     sinon.assert.calledOnce(updateItemStub);
                     done();
                     
+                },
+                getRemainingTimeInMillis: function(){
+                    return 5000;
                 }
             };
 
@@ -599,6 +604,10 @@ describe('Unit Tests', function() {
                 var collector = new TestCollector(ctx, creds);
                 collector.mockGetLogsError = 'Error getting logs';
                 collector.handleEvent(testEvent);
+                // Verify that collector.done called the context succeed.
+                assert(ctx.getRemainingTimeInMillis.callCount, 1);
+                assert(AlLogger.error.calledWith(`PAWS000303 Error handling poll request: ${JSON.stringify(collector.mockGetLogsError)}`));
+                assert(ctx.succeed.calledOnce);
             });
         });
         
@@ -723,6 +732,9 @@ describe('Unit Tests', function() {
                     mockSendCollectorStatus.restore();
                     AWS.restore('CloudWatch');
                     done();
+                },
+                getRemainingTimeInMillis: function(){
+                    return moment().valueOf();
                 }
             };
             let mockSendCollectorStatus = sinon.stub(m_al_aws.AlAwsCollector.prototype, 'sendCollectorStatus').callsFake(
@@ -766,6 +778,9 @@ describe('Unit Tests', function() {
                     mockSendCollectorStatus.restore();
                     AWS.restore('CloudWatch');
                     done();
+                },
+                getRemainingTimeInMillis: function(){
+                    return moment().valueOf();
                 }
             };
             let mockSendCollectorStatus = sinon.stub(m_al_aws.AlAwsCollector.prototype, 'sendCollectorStatus').callsFake(
@@ -809,6 +824,9 @@ describe('Unit Tests', function() {
                     mockSendCollectorStatus.restore();
                     AWS.restore('CloudWatch');
                     done();
+                },
+                getRemainingTimeInMillis: function(){
+                    return moment().valueOf();
                 }
             };
             let mockSendCollectorStatus = sinon.stub(m_al_aws.AlAwsCollector.prototype, 'sendCollectorStatus').callsFake(


### PR DESCRIPTION


### Problem Description

1. Collector service return 501 error while validating url because stream contain / which is not excepted
2. If there is any error ; collector send the new SQS message and after that if it fail to exit with lambda succeed because of time constraint. Then there will be duplication of SQS message as lambda not deleted the old one.

### Solution Description
1.Encode the stream value while making the api call.
2. By default value of maxRetryTime is forever , so updating it to 3min . Refer [pr](https://github.com/alertlogic/al-aws-collector-js/pull/95)
3. Also execute the lambda context.succeed if lambda time remaining is less the 10sec.

 
