### PR TITLE
[ENG-58738-Paws all collectors]Update NodeJS version to 22 and fix Vulnerabilities reported by AWS inspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ clean:
 	rm -rf *.coverage.xml
 	rm -rf *.covertool.xml
 	for d in $(COLLECTOR_DIRS); do \
-        echo "\n************\n\cleaning for $$d\n\n************\n\n"; \
-        if [ "$$d" != "collectors//template" ]; then \
+        echo "\n************\n\ncleaning for $$d\n\n************\n\n"; \
+        if [ "$$d" != "collectors/template" ]; then \
                 make -C $$d clean || exit 1; \
-        fi \
-    done;
+        fi; \
+    done

--- a/collectors/auth0/al-auth0-collector.json
+++ b/collectors/auth0/al-auth0-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/auth0/local/sam-template.yaml
+++ b/collectors/auth0/local/sam-template.yaml
@@ -34,7 +34,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.60",
+  "version": "1.1.61",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -21,15 +21,15 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "^3.2.6",
     "auth0": "^3.7.2",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "^2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/carbonblack/al-carbonblack-collector.json
+++ b/collectors/carbonblack/al-carbonblack-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/carbonblack/local/sam-template.yaml
+++ b/collectors/carbonblack/local/sam-template.yaml
@@ -36,7 +36,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -21,14 +21,14 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1",
     "test": "^3.3.0"
   },

--- a/collectors/ciscoamp/al-ciscoamp-collector.json
+++ b/collectors/ciscoamp/al-ciscoamp-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/ciscoamp/local/sam-template.yaml
+++ b/collectors/ciscoamp/local/sam-template.yaml
@@ -34,7 +34,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -21,14 +21,14 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/ciscoduo/al-ciscoduo-collector.json
+++ b/collectors/ciscoduo/al-ciscoduo-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/ciscoduo/local/sam-template.yaml
+++ b/collectors/ciscoduo/local/sam-template.yaml
@@ -35,7 +35,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -21,15 +21,15 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "@duosecurity/duo_api": "^1.4.0",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/ciscomeraki/al-ciscomeraki-collector.json
+++ b/collectors/ciscomeraki/al-ciscomeraki-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/ciscomeraki/local/sam-template.yaml
+++ b/collectors/ciscomeraki/local/sam-template.yaml
@@ -40,7 +40,7 @@ Resources:
           secret:
           dl_s3_bucket_name:
       CodeUri: 
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/ciscomeraki/package.json
+++ b/collectors/ciscomeraki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscomeraki-collector",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Alert Logic AWS based Cisco Meraki Log Collector",
   "repository": {},
   "private": true,
@@ -21,16 +21,15 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1"
-
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/crowdstrike/al-crowdstrike-collector.json
+++ b/collectors/crowdstrike/al-crowdstrike-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/crowdstrike/local/sam-template.yaml
+++ b/collectors/crowdstrike/local/sam-template.yaml
@@ -34,7 +34,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri: 
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300
       MemorySize: 1024

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,
@@ -21,14 +21,14 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/googlestackdriver/al-googlestackdriver-collector.json
+++ b/collectors/googlestackdriver/al-googlestackdriver-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/googlestackdriver/local/sam-template.yaml
+++ b/collectors/googlestackdriver/local/sam-template.yaml
@@ -36,7 +36,7 @@ Resources:
           ssm_direct:
           collector_status_api: api.product.dev.alertlogic.com
       CodeUri: 
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 600
       MemorySize: 1024

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -21,16 +21,16 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
-    "google-auth-library": "^9.15.1",
-    "googleapis": "^144.0.0",
+    "debug": "^4.4.3",
+    "google-auth-library": "^10.3.0",
+    "googleapis": "^160.0.0",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/gsuite/al-gsuite-collector.json
+++ b/collectors/gsuite/al-gsuite-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/gsuite/local/sam-template.yaml
+++ b/collectors/gsuite/local/sam-template.yaml
@@ -34,7 +34,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.58",
+  "version": "1.2.59",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -22,15 +22,15 @@
     "mocha-jenkins-reporter": "^0.4.8",
     "moment": "2.30.1",
     "nyc": "^17.0.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
