### PR TITLE
update the hour-cap condition to collect if delay is 1 hr or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {

--- a/paws_utils.js
+++ b/paws_utils.js
@@ -46,7 +46,7 @@ function calcNextCollectionInterval(strategy, curUntilMoment, pollInterval) {
             }
             break;
         case 'hour-cap':
-            if (hoursDiff > 1) {
+            if (hoursDiff >= 1) {
                 nextUntilMoment = moment(nextSinceMoment).add(1, 'hours');
             }
             else {


### PR DESCRIPTION
### Problem Description
The Cisco collector uses an hourly cap to catch up on backlog data. However, it only allows one call per minute, so it will never be able to catch up to the current time. This can add a delay of more than 2 hours when the delay condition (hour delay > 1) is met. Customers do not want delays in data collection.

### Solution Description
Added an equals condition so that it will collect data for one hour directly if the delay goes to more than or equal to 1 hour. This will reduce the delay to a maximum of 1 hour.
 
