### PR TITLE
ENG-50794: Update to version v7 from v6 for Alerts API

### DIFF
--- a/collectors/carbonblack/collector.js
+++ b/collectors/carbonblack/collector.js
@@ -119,7 +119,9 @@ class CarbonblackCollector extends PawsCollector {
                     return callback(error.response.data);
                 }
                 else {
-                    error.errorCode = error.response.status;
+                    if (error.response) {
+                        error.errorCode = error.response.status
+                    }
                     return callback(error);
                 }
             });

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/carbonblack/test/utils_test.js
+++ b/collectors/carbonblack/test/utils_test.js
@@ -12,7 +12,7 @@ describe('Unit Tests', function () {
         alserviceStub.post = sinon.stub(RestServiceClient.prototype, 'post').callsFake(
             function fakeFn(path, extraOptions) {
                 return new Promise(function (resolve, reject) {
-                    return resolve({ results: [carbonblackMock.LOG_EVENT] });
+                    return resolve({ results: [carbonblackMock.LOG_EVENT],num_found : 2500 });
                 });
             });
         alserviceStub.get = sinon.stub(RestServiceClient.prototype, 'get').callsFake(
@@ -70,17 +70,20 @@ describe('Unit Tests', function () {
                 url: "url",
                 method: "POST",
                 requestBody:{
-                    "criteria": {
-                        "create_time": {
-                            "end": state.until,
-                            "start": state.since
-                        },
+                    "time_range": {
+                         "start": state.since,
+                        "end": state.until
                     },
-                    "rows": 0,
-                    "start": 0
+                    "start": "0",
+                    "rows": "0",
+                    "exclusions": {
+                        "type": [
+                            "CB_ANALYTICS","WATCHLIST"
+                        ]
+                    }
                 },
                 typeIdPaths: [{ path: ["id"] }],
-                tsPaths: [{ path: ["last_update_time"] }]
+                tsPaths: [{ path: ["backend_update_timestamp"] }]
             };
             let accumulator = [];
             const apiEndpoint = process.env.paws_endpoint;

--- a/collectors/carbonblack/themis-template/carbonblackevents.json
+++ b/collectors/carbonblack/themis-template/carbonblackevents.json
@@ -1,6 +1,6 @@
 {
     "method": "GET",
-    "url": "{{endpoint}}/appservices/v6/orgs/{{collector_param_string2}}/alerts/search_suggestions?suggest.q=",
+    "url": "{{endpoint}}/api/alerts/v7/orgs/{{collector_param_string2}}/alerts/search_suggestions?query=n/a",
     "headers": {
         "X-Auth-Token": "{{secret}}/{{client_id}}"
     },

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -56,7 +56,7 @@ stages:
       - ./build_collector.sh carbonblack
     env:
       ALPS_SERVICE_NAME: "paws-carbonblack-collector"
-      ALPS_SERVICE_VERSION: "1.0.52" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.53" #set the value from collector package json
     outputs:
       file: ./carbonblack-collector*
     packagers:


### PR DESCRIPTION
### Problem Description
Alert V6 API will be deactivated on July 31, 2024.

### Solution Description
Migrating to alert api v7 .
The observation Alerts have been removed from the v7 Alerts API and available under [Observations](https://developer.carbonblack.com/reference/carbon-black-cloud/platform/latest/observations-api/) api

1. For now we only migrated the alert api to v7 version.
   a. Change the variable name as per [alert api migration](https://developer.carbonblack.com/reference/carbon-black-cloud/guides/api-migration/alerts-migration) document .
   b. Updated the api url and request body
   c. Updated the themis template json as per api v7[ search recommendation
](https://developer.carbonblack.com/reference/carbon-black-cloud/platform/latest/alerts-api/#get-search-recommendations)

2. Configure observations api and  get observation will be stretch goal.
 
