### PR TITLE
Bump the all paws-collectors version to upgrade node version to 18

### DIFF
--- a/collectors/auth0/local/sam-template.yaml
+++ b/collectors/auth0/local/sam-template.yaml
@@ -13,9 +13,9 @@ Resources:
           aims_secret_key:
           aims_access_key_id:
           al_api:
-          al_application_id:  
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -24,13 +24,17 @@ Resources:
           paws_extension:
           paws_secret_param_name:
           paws_api_client_id:   
-          paws_api_secret: 
+          paws_collector_param_string_1: 
+          collector_streams:
           paws_endpoint:  
           paws_max_pages_per_invocation:    
           collector_id:  
           paws_ddb_table_name:
+          customer_id:
+          paws_type_name:
+          ssm_direct:
       CodeUri:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.50",
+  "version": "1.1.51",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -19,8 +18,9 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.9",
-    "@alertlogic/paws-collector": "^2.1.20",
+    "@alertlogic/al-collector-js": "^3.0.10",
+    "@alertlogic/paws-collector": "^2.1.21",
+    "aws-sdk": "^2.1457.0",
     "async": "^3.2.4",
     "auth0": "^3.1.2",
     "debug": "^4.3.4",

--- a/collectors/carbonblack/local/sam-template.yaml
+++ b/collectors/carbonblack/local/sam-template.yaml
@@ -10,12 +10,14 @@ Resources:
       Environment:
         Variables:
           AWS_LAMBDA_FUNCTION_NAME:
+          maxPages:
           aims_secret_key:
           aims_access_key_id:
           al_api:
           al_application_id:  
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -24,15 +26,17 @@ Resources:
           paws_extension:
           paws_secret_param_name:
           paws_api_client_id:   
-          paws_api_secret: 
           paws_endpoint:  
           paws_collector_param_string_2:
           collector_streams:  
           paws_max_pages_per_invocation:    
           collector_id:  
           paws_ddb_table_name:
+          customer_id:
+          paws_type_name:
+          ssm_direct:
       CodeUri:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -19,8 +18,9 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4",

--- a/collectors/ciscoamp/local/sam-template.yaml
+++ b/collectors/ciscoamp/local/sam-template.yaml
@@ -9,13 +9,14 @@ Resources:
       KmsKeyArn: your-arn-here
       Environment:
         Variables:
-          ssm_direct:
           AWS_LAMBDA_FUNCTION_NAME:
+          maxPages:
           aims_secret_key:
           aims_access_key_id:
           al_api:
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -26,10 +27,14 @@ Resources:
           paws_endpoint:
           paws_api_client_id:
           paws_max_pages_per_invocation:    
+          collector_streams:
           collector_id:
           paws_ddb_table_name:
-          collector_streams:
-      Runtime: nodejs14.x
+          customer_id:
+          paws_type_name:
+          ssm_direct:
+      CodeUri:
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -19,8 +18,9 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"

--- a/collectors/ciscoduo/local/sam-template.yaml
+++ b/collectors/ciscoduo/local/sam-template.yaml
@@ -10,11 +10,13 @@ Resources:
       Environment:
         Variables:
           AWS_LAMBDA_FUNCTION_NAME:
+          maxPages:
           aims_secret_key:
           aims_access_key_id:
           al_api:
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -25,11 +27,15 @@ Resources:
           paws_endpoint:
           paws_api_client_id:
           paws_max_pages_per_invocation:  
+          paws_collector_param_string_2:
           collector_id:
           paws_ddb_table_name:
           collector_streams:
+          customer_id:
+          paws_type_name:
+          ssm_direct:
       CodeUri:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -19,8 +18,9 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "@duosecurity/duo_api": "^1.2.3",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/crowdstrike/local/sam-template.yaml
+++ b/collectors/crowdstrike/local/sam-template.yaml
@@ -15,6 +15,7 @@ Resources:
           al_api:
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -27,9 +28,13 @@ Resources:
           paws_secret_param_name:
           paws_api_client_id:
           paws_endpoint:
+          paws_collector_param_string_2:
           collector_streams:
           customer_id:
