### PR TITLE
ENG- 53314 : Handle the max payload exceeded error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yargs": "^17.6.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.24",
+    "@alertlogic/al-aws-collector-js": "4.1.25",
     "async": "^3.2.4",
     "datadog-lambda-js": "^6.85.0",
     "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
1.Some time there are big messages ,so collector face max playload issue and not able to proceed further. Which may cause delay in collection or some time loss the data if customer not reached out to us for long time. 
Currently we have to manually reduce the max pages from environment variable.

2. With aws-sdk v3 version lambda retry mechanism is break as variable name got change in sdk v3.

### Solution Description
1. If we get the max payload issue ,we split the current batch in to multiple small batches and send the data to ingest.
so no manual intervention required.

2. Fix the variable name as per aws-sdk v3 and update the library .-https://github.com/alertlogic/al-aws-collector-js/pull/103
 
