### PR TITLE
AWS inspector vulnerabilities and ddb warning fixes by making a single static DDB client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -34,12 +34,12 @@
     "mocha": "^10.4.0",
     "nyc": "^17.0.0",
     "rewire": "^7.0.0",
-    "sinon": "^18.0.0",
+    "sinon": "^19.0.2",
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.1.26",
-    "@smithy/node-http-handler":"3.1.3",
+    "@alertlogic/al-aws-collector-js": "^4.1.28",
+    "@smithy/node-http-handler": "^3.2.4",
     "async": "^3.2.5",
     "datadog-lambda-js": "^9.112.0",
     "debug": "^4.3.5",


### PR DESCRIPTION
### Problem Description
] AWS inspector showing Vulnerabilities for our lambda functions and fix ddb warnings and performance by making a single static DDB client.
### Solution Description
1. AWS inspector vulnerabilities fixed.
2. Created a single static DDB client Object to improve performance.

