### PR TITLE
[ENG-58761]:Migrate detect API to Alerts

### DIFF
--- a/collectors/crowdstrike/cfn/crowdstrike-collector.template
+++ b/collectors/crowdstrike/cfn/crowdstrike-collector.template
@@ -60,9 +60,9 @@
             "NoEcho": true
         },
         "CrowdstrikeAPINames": {
-            "Description": "Define API names. Please pass JSON formatted list. Possible values are [\"Incident\", \"Detection\"]",
+            "Description": "Define API names. Please pass JSON formatted list. Possible values are [\"Incident\", \"Detection\",\"Alerts\"]",
             "Type": "String",
-            "Default": "[\"Incident\", \"Detection\"]"
+            "Default": "[\"Incident\", \"Detection\", \"Alerts\"]"
         },
         "CollectionStartTs": {
             "Description": "Timestamp when log collection starts. For example, 2019-11-21T16:00:00Z",

--- a/collectors/crowdstrike/collector.js
+++ b/collectors/crowdstrike/collector.js
@@ -86,13 +86,23 @@ class CrowdstrikeCollector extends PawsCollector {
                         AlLogger.error(`CROW000005 Error while getting incident details`);
                         return collector.setErrorCode(error, callback);
                     });
-                } else if (state.stream === 'Detection') {
+                } // @deprecated: This implementation will be removed in a future release. Use the Alert API to retrieve detect events instead of Detection 
+                else if (state.stream === 'Detection') {
                     return utils.getDetections(accumulator, APIHostName, token).then((data) => {
                         const newState = collector._getNextCollectionStateWithOffset(state, offset, receivedAll);
                         AlLogger.info(`CROW000004 Next collection in ${newState.poll_interval_sec} seconds for ${state.stream}`);
                         return callback(null, data.resources, newState, newState.poll_interval_sec);
                     }).catch((error) => {
                         AlLogger.error(`CROW000005 Error while getting detection details`);
+                        return collector.setErrorCode(error, callback);
+                    });
+                } else if (state.stream === 'Alerts') {
+                    return utils.getAlerts(accumulator, APIHostName, token).then((data) => {
+                        const newState = collector._getNextCollectionStateWithOffset(state, offset, receivedAll);
+                        AlLogger.info(`CROW000004 Next collection in ${newState.poll_interval_sec} seconds for ${state.stream}`);
+                        return callback(null, data.resources, newState, newState.poll_interval_sec);
+                    }).catch((error) => {
+                        AlLogger.error(`CROW000005 Error while getting Alerts details`);
                         return collector.setErrorCode(error, callback);
                     });
                 }

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/crowdstrike/test/crowd-strike-mock.js
+++ b/collectors/crowdstrike/test/crowd-strike-mock.js
@@ -17,7 +17,7 @@ process.env.paws_poll_interval = 60;
 process.env.paws_type_name = "crowdstrike";
 process.env.paws_api_client_id = "client-id";
 process.env.paws_api_secret = "client-secret";
