### PR TITLE
ENG-50123: Replace the request package with axios for REST api call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -28,15 +28,15 @@
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "rewire": "^6.0.0",
-    "sinon": "^15.0.1",
+    "sinon": "^15.2.0",
     "yargs": "^17.6.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.18",
+    "@alertlogic/al-aws-collector-js": "4.1.20",
     "async": "^3.2.4",
     "datadog-lambda-js": "^6.85.0",
     "debug": "^4.3.4",
-    "moment": "2.29.4"
+    "moment": "^2.29.4"
   },
   "author": "Alert Logic Inc."
 }


### PR DESCRIPTION
AWS Inspector shows latest vulnerabilities with Lambda function requires node package updates(request package) for findings to fix.

- Replace request package with axios -https://github.com/alertlogic/al-collector-js/pull/57
- Al-aws-collector updated with latest changes of axios -https://github.com/alertlogic/al-aws-collector-js/pull/96
- Removed agentStatus method and added validation for collectors_status service call https://github.com/alertlogic/al-aws-collector-js/pull/97