-      Runtime: nodejs14.x
+          paws_type_name:
+          ssm_direct:
+      CodeUri: 
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300
       MemorySize: 1024

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -19,8 +18,9 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.9",
-    "@alertlogic/paws-collector": "^2.1.20",
+    "@alertlogic/al-collector-js": "^3.0.10",
+    "@alertlogic/paws-collector": "^2.1.21",
+    "aws-sdk": "^2.1457.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"

--- a/collectors/googlestackdriver/local/sam-template.yaml
+++ b/collectors/googlestackdriver/local/sam-template.yaml
@@ -15,19 +15,26 @@ Resources:
           al_api:
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
           paws_state_queue_url:
           paws_poll_interval:
+          paws_secret_param_name:
           paws_api_client_id:
-          paws_api_secret:
-          google_resource_ids:
+          paws_max_pages_per_invocation:
+          paws_collector_param_string_2:
+          paws_endpoint:
           paws_extension:
           collector_id:
           paws_ddb_table_name:
           collector_streams:
-      Runtime: nodejs10.x
+          customer_id:
+          paws_type_name:
+          ssm_direct:
+      CodeUri: 
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 60 
       MemorySize: 1024

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -19,8 +18,9 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "@google-cloud/logging": "^11.0.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/gsuite/local/sam-template.yaml
+++ b/collectors/gsuite/local/sam-template.yaml
@@ -15,6 +15,7 @@ Resources:
           al_api:
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -24,14 +25,16 @@ Resources:
           paws_collector_param_string_1:
           paws_api_client_id:
           collector_streams:
-          paws_type_name: "gsuite"
           paws_max_pages_per_invocation:
           paws_secret_param_name:
-          paws_api_secret:
+          paws_endpoint:
           collector_id:
           paws_ddb_table_name:
+          customer_id:
+          paws_type_name:
+          ssm_direct:
       CodeUri:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.48",
+  "version": "1.2.49",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -20,8 +19,9 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "googleapis": "^126.0.0",

--- a/collectors/mimecast/local/sam-template.yaml
+++ b/collectors/mimecast/local/sam-template.yaml
@@ -15,6 +15,7 @@ Resources:
           al_api:
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -34,7 +35,7 @@ Resources:
           ssm_direct:
           paws_type_name:
       CodeUri: 
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "@types/adm-zip": "0.5.0",
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -20,8 +19,9 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "adm-zip": "^0.5.10",
     "async": "^3.2.4",
     "debug": "^4.3.4",

--- a/collectors/o365/local/sam-template.yaml
+++ b/collectors/o365/local/sam-template.yaml
@@ -16,6 +16,7 @@ Resources:
           al_api:
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -26,20 +27,15 @@ Resources:
           paws_api_client_id:
           paws_collector_param_string_1:
           collector_streams:
-          paws_api_secret:
-          APP_SUBSCRIPTION_ID:
-          AZURE_APP_TENANT_ID:
-          O365_CONTENT_STREAMS:
-          CUSTOMCONNSTR_APP_CLIENT_ID:
-          CUSTOMCONNSTR_APP_CLIENT_SECRET:
           paws_endpoint:
-          okta_token:
-          okta_collection_start_ts:
           collector_id:
           paws_ddb_table_name:
           customer_id:
-          paws_api_client_id:
-      Runtime: nodejs14.x
+          paws_type_name:
+          paws_dedup_logs_ddb_table_name:
+          ssm_direct:
+      CodeUri: 
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 60 
       MemorySize: 1024

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.60",
+  "version": "1.2.61",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "^2.1443.0",
     "aws-sdk-mock": "^5.0.0",
     "jshint": "^2.11.0",
     "mocha": "^10.2.0",
@@ -19,12 +18,13 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.20",
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-aws-collector-js": "4.1.22",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
     "@azure/ms-rest-azure-js": "2.1.0",
     "@azure/ms-rest-js": "2.7.0",
     "@azure/ms-rest-nodeauth": "3.1.1",
+    "aws-sdk": "^2.1457.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4",

--- a/collectors/okta/local/sam-template.yaml
+++ b/collectors/okta/local/sam-template.yaml
@@ -14,7 +14,8 @@ Resources:
           aims_access_key_id:
           al_api:
           stack_name:
