### PR TITLE
ENG-53369 : GCP collector - Handle the pagination state properly

### DIFF
--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/googlestackdriver/test/test.js
+++ b/collectors/googlestackdriver/test/test.js
@@ -235,13 +235,14 @@ describe('Unit Tests', function() {
         it('Stops paginiating at the pagination limit', function(done) {
             logginClientStub = sinon.stub(logging.v2.LoggingServiceV2Client.prototype, 'listLogEntries');
             
+            const nextPage = { pageToken: 'http://somenextpage.com', "pageSize": 1000, "resourceNames": ["projects/a-fake-project"] };
             logginClientStub.callsFake(() => {
                 return new Promise((res, rej) => {
                     res([
                         [
                             googlestackdriverMock.LOG_EVENT_PROTO_PAYLOAD
                         ],
-                        'http://somenextpage.com'
+                        nextPage
                     ]);
                 });
             });
@@ -258,7 +259,7 @@ describe('Unit Tests', function() {
                 collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) =>{
                     assert.ok(logginClientStub.calledTwice);
                     assert.equal(logs.length, parseInt(process.env.paws_max_pages_per_invocation));
-                    assert.equal(newState.nextPage, 'http://somenextpage.com');
+                    assert.deepEqual(newState.nextPage, nextPage);
                     restoreLoggingClientStub();
                     done();
                 });


### PR DESCRIPTION
### Problem Description
Collector losses the data as state since and until value not set properly during pagination scenario.  
Example : If there is lots of pages and collector collected paws_max_pages_per_invocation(default -10) max pages in one call , if there is still nextPage token since and until value should not change but currently it changes after every call . So if there is no more page it will start collecting the until value which is latest. Hence it lost the data for some period

### Solution Description
If nextPage available then don’t change since & until value only update next_token else update the since and until pass in next filter.


 
