### PR TITLE
[ENG-57829]Themis service validation- Sophos Siem Collector ]: API Token setup EOL

### DIFF
--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/sophossiem/themis-template/sophossiem.json
+++ b/collectors/sophossiem/themis-template/sophossiem.json
@@ -1,12 +1,11 @@
 {
-    "method": "GET",
-    "url": "{{endpoint}}/siem/v1/events?limit=10",
+    "method": "POST",
+    "url": "https://id.sophos.com/api/v2/oauth2/token",
     "headers": {
         "Accept": "*/*",
-        "x-api-key": "{{client_id}}",
-        "Authorization": "{{secret}}"
+        "Content-Type": "application/x-www-form-urlencoded"
     },
-    "body": "",
+    "body": "grant_type=client_credentials&client_id={{client_id}}&client_secret={{secret}}&scope=token",
     "expect": {
         "response": 200,
         "body": "ANY"

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -329,7 +329,7 @@ stages:
       - ./build_collector.sh sophossiem
     env:
       ALPS_SERVICE_NAME: "paws-sophossiem-collector"
-      ALPS_SERVICE_VERSION: "1.2.15" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.16" #set the value from collector package json
     outputs:
       file: ./sophossiem-collector*
     packagers:


### PR DESCRIPTION
### Problem Description

As per Sophos Central API [documentation](https://support.sophos.com/support/s/article/KBA-000004438?language=en_US), the legacy API Token Management is being retired. Existing tokens will remain functional until expiration, but new tokens cannot be created or renewed. Moving forward, authentication will require Api credential management authentication using Client ID and Client Secret instead of direct API tokens.


### Solution Description
Themis service validating for Sophos Siem collector through template https://algithub.pd.alertlogic.net/defender/themis/blob/837f1f2fa83381a9f9f20c7bb36d614cbc09502f/src/themis_paws_validator.erl#L23
Validation done through template using validate_paws_with_template . So updated the themis template to support API credential validation using client_id and client secret.


