### PR TITLE
[ENG-55813]To handle max socket warning while writing the item on DDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@aws-sdk/client-s3": "^3.600.0",
     "@aws-sdk/client-sqs": "^3.600.0",
     "@aws-sdk/client-ssm": "^3.600.0",
-    "@smithy/node-http-handler":"3.1.3",
     "clone": "*",
     "jshint": "^2.13.6",
     "mocha": "^10.4.0",
@@ -40,6 +39,7 @@
   },
   "dependencies": {
     "@alertlogic/al-aws-collector-js": "4.1.26",
+    "@smithy/node-http-handler":"3.1.3",
     "async": "^3.2.5",
     "datadog-lambda-js": "^9.112.0",
     "debug": "^4.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -29,6 +29,7 @@
     "@aws-sdk/client-s3": "^3.600.0",
     "@aws-sdk/client-sqs": "^3.600.0",
     "@aws-sdk/client-ssm": "^3.600.0",
+    "@smithy/node-http-handler":"3.1.3",
     "clone": "*",
     "jshint": "^2.13.6",
     "mocha": "^10.4.0",


### PR DESCRIPTION
### Problem Description
Getting below warning from DDB while  writing item in table.
`@smithy/node-http-handler:WARN socket usage at capacity=50 and 9753 additional requests are enqueued. See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html or increase socketAcquisitionWarningTimeout=(millis) in the NodeHttpHandler config.`


### Solution Description
Added maxSocket configuration as per on AWS doc
https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-configuring-maxsockets.html