-process.env.collector_streams = "[\"Incident\", \"Detection\"]";
+process.env.collector_streams = "[\"Incident\", \"Detection\", \"Alerts\"]";
 process.env.paws_endpoint = "https://api.crowdstrike.com";
 
 const AIMS_TEST_CREDS = {
@@ -88,6 +88,32 @@ const INCIDENT_LOG_EVENT = {
     "errors" : []
 };
 
+const ALERTS_LOG_EVENT = {
+    "meta": {
+        "query_time": 0.01414002,
+        "powered_by": "msa-api",
+        "trace_id": "d4d3158c-731c-4cb6-97ed-8b999f65fedf"
+    },
+    "resources": [
+        {
+            "agent_id": "36f66221fa044c74a9e3ffa5ba8ab2d3",
+            "aggregate_id": "806b5e44b7bce1006b1704c86c42f6f3813367dca081ba24ed1572",
+            "composite_id": "fa23ab2e36fc4d12930f404ce0070d52:ind:36f66221fa044c74a9e3ffa5ba8ab2d3:4369786211892-10335-11200272",
+            "context_timestamp": "2025-08-17T15:31:37.962Z",
+            "crawled_timestamp": "2025-08-17T16:31:41.180070674Z",
+            "created_timestamp": "2025-08-17T15:32:41.196001085Z",
+            "show_in_ui": false,
+            "confidence": 80,
+            "severity": 70,
+            "severity_name": "High",
+            "status": "new",
+            "product": "epp",
+        }
+    ],
+    "errors": []
+};
+
+
 const FUNCTION_ARN = 'arn:aws:lambda:us-east-1:352283894008:function:test-01-CollectLambdaFunction-2CWNLPPW5XO8';
 const FUNCTION_NAME = 'test-TestCollectLambdaFunction-1JNNKQIPOTEST';
 
@@ -97,6 +123,7 @@ module.exports = {
     FUNCTION_NAME: FUNCTION_NAME,
     DETECTION_LOG_EVENT: DETECTION_LOG_EVENT,
     INCIDENT_LOG_EVENT: INCIDENT_LOG_EVENT,
+    ALERTS_LOG_EVENT: ALERTS_LOG_EVENT,
     LIST: LIST,
     AUTHENTICATE: AUTHENTICATE
 };

--- a/collectors/crowdstrike/test/utils-test.js
+++ b/collectors/crowdstrike/test/utils-test.js
@@ -126,6 +126,32 @@ describe('Unit Tests', function () {
         });
     });
 
+    describe('POST Alerts Request', function () {
+        it('POST Alerts Request', function (done) {
+            exeStub();
+            let hostName = process.env.paws_endpoint;
+            const token = crowdstrikeMock.AUTHENTICATE.access_token;
+
+            utils.getAlerts(crowdstrikeMock.LIST.resources, hostName, token).then(data => {
+                assert(data.resources.length == 2, "accumulator length is wrong");
+                done();
+            });
+        });
+    });
+
+    describe('POST Alerts Request with empty IDs array', function () {
+        it('POST Alerts Request', function (done) {
+            exeStub();
+            let hostName = process.env.paws_endpoint;
+            const token = crowdstrikeMock.AUTHENTICATE.access_token;
+
+            utils.getAlerts([], hostName, token).then(data => {
+                assert(data.resources.length == 0, "accumulator length is wrong");
+                done();
+            });
+        });
+    });
+
     describe('Authentication Request', function () {
         beforeEach(function() {
             alserviceStub.post = sinon.stub(RestServiceClient.prototype, 'post').callsFake(

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -155,7 +155,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-crowdstrike-collector"
-      ALPS_SERVICE_VERSION: "1.0.38" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.39" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 20
       - ./build_collector.sh crowdstrike


### PR DESCRIPTION

### Problem Description
The Detection API endpoints are deprecated and will be decommissioned on September 30th, 2025. The Alerts api is provide Legacy concepts, so migrated to Alerts API.

### Solution Description
Added support to collect detection data using the Alerts API. The existing Detection API code can be removed if it begins to fail or once it is officially(i.e. September 30th, 2025) deprecated.
To retrieve alert details, use the following APIs:

1. Query Alert IDs
      GET /alerts/queries/alerts/v2
      Use filters such as `project:epp` and `created_timestamp` to identify relevant alert IDs.
 
2. Fetch Alert Details
      POST /alerts/entities/alerts/v2
      Use the retrieved alert IDs to get detailed information about each alert.

### Acceptance Criteria for Contributors

1. Alerts API Integration
2. Existing Detection API code should remain functional but be clearly marked as deprecated.
3. If the Detection API begins to fail (e.g., returns errors or is unreachable), it should be safely removed or bypassed without breaking the system.
4. Added unit tests to cover the new Alert API integration.

