### PR TITLE
All paws collector : Bump the version to remove the ^ for al-collector.js to avoid axios changes

### DIFF
--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.48",
+  "version": "1.1.49",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "async": "^3.2.4",
     "auth0": "^3.1.2",
     "debug": "^4.3.4",

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "make": "^0.8.1",

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "@duosecurity/duo_api": "^1.2.3",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "@google-cloud/logging": "^10.3.3",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.46",
+  "version": "1.2.47",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "googleapis": "^110.0.0",

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "adm-zip": "^0.5.10",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.58",
+  "version": "1.2.59",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
   },
   "dependencies": {
     "@alertlogic/al-aws-collector-js": "4.1.18",
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "@azure/ms-rest-azure-js": "2.0.1",
     "@azure/ms-rest-js": "2.0.4",
     "@azure/ms-rest-nodeauth": "3.1.1",

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -20,8 +20,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "@okta/okta-sdk-nodejs": "^6.6.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "jsforce": "^1.9.3",

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -21,8 +21,8 @@
     "mockserver": "^3.1.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -19,8 +19,8 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.7",
-    "@alertlogic/paws-collector": "^2.1.19",
+    "@alertlogic/al-collector-js": "3.0.7",
+    "@alertlogic/paws-collector": "2.1.19",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"


### PR DESCRIPTION
### Problem Description
There is direct dependency of al-collector.js in all collector. After releasing the changes today it take latest version of al-collector-js 3.0.8 which contain axios changes.
This break the production.
### Solution Description
Removing the ^ for al-collector.js and paws ,so that it will not take latest version which is currently failing.
