### PR TITLE
[Cisco Meraki] Add warning message productType is not applicable to this network and skip collecting logs in cisco meraki collector

### DIFF
--- a/collectors/ciscomeraki/collector.js
+++ b/collectors/ciscomeraki/collector.js
@@ -20,7 +20,7 @@ const MAX_POLL_INTERVAL = 900;
 const API_THROTTLING_ERROR = 429;
 const API_NOT_FOUND_ERROR = 404;
 const NOT_FOUND_ERROR_MAX_RETRIES = 3;
-
+const PRODUCT_TYPE_NOTAPPLICABLE_MESSAGE = "productType is not applicable to this network";
 const typeIdPaths = [{ path: ["type"] }];
 const tsPaths = [{ path: ["occurredAt"] }];
 
@@ -187,9 +187,14 @@ class CiscomerakiCollector extends PawsCollector {
                 return callback(error);
             }
         } else if (error && error.response && error.response.data) {
-            AlLogger.debug(`CMRI0000022 error ${error.response.data.errors} - status: ${error.response.status}`);
-            error.response.data.errorCode = error.response.status;
-            return callback(error.response.data);
+            if (error.response.data.errors == PRODUCT_TYPE_NOTAPPLICABLE_MESSAGE) {
+                AlLogger.warn(`CMRI0000023 ${error.response.data.errors} : ${state.networkId}`);
+                return callback(null, [], state, state.poll_interval_sec);
+            } else {
+                AlLogger.debug(`CMRI0000022 error ${error.response.data.errors} - status: ${error.response.status}`);
+                error.response.data.errorCode = error.response.status;
+                return callback(error.response.data);
+            }
         } else {
             return callback(error);
         }

--- a/collectors/ciscomeraki/package.json
+++ b/collectors/ciscomeraki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscomeraki-collector",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Alert Logic AWS based Cisco Meraki Log Collector",
   "repository": {},
   "private": true,

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -139,7 +139,7 @@ stages:
       - ./build_collector.sh ciscomeraki
     env:
       ALPS_SERVICE_NAME: "paws-ciscomeraki-collector"
-      ALPS_SERVICE_VERSION: "1.0.5" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.6" #set the value from collector package json
     outputs:
       file: ./ciscomeraki-collector*
     packagers:


### PR DESCRIPTION

### Problem Description
Cisco Meraki collector fetch the data from all the networks from his Cisco Meraki organisations . For customers there may be some networks which doesn't  have product types selected or asisgned and collector try to fetch the data for the selected product type(["appliance","wireless","switch"), ,hence it returning error as below for few networks.
`
"productType is not applicable to this network"`
### Solution Description
To address this, we plan to stop sending error messages for cases where the API returns errors: ["productType is not applicable to this network"], as there is nothing to collect in such scenarios. Consequently, no remediation will be shown in the health console.
Instead, we will log a warning in AWS CloudWatch logs to indicate which networks do not have any product types. This warning will help identify the networks if the customer wants to address them.

