### PR TITLE
[Cisco Meraki] Improve Error handling in cisco meraki collector

### DIFF
--- a/collectors/ciscomeraki/collector.js
+++ b/collectors/ciscomeraki/collector.js
@@ -20,7 +20,6 @@ const MAX_POLL_INTERVAL = 900;
 const API_THROTTLING_ERROR = 429;
 const API_NOT_FOUND_ERROR = 404;
 const NOT_FOUND_ERROR_MAX_RETRIES = 3;
-const PRODUCT_TYPE_NOTAPPLICABLE_MESSAGE = "productType is not applicable to this network";
 const typeIdPaths = [{ path: ["type"] }];
 const tsPaths = [{ path: ["occurredAt"] }];
 
@@ -187,14 +186,9 @@ class CiscomerakiCollector extends PawsCollector {
                 return callback(error);
             }
         } else if (error && error.response && error.response.data) {
-            if (error.response.data.errors == PRODUCT_TYPE_NOTAPPLICABLE_MESSAGE) {
-                AlLogger.warn(`CMRI0000023 ${error.response.data.errors} : ${state.networkId}`);
-                return callback(null, [], state, state.poll_interval_sec);
-            } else {
-                AlLogger.debug(`CMRI0000022 error ${error.response.data.errors} - status: ${error.response.status}`);
-                error.response.data.errorCode = error.response.status;
-                return callback(error.response.data);
-            }
+            AlLogger.debug(`CMRI0000022 error ${error.response.data.errors} - status: ${error.response.status}`);
+            error.response.data.errorCode = error.response.status;
+            return callback(error.response.data);
         } else {
             return callback(error);
         }

--- a/collectors/ciscomeraki/meraki_client.js
+++ b/collectors/ciscomeraki/meraki_client.js
@@ -8,6 +8,7 @@ const NETWORKS_PER_PAGE = 1000;
 const EVENTS_PER_PAGE = 500;
 const API_THROTTLING_ERROR = 429;
 const DEFAULT_RETRY_DELAY_MILLIS = 1000;
+const PRODUCT_TYPE_NOTAPPLICABLE_MESSAGE = "productType is not applicable to this network";
 
 async function getAPILogs(apiDetails, accumulator, apiEndpoint, state, clientSecret, maxPagesPerInvocation) {
     let nextPage;
@@ -55,7 +56,11 @@ async function getAPILogs(apiDetails, accumulator, apiEndpoint, state, clientSec
                     throw new Error(`CMRI000007 Error:NetworkId required in ${url}`);
                 }
             } catch (error) {
-                throw error;
+                if (error && error.response && error.response.data && (error.response.data.errors == PRODUCT_TYPE_NOTAPPLICABLE_MESSAGE)) {
+                    AlLogger.warn(`CMRI0000027 ${productType} ${error.response.data.errors} : ${state.networkId}`);
+                } else {
+                    throw error;
+                }
             }
         } else {
             nextPage = since;

--- a/collectors/ciscomeraki/package.json
+++ b/collectors/ciscomeraki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscomeraki-collector",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Alert Logic AWS based Cisco Meraki Log Collector",
   "repository": {},
   "private": true,

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -139,7 +139,7 @@ stages:
       - ./build_collector.sh ciscomeraki
     env:
       ALPS_SERVICE_NAME: "paws-ciscomeraki-collector"
-      ALPS_SERVICE_VERSION: "1.0.6" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.7" #set the value from collector package json
     outputs:
       file: ./ciscomeraki-collector*
     packagers:


### PR DESCRIPTION
### Problem Description
When the error "productType is not applicable to this network" occurs and is caught and thrown, the collector not collecting data for other product types associated with the network.
### Solution Description
Improved Error handling in cisco meraki collector to ensure continuous data collection even if productType is not applicable to networks