-    "googleapis": "^144.0.0",
+    "debug": "^4.4.3",
+    "googleapis": "^160.0.0",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/mimecast/al-mimecast-collector.json
+++ b/collectors/mimecast/al-mimecast-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/mimecast/local/sam-template.yaml
+++ b/collectors/mimecast/local/sam-template.yaml
@@ -35,7 +35,7 @@ Resources:
           ssm_direct:
           paws_type_name:
       CodeUri: 
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -22,17 +22,17 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "adm-zip": "^0.5.16",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1",
-    "uuid": "^10.0.0"
+    "uuid": "^13.0.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/o365/al-o365-collector.json
+++ b/collectors/o365/al-o365-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/o365/local/sam-template.yaml
+++ b/collectors/o365/local/sam-template.yaml
@@ -35,7 +35,7 @@ Resources:
           paws_dedup_logs_ddb_table_name:
           ssm_direct:
       CodeUri: 
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 60 
       MemorySize: 1024

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.70",
+  "version": "1.2.71",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -21,24 +21,24 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-     "@alertlogic/al-aws-collector-js": "^4.1.29",
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-aws-collector-js": "^4.1.29",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "@azure/ms-rest-azure-js": "2.1.0",
     "@azure/ms-rest-js": "2.7.0",
     "@azure/ms-rest-nodeauth": "3.1.1",
     "@smithy/node-http-handler": "^4.0.4",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1",
     "tiny-async-pool": "^2.1.0"
   },
   "overrides": {
-    "axios": "^1.8.4"
+    "axios": "^1.11.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/okta/al-okta-collector.json
+++ b/collectors/okta/al-okta-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/okta/local/sam-template.yaml
+++ b/collectors/okta/local/sam-template.yaml
@@ -31,7 +31,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri: 
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.2.30",
+  "version": "1.2.31",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -20,17 +20,17 @@
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
-    "nock": "^13.5.5",
+    "nock": "^14.0.10",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "@okta/okta-sdk-nodejs": "^7.1.1",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/salesforce/al-salesforce-collector.json
+++ b/collectors/salesforce/al-salesforce-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/salesforce/local/sam-template.yaml
+++ b/collectors/salesforce/local/sam-template.yaml
@@ -35,7 +35,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.59",
+  "version": "1.1.60",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -21,14 +21,14 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "jsforce": "^3.7.0",
     "jsonwebtoken": "^9.0.2",
     "moment": "2.30.1"

--- a/collectors/sentinelone/al-sentinelone-collector.json
+++ b/collectors/sentinelone/al-sentinelone-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/sentinelone/local/sam-template.yaml
+++ b/collectors/sentinelone/local/sam-template.yaml
@@ -32,7 +32,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri: 
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -21,14 +21,14 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/sophos/al-sophos-collector.json
+++ b/collectors/sophos/al-sophos-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/sophos/local/sam-template.yaml
+++ b/collectors/sophos/local/sam-template.yaml
@@ -32,7 +32,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:      
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -23,14 +23,14 @@
     "mocha-jenkins-reporter": "^0.4.8",
     "mockserver": "^3.1.1",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/sophossiem/al-sophossiem-collector.json
+++ b/collectors/sophossiem/al-sophossiem-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/sophossiem/local/sam-template.yaml
+++ b/collectors/sophossiem/local/sam-template.yaml
@@ -32,7 +32,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:     
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -21,14 +21,14 @@
     "mocha": "^10.7.3",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.15",
-    "@alertlogic/paws-collector": "2.2.7",
+    "@alertlogic/al-collector-js": "3.0.16",
+    "@alertlogic/paws-collector": "2.2.8",
     "async": "^3.2.6",
-    "debug": "^4.4.0",
+    "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/collectors/template/collector.json
+++ b/collectors/template/collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/collectors/template/local/sam-template.yaml
+++ b/collectors/template/local/sam-template.yaml
@@ -25,7 +25,7 @@ Resources:
           collector_id:
           ssm_direct:
           paws_type_name:
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/template/package.json.template
+++ b/collectors/template/package.json.template
@@ -19,8 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "^3.0.5",
-    "@alertlogic/paws-collector": "^2.1.13",
+    "@alertlogic/al-collector-js": "^3.0.16",
+    "@alertlogic/paws-collector": "^2.2.8",
     "async": "^3.2.4",
     "debug": "^4.3.4",
     "moment": "2.29.4"

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -60,9 +60,9 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-auth0-collector"
-      ALPS_SERVICE_VERSION: "1.1.60" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.1.61" #set the value from collector package json
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh auth0
     outputs:
       file: ./auth0-collector*
@@ -78,11 +78,11 @@ stages:
       - pull_request:
           trigger_phrase: build-collectors
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh carbonblack
     env:
       ALPS_SERVICE_NAME: "paws-carbonblack-collector"
-      ALPS_SERVICE_VERSION: "1.0.58" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.59" #set the value from collector package json
     outputs:
       file: ./carbonblack-collector*
     packagers:
@@ -98,9 +98,9 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-ciscoamp-collector"
-      ALPS_SERVICE_VERSION: "1.0.57" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.58" #set the value from collector package json
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh ciscoamp
     outputs:
       file: ./ciscoamp-collector*
@@ -116,11 +116,11 @@ stages:
       - pull_request:
           trigger_phrase: build-collectors
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh ciscoduo
     env:
       ALPS_SERVICE_NAME: "paws-ciscoduo-collector"
-      ALPS_SERVICE_VERSION: "1.0.57" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.58" #set the value from collector package json
     outputs:
       file: ./ciscoduo-collector*
     packagers:
@@ -135,11 +135,11 @@ stages:
       - pull_request:
           trigger_phrase: build-collectors
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh ciscomeraki
     env:
       ALPS_SERVICE_NAME: "paws-ciscomeraki-collector"
-      ALPS_SERVICE_VERSION: "1.0.9" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.10" #set the value from collector package json
     outputs:
       file: ./ciscomeraki-collector*
     packagers:
@@ -155,9 +155,9 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-crowdstrike-collector"
-      ALPS_SERVICE_VERSION: "1.0.39" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.40" #set the value from collector package json
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh crowdstrike
     outputs:
       file: ./crowdstrike-collector*
@@ -173,11 +173,11 @@ stages:
       - pull_request:
           trigger_phrase: build-collectors
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh googlestackdriver
     env:
       ALPS_SERVICE_NAME: "paws-googlestackdriver-collector"
-      ALPS_SERVICE_VERSION: "1.2.16" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.17" #set the value from collector package json
     outputs:
       file: ./googlestackdriver-collector*
     packagers:
@@ -193,9 +193,9 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-gsuite-collector"
-      ALPS_SERVICE_VERSION: "1.2.58" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.59" #set the value from collector package json
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh gsuite
     outputs:
       file: ./gsuite-collector*
@@ -211,11 +211,11 @@ stages:
       - pull_request:
           trigger_phrase: build-collectors
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh mimecast
     env:
       ALPS_SERVICE_NAME: "paws-mimecast-collector"
-      ALPS_SERVICE_VERSION: "1.0.50" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.51" #set the value from collector package json
     outputs:
       file: ./mimecast-collector*
     packagers:
@@ -231,9 +231,9 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-o365-collector"
-      ALPS_SERVICE_VERSION: "1.2.70" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.71" #set the value from collector package json
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh o365
     outputs:
       file: ./o365-collector*
@@ -249,11 +249,11 @@ stages:
       - pull_request:
           trigger_phrase: build-collectors
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh okta
     env:
       ALPS_SERVICE_NAME: "paws-okta-collector"
-      ALPS_SERVICE_VERSION: "1.2.30" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.31" #set the value from collector package json
     outputs:
       file: ./okta-collector*
     packagers:
@@ -269,9 +269,9 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-salesforce-collector"
-      ALPS_SERVICE_VERSION: "1.1.59" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.1.60" #set the value from collector package json
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh salesforce
     outputs:
       file: ./salesforce-collector*
@@ -287,11 +287,11 @@ stages:
       - pull_request:
           trigger_phrase: build-collectors
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh sentinelone
     env:
       ALPS_SERVICE_NAME: "paws-sentinelone-collector"
-      ALPS_SERVICE_VERSION: "1.0.56" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.57" #set the value from collector package json
     outputs:
       file: ./sentinelone-collector*
     packagers:
@@ -307,9 +307,9 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-sophos-collector"
-      ALPS_SERVICE_VERSION: "1.0.56" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.57" #set the value from collector package json
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh sophos
     outputs:
       file: ./sophos-collector*
@@ -325,11 +325,11 @@ stages:
       - pull_request:
           trigger_phrase: build-collectors
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh sophossiem
     env:
       ALPS_SERVICE_NAME: "paws-sophossiem-collector"
-      ALPS_SERVICE_VERSION: "1.2.17" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.18" #set the value from collector package json
     outputs:
       file: ./sophossiem-collector*
     packagers:
@@ -342,7 +342,7 @@ stages:
       - pull_request:
           trigger_phrase: build-all-collectors
     commands:
-      - source $NVM_DIR/nvm.sh && nvm use 20
+      - source $NVM_DIR/nvm.sh && nvm use 22
       - make package-all
       - zip -r artifact_folder.zip artifact_folder
     outputs:


### PR DESCRIPTION
### Problem Description
Update NodeJS version to 22 and fix Vulnerabilities reported by AWS inspector 

### Solution Description
Fixed by bumping npm packages versions
```
1.     "@alertlogic/al-collector-js": "3.0.16",
2.     "@alertlogic/paws-collector": "2.2.8",
3.     "rewire": "^9.0.1",
4.     "debug": "^4.4.3",
5.     "@alertlogic/al-aws-collector-js": "^4.1.29"
```
and updated node js to 22 version in sam templates
gsuite and googlestackdriver npm packages updated are:

```
- "google-auth-library": "^10.3.0",
- "googleapis": "^160.0.0",
```