-          azollect_api:
+          azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_secret_param_name:
@@ -22,13 +23,15 @@ Resources:
           paws_state_queue_url:
           paws_poll_interval:
           paws_extension:
+          paws_max_pages_per_invocation:
           paws_endpoint:
-          okta_token:
-          okta_collection_start_ts:
           collector_id:
           paws_ddb_table_name:
           customer_id:
-      Runtime: nodejs14.x
+          paws_type_name:
+          ssm_direct:
+      CodeUri: 
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.2.20",
+  "version": "1.2.21",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -20,9 +19,10 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
     "@okta/okta-sdk-nodejs": "^6.6.0",
+    "aws-sdk": "^2.1457.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"

--- a/collectors/salesforce/local/sam-template.yaml
+++ b/collectors/salesforce/local/sam-template.yaml
@@ -16,6 +16,7 @@ Resources:
           al_application_id:
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -23,7 +24,6 @@ Resources:
           paws_poll_interval:
           paws_extension:
           paws_secret_param_name:
-          paws_api_secret:
           paws_api_client_id:  
           paws_endpoint: 
           paws_collector_param_string_1:
@@ -31,8 +31,11 @@ Resources:
           paws_max_pages_per_invocation:
           paws_ddb_table_name:        
           collector_id:
+          customer_id:
+          paws_type_name:
+          ssm_direct:
       CodeUri:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.49",
+  "version": "1.1.50",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -19,8 +18,9 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "jsforce": "^1.11.1",

--- a/collectors/sentinelone/local/sam-template.yaml
+++ b/collectors/sentinelone/local/sam-template.yaml
@@ -14,7 +14,8 @@ Resources:
           aims_access_key_id:
           al_api:
           stack_name:
-          azollect_api:
+          azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -22,11 +23,16 @@ Resources:
           paws_poll_interval:
           paws_extension:
           paws_secret_param_name:
+          paws_api_client_id:
           paws_endpoint:
-          paws_api_secret:
           paws_max_pages_per_invocation:      
           collector_id:
-      Runtime: nodejs14.x
+          paws_ddb_table_name:
+          customer_id:
+          paws_type_name:
+          ssm_direct:
+      CodeUri: 
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -19,8 +18,9 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/sophos/local/sam-template.yaml
+++ b/collectors/sophos/local/sam-template.yaml
@@ -15,6 +15,7 @@ Resources:
           al_api:
           stack_name:
           azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -28,8 +29,10 @@ Resources:
           collector_id:
           paws_ddb_table_name:
           customer_id:
+          paws_type_name:
+          ssm_direct:
       CodeUri:      
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -10,7 +10,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -21,8 +20,9 @@
     "mockserver": "^3.1.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "async": "3.2.2",
     "debug": "4.1.1",
     "moment": "2.29.4"

--- a/collectors/sophossiem/local/sam-template.yaml
+++ b/collectors/sophossiem/local/sam-template.yaml
@@ -14,7 +14,8 @@ Resources:
           aims_access_key_id:
           al_api:
           stack_name:
-          azollect_api:
+          azcollect_api:
+          collector_status_api:
           ingest_api:
           DEBUG:
           paws_state_queue_arn:
@@ -27,9 +28,11 @@ Resources:
           paws_max_pages_per_invocation:
           collector_id:
           paws_ddb_table_name:
-          collector_streams:
+          customer_id:
+          paws_type_name:
+          ssm_direct:
       CodeUri:     
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -9,7 +9,6 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "aws-sdk": "*",
     "aws-sdk-mock": "*",
     "jshint": "^2.9.5",
     "mocha": "^10.2.0",
@@ -19,8 +18,9 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.9",
-    "@alertlogic/paws-collector": "2.1.20",
+    "@alertlogic/al-collector-js": "3.0.10",
+    "@alertlogic/paws-collector": "2.1.21",
+    "aws-sdk": "^2.1457.0",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"


### PR DESCRIPTION
### Problem Description
AWS lambda runtime deprecated the node version 14

### Solution Description
Update node version to 18. 
Added aws-sdk in dependancy as node 18 runtime does not provide aws-sdk complete module.Node 18 work with aws-sdk v3 and not v2 so explicitly adding aws-sdk which is required .
 
