### PR TITLE
[GCP ]Filter the logs base on logNames and timestamps

### DIFF
--- a/collectors/googlestackdriver/cfn/googlestackdriver-collector.template
+++ b/collectors/googlestackdriver/cfn/googlestackdriver-collector.template
@@ -57,6 +57,10 @@
             "Description": "JSON list of google resources to poll logs from. In the format <resourceType>/<resourceID>",
             "Type": "String"
         },
+        "LogNameFilters": {
+            "Description": "A JSON list of Google Cloud log names used to filter logs. The format should be 'service.googleapis.com%2Flog_type', for example: 'compute.googleapis.com%2Factivity_log'.",
+            "Type": "String"
+        },
         "CollectionStartTs": {
             "Description": "Timestamp when log collection starts. For example, 2020-01-13T16:00:00Z",
             "Type": "String",
@@ -112,6 +116,9 @@
                     "PawsEndpoint": "No-Endpoint",
                     "CollectorStreams": {
                         "Ref": "GoogleResourceIds"
+                    },
+                    "CollectorParamString2": {
+                        "Ref": "LogNameFilters"
                     },
                     "CollectionStartTs": {
                         "Ref": "CollectionStartTs"

--- a/collectors/googlestackdriver/cfn/googlestackdriver-collector.template
+++ b/collectors/googlestackdriver/cfn/googlestackdriver-collector.template
@@ -58,7 +58,7 @@
             "Type": "String"
         },
         "LogNameFilters": {
-            "Description": "A JSON list of Google Cloud log names used to filter logs. The format should be 'service.googleapis.com%2Flog_type', for example: 'compute.googleapis.com%2Factivity_log'.",
+            "Description": "A JSON list of Google Cloud log names used to filter logs. The format should be 'service.googleapis.com%2Flog_type', for example: 'cloudaudit.googleapis.com%2Factivity'.",
             "Type": "String"
         },
         "CollectionStartTs": {

--- a/collectors/googlestackdriver/collector.js
+++ b/collectors/googlestackdriver/collector.js
@@ -183,17 +183,17 @@ class GooglestackdriverCollector extends PawsCollector {
     }
 
     generateFilter(state) {
-        const logIds = process.env.paws_collector_param_string_2 ? JSON.parse(process.env.paws_collector_param_string_2) : [];
+        const logNames = process.env.paws_collector_param_string_2 ? JSON.parse(process.env.paws_collector_param_string_2) : [];
         const filterConditions = [];
         let logFilterCondition;
 
-        if (logIds.length > 0) {
-            logIds.forEach(logId => {
-                const trimmedLogId = logId?.trim();
+        if (logNames.length > 0) {
+            logNames.forEach(logName => {
+                const trimmedlogName = logName?.trim();
 
-                if (trimmedLogId) {
-                    const encodeLogId = this.isUriEncoded(logId) ? logId : encodeURIComponent(logId);
-                    filterConditions.push(`logName:"${encodeLogId}"`);
+                if (trimmedlogName) {
+                    const encodelogName = this.isUriEncoded(logName) ? logName : encodeURIComponent(logName);
+                    filterConditions.push(`logName:"${encodelogName}"`);
                 } else {
                     AlLogger.warn("Skipping empty log ID.");
                 }
@@ -204,7 +204,6 @@ class GooglestackdriverCollector extends PawsCollector {
         }
         // Construct the basic timestamp filter
         let filterQuery = `timestamp >= "${state.since}" AND timestamp < "${state.until}"`;
-
         if (logFilterCondition) {
             // Combine the LogName and timesamp filter
             filterQuery = `${filterQuery} AND (${logFilterCondition})`;
@@ -212,8 +211,8 @@ class GooglestackdriverCollector extends PawsCollector {
         return filterQuery;
     }
 
-    isUriEncoded(logId) {
-        return decodeURIComponent(logId) !== logId;
+    isUriEncoded(logName) {
+        return decodeURIComponent(logName) !== logName;
     }
 
 

--- a/collectors/googlestackdriver/collector.js
+++ b/collectors/googlestackdriver/collector.js
@@ -61,13 +61,15 @@ class GooglestackdriverCollector extends PawsCollector {
             endTs = moment(startTs).add(this.pollInterval, 'seconds').toISOString();
         }
         const resourceNames = JSON.parse(process.env.collector_streams);
-        const initialStates = resourceNames.map(stream => ({
-            stream,
-            nextPage:null,
-            since: startTs,
-            until: endTs,
-            poll_interval_sec: 1
-        }));
+        const initialStates = resourceNames
+            .filter(stream => stream && stream.trim() !== "")  // Filter out empty or invalid values
+            .map(stream => ({
+                stream,
+                nextPage: null,
+                since: startTs,
+                until: endTs,
+                poll_interval_sec: 1
+            }));
         return callback(null, initialStates, 1);
     }
 

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.14",
-    "@alertlogic/paws-collector": "2.2.5",
+    "@alertlogic/paws-collector": "2.2.6",
     "async": "^3.2.6",
     "debug": "^4.3.7",
     "google-auth-library": "^9.14.1",

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -9,28 +9,28 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.632.0",
-    "@aws-sdk/client-cloudwatch": "^3.632.0",
-    "@aws-sdk/client-dynamodb": "^3.632.0",
-    "@aws-sdk/client-kms": "^3.632.0",
-    "@aws-sdk/client-lambda": "^3.632.0",
-    "@aws-sdk/client-s3": "^3.633.0",
-    "@aws-sdk/client-sqs": "^3.632.0",
-    "@aws-sdk/client-ssm": "^3.632.0",
+    "@aws-sdk/client-cloudformation": "^3.666.0",
+    "@aws-sdk/client-cloudwatch": "^3.666.0",
+    "@aws-sdk/client-dynamodb": "^3.666.0",
+    "@aws-sdk/client-kms": "^3.666.0",
+    "@aws-sdk/client-lambda": "^3.666.0",
+    "@aws-sdk/client-s3": "^3.666.0",
+    "@aws-sdk/client-sqs": "^3.666.0",
+    "@aws-sdk/client-ssm": "^3.666.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
-    "nyc": "^17.0.0",
+    "nyc": "^17.1.0",
     "rewire": "^7.0.0",
-    "sinon": "^18.0.0"
+    "sinon": "^19.0.2"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.12",
+    "@alertlogic/al-collector-js": "3.0.14",
     "@alertlogic/paws-collector": "2.2.5",
-    "async": "^3.2.5",
-    "debug": "^4.3.6",
-    "google-auth-library": "^9.13.0",
-    "googleapis": "^140.0.1",
+    "async": "^3.2.6",
+    "debug": "^4.3.7",
+    "google-auth-library": "^9.14.1",
+    "googleapis": "^144.0.0",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/googlestackdriver/test/test.js
+++ b/collectors/googlestackdriver/test/test.js
@@ -555,7 +555,7 @@ describe('Unit Tests', function() {
                 const startDate = moment().subtract(20, 'minutes');
                 let since = startDate.toISOString();
                 let until = startDate.add(collector.pollInterval, 'seconds').toISOString();
-                process.env.paws_collector_param_string_2 = "[\"cloudaudit.googleapis.com%2Factivity\",\"\",\"cloudfunctions.googleapis.com%2Fcloud-functions\"]";
+                process.env.paws_collector_param_string_2 = "[\"cloudaudit.googleapis.com%2Factivity\",\"\",\"cloudfunctions.googleapis.com/cloud-functions\"]";
                 const curState = {
                     since: since,
                     until: until,
@@ -563,7 +563,7 @@ describe('Unit Tests', function() {
                     stream: 'projects/imran-49253',
                 };
                 // Expected filter string
-                const expectedFilter = `timestamp >= "${since}" AND timestamp < "${until}" AND (logName="projects/imran-49253/logs/cloudaudit.googleapis.com%2Factivity" OR logName="projects/imran-49253/logs/cloudfunctions.googleapis.com%2Fcloud-functions")`;
+                const expectedFilter = `timestamp >= "${since}" AND timestamp < "${until}" AND (logName:"cloudaudit.googleapis.com%2Factivity" OR logName:"cloudfunctions.googleapis.com%2Fcloud-functions")`;
 
                 // Call the function to generate the filter
                 const filter = collector.generateFilter(curState);
@@ -622,7 +622,6 @@ describe('Unit Tests', function() {
                 const startDate = moment().subtract(20, 'minutes');
                 let since = startDate.toISOString();
                 let until = startDate.add(collector.pollInterval, 'seconds').toISOString();
-                process.env.paws_collector_param_string_2 = null;
                 const curState = {
                     since: since,
                     until: until,

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -177,7 +177,7 @@ stages:
       - ./build_collector.sh googlestackdriver
     env:
       ALPS_SERVICE_NAME: "paws-googlestackdriver-collector"
-      ALPS_SERVICE_VERSION: "1.2.14" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.15" #set the value from collector package json
     outputs:
       file: ./googlestackdriver-collector*
     packagers:


### PR DESCRIPTION
### Problem Description
Currently there is no functionality to filter the logs base on log names and collector pull all type of logs

### Solution Description
Apply filtering based on the provided logName values,
So that the system fetches only the relevant logs, or all logs if no logName is provided, using the GCP Logging API.

### Acceptance Criteria for Contributors

1. Filter Handling: 

- The backend should receive the logName filter value from the UI.
- If one or more logName values are provided, the backend should apply these filters when making requests to the GCP Logging API.
        It will encode the Log name URI if it is not encoded. It will accept below pattern :
        1.`cloudaudit.googleapis.com%2Factivity`;
        2. `cloudaudit.googleapis.com/activity`;
        3. `cloudaudit.googleapis.com%2Factivity\ncloudaudit.googleapis.com%2Factivity-function`; // Valid multiple entries
        4. `cloudaudit.googleapis.com`
- Else If no logName value is provided, the system should fetch all available logs from the GCP Logging API without any filtering.
 
