### PR TITLE
ENG-55392-Googlestackdriver collector: Handle the throttle error for pagination scenario

### DIFF
--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -132,7 +132,7 @@ stages:
       - ./build_collector.sh googlestackdriver
     env:
       ALPS_SERVICE_NAME: "paws-googlestackdriver-collector"
-      ALPS_SERVICE_VERSION: "1.2.9" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.10" #set the value from collector package json
     outputs:
       file: ./googlestackdriver-collector*
     packagers:


### PR DESCRIPTION
### Problem Description
During throttling, we increase the poll interval and decrease the time duration. However, when the collector is collecting data through pagination, it already sets the filter timestamp (timestamp >= since and timestamp < until). The actual until value changes in the state during throttling. Once pagination completes and the collector creates a new state, it starts again from the same timestamp, resulting in duplicate data collection.

ex. In below state example until value(i.e 2024-05-25T10:39:49.000Z) in filter and actual(i.e 2024-05-24T10:39:50.000Z) is different.
`{"priv_collector_state":{"since":"2024-05-24T10:39:49.000Z","nextPage":{"filter":"timestamp >= \"2024-05-24T10:39:49.000Z\"\ntimestamp < \"2024-05-25T10:39:49.000Z\"","pageSize":1000,"resourceNames":["projects/prj-mstr-prod"],"pageToken":"EAA44cC8vNq0xP5RSq
"},"stream":"projects/prj-mstr-prod","until":"2024-05-24T10:39:50.000Z","poll_interval_sec":420},"retry_count":0}`
### Solution Description
Now we just reduce the page size during pagination and not the until value.