### PR TITLE
[ENG-58738-Paws all collectors]Revert datadog-lambda-js npm package version from 12.128.0 to 9.120.0

### DIFF
--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.1.61",
+  "version": "1.1.62",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^3.0.15",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "^3.2.6",
     "auth0": "^3.7.2",
     "debug": "^4.4.3",

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "^3.2.6",
     "debug": "^4.4.3",
     "moment": "2.30.1",

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "^3.2.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "@duosecurity/duo_api": "^1.4.0",
     "async": "^3.2.6",
     "debug": "^4.4.3",

--- a/collectors/ciscomeraki/package.json
+++ b/collectors/ciscomeraki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscomeraki-collector",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Alert Logic AWS based Cisco Meraki Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "^3.2.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "^3.0.15",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "^3.2.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "^3.2.6",
     "debug": "^4.4.3",
     "google-auth-library": "^10.3.0",

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.2.59",
+  "version": "1.2.60",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "^3.2.6",
     "debug": "^4.4.3",
     "googleapis": "^160.0.0",

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "adm-zip": "^0.5.16",
     "async": "^3.2.6",
     "debug": "^4.4.3",

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.2.71",
+  "version": "1.2.72",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -27,7 +27,7 @@
   "dependencies": {
     "@alertlogic/al-aws-collector-js": "^4.1.29",
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "@azure/ms-rest-azure-js": "2.1.0",
     "@azure/ms-rest-js": "2.7.0",
     "@azure/ms-rest-nodeauth": "3.1.1",

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.2.31",
+  "version": "1.2.32",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "@okta/okta-sdk-nodejs": "^7.1.1",
     "async": "^3.2.6",
     "debug": "^4.4.3",

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.60",
+  "version": "1.1.61",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "^3.2.6",
     "debug": "^4.4.3",
     "jsforce": "^3.7.0",

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "3.2.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "3.2.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.16",
-    "@alertlogic/paws-collector": "2.2.8",
+    "@alertlogic/paws-collector": "2.2.9",
     "async": "^3.2.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -60,7 +60,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-auth0-collector"
-      ALPS_SERVICE_VERSION: "1.1.61" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.1.62" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh auth0
@@ -82,7 +82,7 @@ stages:
       - ./build_collector.sh carbonblack
     env:
       ALPS_SERVICE_NAME: "paws-carbonblack-collector"
-      ALPS_SERVICE_VERSION: "1.0.59" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.60" #set the value from collector package json
     outputs:
       file: ./carbonblack-collector*
     packagers:
@@ -98,7 +98,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-ciscoamp-collector"
-      ALPS_SERVICE_VERSION: "1.0.58" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.59" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh ciscoamp
@@ -120,7 +120,7 @@ stages:
       - ./build_collector.sh ciscoduo
     env:
       ALPS_SERVICE_NAME: "paws-ciscoduo-collector"
-      ALPS_SERVICE_VERSION: "1.0.58" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.59" #set the value from collector package json
     outputs:
       file: ./ciscoduo-collector*
     packagers:
@@ -139,7 +139,7 @@ stages:
       - ./build_collector.sh ciscomeraki
     env:
       ALPS_SERVICE_NAME: "paws-ciscomeraki-collector"
-      ALPS_SERVICE_VERSION: "1.0.10" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.11" #set the value from collector package json
     outputs:
       file: ./ciscomeraki-collector*
     packagers:
@@ -155,7 +155,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-crowdstrike-collector"
-      ALPS_SERVICE_VERSION: "1.0.40" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.41" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh crowdstrike
@@ -177,7 +177,7 @@ stages:
       - ./build_collector.sh googlestackdriver
     env:
       ALPS_SERVICE_NAME: "paws-googlestackdriver-collector"
-      ALPS_SERVICE_VERSION: "1.2.17" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.18" #set the value from collector package json
     outputs:
       file: ./googlestackdriver-collector*
     packagers:
@@ -193,7 +193,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-gsuite-collector"
-      ALPS_SERVICE_VERSION: "1.2.59" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.60" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh gsuite
@@ -215,7 +215,7 @@ stages:
       - ./build_collector.sh mimecast
     env:
       ALPS_SERVICE_NAME: "paws-mimecast-collector"
-      ALPS_SERVICE_VERSION: "1.0.52" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.53" #set the value from collector package json
     outputs:
       file: ./mimecast-collector*
     packagers:
@@ -231,7 +231,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-o365-collector"
-      ALPS_SERVICE_VERSION: "1.2.71" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.72" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh o365
@@ -253,7 +253,7 @@ stages:
       - ./build_collector.sh okta
     env:
       ALPS_SERVICE_NAME: "paws-okta-collector"
-      ALPS_SERVICE_VERSION: "1.2.31" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.32" #set the value from collector package json
     outputs:
       file: ./okta-collector*
     packagers:
@@ -269,7 +269,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-salesforce-collector"
-      ALPS_SERVICE_VERSION: "1.1.60" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.1.61" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh salesforce
@@ -291,7 +291,7 @@ stages:
       - ./build_collector.sh sentinelone
     env:
       ALPS_SERVICE_NAME: "paws-sentinelone-collector"
-      ALPS_SERVICE_VERSION: "1.0.57" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.58" #set the value from collector package json
     outputs:
       file: ./sentinelone-collector*
     packagers:
@@ -307,7 +307,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-sophos-collector"
-      ALPS_SERVICE_VERSION: "1.0.57" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.0.58" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh sophos
@@ -329,7 +329,7 @@ stages:
       - ./build_collector.sh sophossiem
     env:
       ALPS_SERVICE_NAME: "paws-sophossiem-collector"
-      ALPS_SERVICE_VERSION: "1.2.18" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.19" #set the value from collector package json
     outputs:
       file: ./sophossiem-collector*
     packagers:


### PR DESCRIPTION
### Problem Description
Revert datadog-lambda-js npm package version from 12.128.0 to 9.120.0


### Solution Description
See the release tag of datadog-lambda-js for more information
https://github.com/DataDog/datadog-lambda-js/releases/tag/v12.127.0