### PR TITLE
[All Paws collectors] : Bump the all package version for stream encode and handle SQS duplication.

### DIFF
--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "async": "^3.2.4",
     "auth0": "^3.1.2",
     "debug": "^4.3.4",

--- a/collectors/auth0/test/auth0_mock.js
+++ b/collectors/auth0/test/auth0_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/auth0/test/auth0_test.js
+++ b/collectors/auth0/test/auth0_test.js
@@ -33,6 +33,11 @@ function setAlServiceStub() {
                             azcollect: 'new-azcollect-endpoint'
                         };
                         break;
+                    case '/residency/default/services/collectors_status/endpoint':
+                        ret = {
+                            collector_status: 'new-collector_status-endpoint'
+                        };
+                        break;
                     default:
                         break;
                 }
@@ -51,11 +56,18 @@ function setAlServiceStub() {
                 return resolve();
             });
         });
+    alserviceStub.put = sinon.stub(m_alCollector.AlServiceC.prototype, 'put').callsFake(
+        function fakeFn(path) {
+            return new Promise(function (resolve, reject) {
+                return resolve();
+            });
+        });
 }
 
 function restoreAlServiceStub() {
     alserviceStub.get.restore();
     alserviceStub.post.restore();
+    alserviceStub.put.restore();
     alserviceStub.del.restore();
 }
 
@@ -63,10 +75,12 @@ function mockSetEnvStub() {
     setEnvStub = sinon.stub(m_al_aws, 'setEnv').callsFake((vars, callback) => {
         const {
             ingest_api,
-            azcollect_api
+            azcollect_api,
+            collector_status_api
         } = vars;
         process.env.ingest_api = ingest_api ? ingest_api : process.env.ingest_api;
         process.env.azollect_api = azcollect_api ? azcollect_api : process.env.azollect_api;
+        process.env.collector_status_api = collector_status_api ? collector_status_api : process.env.collector_status_api;
         const returnBody = {
             Environment: {
                 Varaibles: vars

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "make": "^0.8.1",

--- a/collectors/carbonblack/test/carbonblack_mock.js
+++ b/collectors/carbonblack/test/carbonblack_mock.js
@@ -2,6 +2,7 @@ process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
 process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"

--- a/collectors/ciscoamp/test/ciscoamp_mock.js
+++ b/collectors/ciscoamp/test/ciscoamp_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collectors_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "@duosecurity/duo_api": "^1.2.3",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/ciscoduo/test/ciscoduo_mock.js
+++ b/collectors/ciscoduo/test/ciscoduo_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"

--- a/collectors/crowdstrike/test/crowd-strike-mock.js
+++ b/collectors/crowdstrike/test/crowd-strike-mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.1.49",
+  "version": "1.2.0",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "@google-cloud/logging": "^10.3.3",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/googlestackdriver/test/mock.js
+++ b/collectors/googlestackdriver/test/mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.44",
+  "version": "1.2.45",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "googleapis": "^110.0.0",

--- a/collectors/gsuite/test/gsuite_mock.js
+++ b/collectors/gsuite/test/gsuite_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.paws_api_secret = 'paws-secret-key-encrypted';

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "adm-zip": "^0.5.10",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/mimecast/test/mimecast_mock.js
+++ b/collectors/mimecast/test/mimecast_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.57",
+  "version": "1.2.58",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -19,9 +19,9 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.17",
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-aws-collector-js": "4.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "@azure/ms-rest-azure-js": "2.0.1",
     "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-nodeauth": "3.1.1",

--- a/collectors/o365/test/o365_mock.js
+++ b/collectors/o365/test/o365_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.paws_api_client_id = 'a-client-id';

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "@okta/okta-sdk-nodejs": "^6.6.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/okta/test/okta_mock.js
+++ b/collectors/okta/test/okta_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.46",
+  "version": "1.1.47",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "jsforce": "^1.9.3",

--- a/collectors/salesforce/test/salesforce_mock.js
+++ b/collectors/salesforce/test/salesforce_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/sentinelone/test/sentinelone_mock.js
+++ b/collectors/sentinelone/test/sentinelone_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -21,8 +21,8 @@
     "mockserver": "^3.1.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/sophos/test/sophos_mock.js
+++ b/collectors/sophos/test/sophos_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.6",
-    "@alertlogic/paws-collector": "^2.1.18",
+    "@alertlogic/al-collector-js": "^3.0.7",
+    "@alertlogic/paws-collector": "^2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"

--- a/collectors/sophossiem/test/sophossiem_mock.js
+++ b/collectors/sophossiem/test/sophossiem_mock.js
@@ -1,7 +1,8 @@
 process.env.AWS_REGION = 'us-east-1';
 process.env.al_api = 'api.global-services.global.alertlogic.com';
 process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
+process.env.collector_status_api = 'collector_status.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';


### PR DESCRIPTION
Bump the package version for stream encode and SQS duplication due to lambda timeout . Refer [pr](https://github.com/alertlogic/paws-collector/pull/338) 