### PR TITLE
[ENG-57488] Added the retention period to 13 month for cloud watch log group

### DIFF
--- a/cfn/paws-collector-shared.template
+++ b/cfn/paws-collector-shared.template
@@ -442,16 +442,17 @@
         "Properties": {
             "LogGroupName": {
                 "Fn::Join": [
-                "",
-                [
-                    "/aws/lambda/",
-                    { "Ref": "CollectLambdaFunction" }
+                    "",
+                    [
+                        "/aws/lambda/",
+                        { "Ref": "CollectLambdaFunction" }
+                    ]
                 ]
-            ]
+            },
+            "RetentionInDays": 400
         },
-        "RetentionInDays": 400
-        }
-      },
+        "DeletionPolicy": "Retain"
+     },
       "RegistrationResource": {
          "Type": "Custom::RegistrationResource",
          "DependsOn": [


### PR DESCRIPTION
### Problem Description
If we delete a CloudFormation (CFN) stack, it will delete all its resources. We need to retain CloudWatch log groups to review logs from failed stacks.

### Solution Description
Added a DeletionPolicy of Retain for CloudWatch log groups to prevent their deletion.
`"DeletionPolicy": "Retain"`

 
