### PR TITLE
Bump the version to update collect lambda function from node version 14 to 18

### DIFF
--- a/collectors/auth0/al-auth0-collector.json
+++ b/collectors/auth0/al-auth0-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.51",
+  "version": "1.1.52",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,

--- a/collectors/carbonblack/al-carbonblack-collector.json
+++ b/collectors/carbonblack/al-carbonblack-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoamp/al-ciscoamp-collector.json
+++ b/collectors/ciscoamp/al-ciscoamp-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoduo/al-ciscoduo-collector.json
+++ b/collectors/ciscoduo/al-ciscoduo-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/crowdstrike/al-crowdstrike-collector.json
+++ b/collectors/crowdstrike/al-crowdstrike-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/googlestackdriver/al-googlestackdriver-collector.json
+++ b/collectors/googlestackdriver/al-googlestackdriver-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/gsuite/al-gsuite-collector.json
+++ b/collectors/gsuite/al-gsuite-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.49",
+  "version": "1.2.50",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/mimecast/al-mimecast-collector.json
+++ b/collectors/mimecast/al-mimecast-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/o365/al-o365-collector.json
+++ b/collectors/o365/al-o365-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.61",
+  "version": "1.2.62",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/okta/al-okta-collector.json
+++ b/collectors/okta/al-okta-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/salesforce/al-salesforce-collector.json
+++ b/collectors/salesforce/al-salesforce-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.50",
+  "version": "1.1.51",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sentinelone/al-sentinelone-collector.json
+++ b/collectors/sentinelone/al-sentinelone-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sophos/al-sophos-collector.json
+++ b/collectors/sophos/al-sophos-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sophossiem/al-sophossiem-collector.json
+++ b/collectors/sophossiem/al-sophossiem-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/template/collector.json
+++ b/collectors/template/collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs14.x"
+        "value": "nodejs18.x"
     }
 }

--- a/collectors/template/local/sam-template.yaml
+++ b/collectors/template/local/sam-template.yaml
@@ -14,8 +14,9 @@ Resources:
           aims_access_key_id:
           al_api:
           stack_name:
-          azollect_api:
+          azcollect_api:
           ingest_api:
+          collector_status_api:
           DEBUG:
           paws_state_queue_arn:
           paws_state_queue_url:
@@ -24,7 +25,7 @@ Resources:
           collector_id:
           ssm_direct:
           paws_type_name:
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024


### PR DESCRIPTION
Missed to push the collector.json file to upgrade  collectLambda function runtime node version from 14 to 18 in last [pr](https://github.com/alertlogic/paws-collector/pull/350) 