### PR TITLE
[mimecast-collector] build issue as creation of zip failed because of ESM uuid package

### DIFF
--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -32,7 +32,7 @@
     "async": "^3.2.6",
     "debug": "^4.4.3",
     "moment": "2.30.1",
-    "uuid": "^13.0.0"
+    "uuid": "^10.0.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -215,7 +215,7 @@ stages:
       - ./build_collector.sh mimecast
     env:
       ALPS_SERVICE_NAME: "paws-mimecast-collector"
-      ALPS_SERVICE_VERSION: "1.0.51" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.52" #set the value from collector package json
     outputs:
       file: ./mimecast-collector*
     packagers:


### PR DESCRIPTION
### Problem Description
Upgrading uuid beyond version 10 introduces breaking changes with node version 22.3.0. Starting with uuid@12, CommonJS (require()) is no longer supported, and the package is ESM-only. Since this project still depends on CommonJS modules, using uuid@12+ results in runtime errors (ERR_REQUIRE_ESM).

### Solution Description
Pin uuid to ^10.0.0, the latest version that supports CommonJS. This ensures compatibility with our current codebase while avoiding ESM migration work for now.