### PR TITLE
Updated the poll interval to reduce delay and handle throttle

### DIFF
--- a/collectors/ciscoduo/collector.js
+++ b/collectors/ciscoduo/collector.js
@@ -122,7 +122,7 @@ class CiscoduoCollector extends PawsCollector {
                 if (error.code && error.code === API_THROTTLING_ERROR) {
                     state.poll_interval_sec = state.poll_interval_sec < MAX_POLL_INTERVAL ?
                     state.poll_interval_sec + POLL_INTERVAL_SECS : MAX_POLL_INTERVAL;
-                    AlLogger.warn(`CDUO000003 API Request Limit Exceeded`, error);
+                    AlLogger.warn(`CDUO000003 API Request Limit Exceeded ${JSON.stringify(error)}`);
                     collector.reportApiThrottling(function () {
                         return callback(null, [], state, state.poll_interval_sec);
                     });
@@ -140,9 +140,9 @@ class CiscoduoCollector extends PawsCollector {
         if (curState.stream === Authentication) {
 
             const untilMoment = moment(parseInt(curState.until));
-             // Used hour-cap instead of making api call for 1 min interval, may help to reduce throtling issue.
+            // As Cisco duo api allows one call per minute, we used an hour cap instead of making API calls for 1-minute intervals. This will help reduce collection delay and throttling.
             const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-cap', untilMoment, this.pollInterval);
-            const nextPollIntervalSec = nextPollInterval >= POLL_INTERVAL_SECS ? nextPollInterval : POLL_INTERVAL_SECS * JSON.parse(process.env.collector_streams).length;
+            const nextPollIntervalSec = nextPollInterval >= POLL_INTERVAL_SECS ? nextPollInterval : POLL_INTERVAL_SECS;
             return {
                 stream: curState.stream,
                 since: nextSinceMoment.valueOf(),

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.11",
-    "@alertlogic/paws-collector": "2.2.3",
+    "@alertlogic/paws-collector": "2.2.4",
     "@duosecurity/duo_api": "^1.4.0",
     "async": "^3.2.5",
     "debug": "^4.3.5",

--- a/collectors/ciscoduo/test/ciscoduo_test.js
+++ b/collectors/ciscoduo/test/ciscoduo_test.js
@@ -139,7 +139,7 @@ describe('Unit Tests', function () {
                 };
                 collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
                     assert.equal(logs.length, 2);
-                    assert.equal(newState.poll_interval_sec, 240);
+                    assert.equal(newState.poll_interval_sec, 60);
                     assert.ok(logs[0].txid);
                     getAPILogs.restore();
                     getAPIDetails.restore();
@@ -326,7 +326,7 @@ describe('Unit Tests', function () {
                     poll_interval_sec: 1
                 };
                 let nextState = collector._getNextCollectionState(curState);
-                 assert.equal(nextState.poll_interval_sec, 240);
+                assert.equal(nextState.poll_interval_sec, 60);
                 assert.equal(moment(parseInt(nextState.until)).diff(parseInt(nextState.since), 'minutes'), 60);
                 done();
             });

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -120,7 +120,7 @@ stages:
       - ./build_collector.sh ciscoduo
     env:
       ALPS_SERVICE_NAME: "paws-ciscoduo-collector"
-      ALPS_SERVICE_VERSION: "1.0.52" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.53" #set the value from collector package json
     outputs:
       file: ./ciscoduo-collector*
     packagers:


### PR DESCRIPTION
### Problem Description
The customer is experiencing two delays in collecting Cisco Duo logs.

### Solution Description
Reduce the poll interval from 4 minutes (previously based on the number of streams) to 1 minute.
Change the condition to catch up if the collection delay is greater than or equal to 1 hour. [pr](https://github.com/alertlogic/paws-collector/pull/374)


### Acceptance Criteria for Contributors
According to the[ Cisco duo api doc](https://duo.com/docs/adminapi#authentication-logs)   it is recommended to make only one API call per minute. Therefore, we cannot catch up quickly, and there might be a delay of up to 1 hour, but not more than that.
<img width="969" alt="image" src="https://github.com/alertlogic/paws-collector/assets/60738948/23cf58bd-8151-42f3-98d7-bf4c1d224cf8">

 
