### PR TITLE
[Cisco Meraki] Duplicate data is sent to ingest because of state.since not updating properly in cisco meraki collector

### DIFF
--- a/collectors/ciscomeraki/collector.js
+++ b/collectors/ciscomeraki/collector.js
@@ -165,7 +165,7 @@ class CiscomerakiCollector extends PawsCollector {
     }
 
     handleThrottlingError(error, state, callback) {
-        const maxRandom = 5;
+        const maxRandom = parseInt(process.env.ciscomeraki_throttlingmaxrandom, 10) || 5;
         let retry = parseInt(error.response.headers['retry-after']) || 1;
         retry += Math.floor(Math.random() * (maxRandom + 1));
         state.poll_interval_sec = state.poll_interval_sec < MAX_POLL_INTERVAL ?

--- a/collectors/ciscomeraki/meraki_client.js
+++ b/collectors/ciscomeraki/meraki_client.js
@@ -37,11 +37,8 @@ async function getAPILogs(apiDetails, accumulator, apiEndpoint, state, clientSec
                     let data = response && response.data ? response.data.events : [];
                     if (data.length) {
                         accumulator = accumulator.concat(data);
-                    } else {
-                        return accumulator;
                     }
-                    headers = response.headers;
-                    const linkHeader = response.headers.link;
+                    const linkHeader = response && response.headers ? response.headers.link : undefined;
                     if (linkHeader && linkHeader.includes('rel=next')) {
                         const nextLink = linkHeader.match(/<(.*?)>; rel=next/)[1];
                         startingAfter = new URL(nextLink).searchParams.get('startingAfter');

--- a/collectors/ciscomeraki/package.json
+++ b/collectors/ciscomeraki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscomeraki-collector",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Alert Logic AWS based Cisco Meraki Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscomeraki/test/meraki_client_test.js
+++ b/collectors/ciscomeraki/test/meraki_client_test.js
@@ -30,6 +30,11 @@ describe('API Tests', function () {
                 headers: {}
             }));
 
+            axiosGetStub.onThirdCall().returns(Promise.resolve({
+                data: { events: [], pageEndAt: '2024-04-15T11:00:00Z' },
+                headers: {}
+            }));
+
             const apiDetails = { productTypes: ['appliance', 'switch'] };
             const accumulator = [];
             const apiEndpoint = 'api.meraki.com';
@@ -38,7 +43,6 @@ describe('API Tests', function () {
             const maxPagesPerInvocation = 2;
 
             const result = await getAPILogs(apiDetails, accumulator, apiEndpoint, state, clientSecret, maxPagesPerInvocation);
-
             assert.deepStrictEqual(result.accumulator, [ciscomerakiMock.LOG_EVENT, ciscomerakiMock.LOG_EVENT, ciscomerakiMock.LOG_EVENT, ciscomerakiMock.LOG_EVENT]);
             assert.strictEqual(result.nextPage, undefined);
         });
@@ -234,14 +238,18 @@ describe('API Tests', function () {
             const maxPagesPerInvocation = 2;
 
             axiosGetStub.onFirstCall().returns(Promise.resolve({
-                data: { events: [ciscomerakiMock.LOG_EVENT, ciscomerakiMock.LOG_EVENT], startingAfter: '2024-04-15T10:00:00Z' },
+                data: { events: [ciscomerakiMock.LOG_EVENT, ciscomerakiMock.LOG_EVENT], pageEndAt: '2024-04-15T10:00:00Z' },
                 headers: { link: '<https://api.meraki.com/next>; rel=next' }
             }));
             axiosGetStub.onSecondCall().returns(Promise.resolve({
-                data: { events: [ciscomerakiMock.LOG_EVENT, ciscomerakiMock.LOG_EVENT], startingAfter: '2024-04-16T10:00:00Z' },
+                data: { events: [ciscomerakiMock.LOG_EVENT, ciscomerakiMock.LOG_EVENT], pageEndAt: '2024-04-16T10:00:00Z' },
                 headers: {}
             }));
 
+            axiosGetStub.onThirdCall().returns(Promise.resolve({
+                data: { events: [], pageEndAt: '2024-04-16T10:00:00Z' },
+                headers: {}
+            }));
             const result = await getAPILogs(apiDetails, [], apiEndpoint, state, clientSecret, maxPagesPerInvocation);
 
             assert.deepStrictEqual(result.accumulator.length, 4); // Total events from both pages

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -139,7 +139,7 @@ stages:
       - ./build_collector.sh ciscomeraki
     env:
       ALPS_SERVICE_NAME: "paws-ciscomeraki-collector"
-      ALPS_SERVICE_VERSION: "1.0.7" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.8" #set the value from collector package json
     outputs:
       file: ./ciscomeraki-collector*
     packagers:


### PR DESCRIPTION

### Problem Description
Duplicate data is sent to ingest because of state.since not updating properly in cisco meraki collector
### Solution Description
Modified code to updates state.since not updating properly by removing returing accumulator logic.
