### PR TITLE
[ENG-59912 Salesforce, Sentinel one, Sophos and Sophos siem collectors] : Migrate the code from callback to async/await

### DIFF
--- a/collectors/salesforce/.jshintrc
+++ b/collectors/salesforce/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "esversion": 6,
+  "esversion": 11,
   "shadow": "outer",
   "undef": true,
   "unused": "vars",

--- a/collectors/salesforce/collector.js
+++ b/collectors/salesforce/collector.js
@@ -29,7 +29,7 @@ class SalesforceCollector extends PawsCollector {
         super(context, creds, packageJson.version);
     }
 
-    pawsInitCollectionState(event, callback) {
+    async pawsInitCollectionState(event) {
 
         const startTs = process.env.paws_collection_start_ts ?
             process.env.paws_collection_start_ts :
@@ -48,19 +48,19 @@ class SalesforceCollector extends PawsCollector {
                 poll_interval_sec: 1
             }
         });
-        return callback(null, initialStates, 1);
+        return { state: initialStates, nextInvocationTimeout: 1 };
     }
 
-    pawsGetRegisterParameters(event, callback) {
+    async pawsGetRegisterParameters(event) {
         const regValues = {
             salesforceUserID: process.env.paws_collector_param_string_1,
             salesforceObjectNames: process.env.collector_streams
         };
 
-        callback(null, regValues);
+        return regValues;
     }
 
-    pawsGetLogs(state, callback) {
+    async pawsGetLogs(state) {
         let collector = this;
         // This code can remove once exsisting code set stream and collector_streams env variable
         if (!process.env.collector_streams) {
@@ -69,7 +69,7 @@ class SalesforceCollector extends PawsCollector {
         if (!state.stream) {
             state = collector.setStreamToCollectionState(state);
         }
-          
+
         const privateKey = collector.secret;
         if (!privateKey) {
             throw new Error("The private key was not found!");
@@ -92,76 +92,83 @@ class SalesforceCollector extends PawsCollector {
 
         if (state.apiQuotaResetDate && moment().isBefore(state.apiQuotaResetDate)) {
             AlLogger.info(`API Request Limit Exceeded. The quota will be reset at ${state.apiQuotaResetDate}`);
-            collector.reportApiThrottling(function () {
-                return callback(null, [], state, state.poll_interval_sec);
-            });
+            await collector.reportApiThrottling();
+            return [[], state, state.poll_interval_sec];
         }
-        else {
+        const restServiceClient = new RestServiceClient(baseUrl);
+        const formData = new URLSearchParams();
+        formData.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
+        formData.append('assertion', token);
 
-            let restServiceClient = new RestServiceClient(baseUrl);
-            const formData = new URLSearchParams();
-            formData.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
-            formData.append('assertion', token);
-            restServiceClient.post(tokenUrl, {
+        let response;
+        try {
+            response = await restServiceClient.post(tokenUrl, {
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
                 data: formData
-            }).then(response => {
-                var objectQueryDetails = utils.getObjectQuery(state);
-                if (!objectQueryDetails.query) {
-                    return callback("The object name was not found!");
-                }
-                tsPaths = objectQueryDetails.tsPaths;
-                utils.getObjectLogs(response, objectQueryDetails, [], state, process.env.paws_max_pages_per_invocation)
-                    .then(({ accumulator, nextPage }) => {
-                        let newState;
-                        if (nextPage === undefined) {
-                            newState = this._getNextCollectionState(state);
-                        } else {
-                            newState = this._getNextCollectionStateWithNextPage(state, nextPage);
-                        }
-                        AlLogger.info(`SALE000002 Next collection in ${newState.poll_interval_sec} seconds`);
-                        return callback(null, accumulator, newState, newState.poll_interval_sec);
-                    })
-                    .catch((error) => {
-                        if (error.errorCode && error.errorCode === "REQUEST_LIMIT_EXCEEDED") {
-                            // Api will reset after next 24 hours 
-                            // Added extra 1 hours for buffer
-                            state.apiQuotaResetDate = moment().add(25, "hours").toISOString();
-                            state.poll_interval_sec = 900;
-                            AlLogger.info(`API Request Limit Exceeded. The quota will be reset at ${state.apiQuotaResetDate}`);
-                            collector.reportApiThrottling(function () {
-                                return callback(null, [], state, state.poll_interval_sec);
-                            });
-                        }
-                        else {
-                            if (error.errorCode && error.errorCode === "INVALID_FIELD") {
-                                AlLogger.info(`API not able to fetch field for object ${state.stream}`);
-                            }
-                            if (error.errorCode && error.errorCode === "INVALID_TYPE") {
-                                AlLogger.info(`API not able to fetch logs for object ${state.stream}`);
-                            }
-                            if (error.errorCode && error.errorCode === "INVALID_SESSION_ID") {
-                                AlLogger.info("User not added 'Access and manage your data (api)' in Oauth scope");
-                            }
-                            return callback(error);
-                        }
-
-                    });
-
-            }).catch(err => {
-                // set errorCode if not available in error object to showcase client error on DDMetrics
-                if (err.response && err.response.data) {
-                    err.response.data.errorCode = err.response.data.error;
-                    return callback(err.response.data);
-                }
-                else {
-                    err.errorCode = err.response.status;
-                    return callback(err);
-                }
             });
-        } 
+        } catch (err) {
+            this._throwNormalizedClientError(err);
+        }
+
+        const objectQueryDetails = utils.getObjectQuery(state);
+        if (!objectQueryDetails.query) {
+            throw new Error("The object name was not found!");
+        }
+        tsPaths = objectQueryDetails.tsPaths;
+
+        try {
+            const { accumulator, nextPage } = await utils.getObjectLogs(response, objectQueryDetails, [], state, process.env.paws_max_pages_per_invocation);
+
+            let newState;
+            if (nextPage === undefined) {
+                newState = this._getNextCollectionState(state);
+            } else {
+                newState = this._getNextCollectionStateWithNextPage(state, nextPage);
+            }
+            AlLogger.info(`SALE000002 Next collection in ${newState.poll_interval_sec} seconds`);
+            return [accumulator, newState, newState.poll_interval_sec];
+        } catch (error) {
+            return this._handleGetLogsError(error, state, collector);
+        }
+    }
+
+    _throwNormalizedClientError(error) {
+        // set errorCode if not available in error object to showcase client error on DDMetrics
+        if (error && error.response && error.response.data && typeof error.response.data === 'object') {
+            if (!error.response.data.errorCode) {
+                error.response.data.errorCode = error.response.data.error || error.response.status || "CLIENT_ERROR";
+            }
+            throw error.response.data;
+        }
+        if (error && error.response) {
+            error.errorCode = error.errorCode || error.response.status || "CLIENT_ERROR";
+        }
+        throw error;
+    }
+
+    async _handleGetLogsError(error, state, collector) {
+        if (error.errorCode && error.errorCode === "REQUEST_LIMIT_EXCEEDED") {
+            // Api will reset after next 24 hours 
+            // Added extra 1 hours for buffer
+            state.apiQuotaResetDate = moment().add(25, "hours").toISOString();
+            state.poll_interval_sec = 900;
+            AlLogger.info(`API Request Limit Exceeded. The quota will be reset at ${state.apiQuotaResetDate}`);
+            await collector.reportApiThrottling();
+            return [[], state, state.poll_interval_sec];
+        }
+
+        if (error.errorCode && error.errorCode === "INVALID_FIELD") {
+            AlLogger.info(`API not able to fetch field for object ${state.stream}`);
+        }
+        if (error.errorCode && error.errorCode === "INVALID_TYPE") {
+            AlLogger.info(`API not able to fetch logs for object ${state.stream}`);
+        }
+        if (error.errorCode && error.errorCode === "INVALID_SESSION_ID") {
+            AlLogger.info("User not added 'Access and manage your data (api)' in Oauth scope");
+        }
+        throw error;
     }
 
     _getNextCollectionState(curState) {

--- a/collectors/salesforce/index.js
+++ b/collectors/salesforce/index.js
@@ -12,11 +12,15 @@ const debug = require('debug') ('index');
 const AlLogger = require('@alertlogic/al-aws-collector-js').Logger;
 const SalesforceCollector = require('./collector').SalesforceCollector;
 
-exports.handler = SalesforceCollector.makeHandler(function(event, context) {
+exports.handler = SalesforceCollector.makeHandler(async function(event, context) {
     debug('input event: ', event);
     AlLogger.defaultMeta = { requestId: context.awsRequestId };
-    SalesforceCollector.load().then(function(creds) {
-        var salesforcec = new SalesforceCollector(context, creds);
-        salesforcec.handleEvent(event);
-    });
+    try {
+        const creds = await SalesforceCollector.load();
+        let salesforcec = new SalesforceCollector(context, creds);
+        await salesforcec.handleEvent(event);
+    } catch (error) {
+        AlLogger.error('Unhandled error in handler: ', error);
+        throw error;
+    }
 });

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.1.63",
+  "version": "1.2.0",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.777.0",
-    "@aws-sdk/client-cloudwatch": "^3.777.0",
-    "@aws-sdk/client-dynamodb": "^3.777.0",
-    "@aws-sdk/client-kms": "^3.777.0",
-    "@aws-sdk/client-lambda": "^3.777.0",
-    "@aws-sdk/client-s3": "^3.779.0",
-    "@aws-sdk/client-sqs": "^3.777.0",
-    "@aws-sdk/client-ssm": "^3.777.0",
+    "@aws-sdk/client-cloudformation": "^3.1000.0",
+    "@aws-sdk/client-cloudwatch": "^3.1000.0",
+    "@aws-sdk/client-dynamodb": "^3.1000.0",
+    "@aws-sdk/client-kms": "^3.1000.0",
+    "@aws-sdk/client-lambda": "^3.1000.0",
+    "@aws-sdk/client-s3": "^3.1000.0",
+    "@aws-sdk/client-sqs": "^3.1000.0",
+    "@aws-sdk/client-ssm": "^3.1000.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -25,15 +25,16 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.2.11",
-    "async": "^3.2.6",
+    "@alertlogic/paws-collector": "2.3.2",
     "debug": "^4.4.3",
     "jsforce": "^3.7.0",
     "jsonwebtoken": "^9.0.2",
     "moment": "2.30.1"
   },
   "overrides": {
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "minimatch": "^3.1.4",
+    "serialize-javascript": "^7.0.3"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/salesforce/test/salesforce_test.js
+++ b/collectors/salesforce/test/salesforce_test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const m_response = require('cfn-response');
+const m_response = require('@alertlogic/al-aws-collector-js').CfnResponse;
 const salesforceMock = require('./salesforce_mock');
 var SalesforceCollector = require('../collector').SalesforceCollector;
 const moment = require('moment');
@@ -42,29 +42,34 @@ function setAlServiceStub() {
 }
 
 function restoreAlServiceStub() {
-
-    token.restore();
-    requestPost.restore();
-    getObjectQuery.restore();
+    if (token && token.restore) {
+        token.restore();
+    }
+    if (requestPost && requestPost.restore) {
+        requestPost.restore();
+    }
+    if (getObjectQuery && getObjectQuery.restore) {
+        getObjectQuery.restore();
+    }
 }
 
 describe('Unit Tests', function () {
 
     beforeEach(function () {
-        sinon.stub(SSM.prototype, 'getParameter').callsFake(function (params, callback) {
+        sinon.stub(SSM.prototype, 'getParameter').callsFake(function (params) {
             const data = Buffer.from('test-secret');
-            return callback(null, { Parameter: { Value: data.toString('base64') } });
+            return Promise.resolve({ Parameter: { Value: data.toString('base64') } });
         });
-        sinon.stub(KMS.prototype, 'decrypt').callsFake(function (params, callback) {
+        sinon.stub(KMS.prototype, 'decrypt').callsFake(function (params) {
             const data = {
                 Plaintext: Buffer.from('{}')
             };
-            return callback(null, data);
+            return Promise.resolve(data);
         });
 
         responseStub = sinon.stub(m_response, 'send').callsFake(
             function fakeFn(event, mockContext, responseStatus, responseData, physicalResourceId) {
-                mockContext.succeed();
+               return Promise.resolve();
             });
     
     });
@@ -87,64 +92,52 @@ describe('Unit Tests', function () {
         beforeEach(function(){
             setAlServiceStub();
         });
-        it('get inital state less than 7 days in the past', function (done) {
-            SalesforceCollector.load().then(function (creds) {
-                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
-                const startDate = moment().subtract(1, 'days').toISOString();
-                process.env.paws_collection_start_ts = startDate;
+        it('get inital state less than 7 days in the past', async function () {
+            const creds = await SalesforceCollector.load();
+            var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+            const startDate = moment().subtract(1, 'days').toISOString();
+            process.env.paws_collection_start_ts = startDate;
 
-                collector.pawsInitCollectionState(null, (err, initialStates, nextPoll) => {
-                    initialStates.forEach((state) => {
-                        assert.equal(state.since, startDate, "Dates are not equal");
-                        assert.notEqual(moment(state.until).diff(state.since, 'hours'), 24);
-                    });
-                    done();
-                });
+            const { state: initialStates } = await collector.pawsInitCollectionState(null);
+            initialStates.forEach((collectionState) => {
+                assert.equal(collectionState.since, startDate, "Dates are not equal");
+                assert.notEqual(moment(collectionState.until).diff(collectionState.since, 'hours'), 24);
             });
         });
-        it('get inital state less than 24 hours in the past', function (done) {
-            SalesforceCollector.load().then(function (creds) {
-                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
-                const startDate = moment().subtract(12, 'hours').toISOString();
-                process.env.paws_collection_start_ts = startDate;
+        it('get inital state less than 24 hours in the past', async function () {
+            const creds = await SalesforceCollector.load();
+            var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+            const startDate = moment().subtract(12, 'hours').toISOString();
+            process.env.paws_collection_start_ts = startDate;
 
-                collector.pawsInitCollectionState(null, (err, initialStates, nextPoll) => {
-                    initialStates.forEach((state) => {
-                        assert.notEqual(moment(state.until).diff(state.since, 'hours'), 24);
-                    });
-                    done();
-                });
+            const { state: initialStates } = await collector.pawsInitCollectionState(null);
+            initialStates.forEach((collectionState) => {
+                assert.notEqual(moment(collectionState.until).diff(collectionState.since, 'hours'), 24);
             });
         });
 
     });
 
     describe('Paws Get Register Parameters', function () {
-        it('Paws Get Register Parameters Success', function (done) {
+        it('Paws Get Register Parameters Success', async function () {
             setAlServiceStub();
             let ctx = {
                 invokedFunctionArn: salesforceMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
-            SalesforceCollector.load().then(function (creds) {
-                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
-                const sampleEvent = { ResourceProperties: { StackName: 'a-stack-name' } };
-                collector.pawsGetRegisterParameters(sampleEvent, (err, regValues) => {
-                    const expectedRegValues = {
-                        salesforceUserID: 'salesforceUserID',
-                        salesforceObjectNames: '["LoginHistory", "EventLogFile","ApiEvent", "LoginEvent", "LogoutEvent", "LoginAsEvent"]'
-                    };
-                    assert.deepEqual(regValues, expectedRegValues);
-                    done();
-                });
-            });
+            const creds = await SalesforceCollector.load();
+            var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+            const sampleEvent = { ResourceProperties: { StackName: 'a-stack-name' } };
+            const regValues = await collector.pawsGetRegisterParameters(sampleEvent);
+            const expectedRegValues = {
+                salesforceUserID: 'salesforceUserID',
+                salesforceObjectNames: '["LoginHistory", "EventLogFile","ApiEvent", "LoginEvent", "LogoutEvent", "LoginAsEvent"]'
+            };
+            assert.deepEqual(regValues, expectedRegValues);
         });
     });
 
@@ -159,7 +152,7 @@ describe('Unit Tests', function () {
         beforeEach(function(){
             setAlServiceStub();
         });
-        it('Paws Get Logs Success', function (done) {
+        it('Paws Get Logs Success', async function () {
 
             getObjectLogs = sinon.stub(utils, 'getObjectLogs').callsFake(
                 function fakeFn(response, objectQueryDetails, accumulator, state, maxPagesPerInvocation) {
@@ -167,8 +160,8 @@ describe('Unit Tests', function () {
                         return resolve({ accumulator: [salesforceMock.LOG_EVENT, salesforceMock.LOG_EVENT] });
                     });
                 });
-
-            SalesforceCollector.load().then(function (creds) {
+            try {
+                const creds = await SalesforceCollector.load();
                 var collector = new SalesforceCollector(ctx, creds, 'salesforce');
                 const startDate = moment().subtract(3, 'days');
                 const curState = {
@@ -178,18 +171,16 @@ describe('Unit Tests', function () {
                     poll_interval_sec: 1
                 };
 
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(logs.length, 2);
-                    assert.equal(newState.poll_interval_sec, 1);
-                    assert.ok(logs[0].attributes);
-                    getObjectLogs.restore();
-                    done();
-                });
-
-            });
+                const [logs, newState] = await collector.pawsGetLogs(curState);
+                assert.equal(logs.length, 2);
+                assert.equal(newState.poll_interval_sec, 1);
+                assert.ok(logs[0].attributes);
+            } finally {
+                getObjectLogs.restore();
+            }
         });
 
-        it('Paws Get Logs with API Quota Reset Date', function (done) {
+        it('Paws Get Logs with API Quota Reset Date', async function () {
 
             getObjectLogs = sinon.stub(utils, 'getObjectLogs').callsFake(
                 function fakeFn(response, objectQueryDetails, accumulator, state, maxPagesPerInvocation) {
@@ -197,8 +188,9 @@ describe('Unit Tests', function () {
                         return resolve({ accumulator: [salesforceMock.LOG_EVENT, salesforceMock.LOG_EVENT] });
                     });
                 });
-
-            SalesforceCollector.load().then(function (creds) {
+            let putMetricDataStub;
+            try {
+                const creds = await SalesforceCollector.load();
                 var collector = new SalesforceCollector(ctx, creds, 'salesforce');
                 const startDate = moment().subtract(3, 'days');
                 const curState = {
@@ -210,20 +202,20 @@ describe('Unit Tests', function () {
                 };
 
                 var reportSpy = sinon.spy(collector, 'reportApiThrottling');
-                let putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake((params, callback) => callback(null));
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(true, reportSpy.calledOnce);
-                    assert.equal(logs.length, 0);
-                    assert.equal(newState.poll_interval_sec, 900);
-                    getObjectLogs.restore();
+                putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake((params) => Promise.resolve());
+                const [logs, newState] = await collector.pawsGetLogs(curState);
+                assert.equal(true, reportSpy.calledOnce);
+                assert.equal(logs.length, 0);
+                assert.equal(newState.poll_interval_sec, 900);
+            } finally {
+                getObjectLogs.restore();
+                if (putMetricDataStub && putMetricDataStub.restore) {
                     putMetricDataStub.restore();
-                    done();
-                });
-
-            });
+                }
+            }
         });
 
-        it('Paws Get Logs check throttling error', function (done) {
+        it('Paws Get Logs check throttling error', async function () {
 
             getObjectLogs = sinon.stub(utils, 'getObjectLogs').callsFake(
                 function fakeFn(response, objectQueryDetails, accumulator, state, maxPagesPerInvocation) {
@@ -231,8 +223,9 @@ describe('Unit Tests', function () {
                         return reject({ errorCode: "REQUEST_LIMIT_EXCEEDED"  });
                     });
                 });
-
-            SalesforceCollector.load().then(function (creds) {
+            let putMetricDataStub;
+            try {
+                const creds = await SalesforceCollector.load();
                 var collector = new SalesforceCollector(ctx, creds, 'salesforce');
                 const startDate = moment().subtract(3, 'days');
                 const curState = {
@@ -243,17 +236,17 @@ describe('Unit Tests', function () {
                 };
 
                 var reportSpy = sinon.spy(collector, 'reportApiThrottling');
-                let putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake((params, callback) => callback(null));
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(true, reportSpy.calledOnce);
-                    assert.equal(logs.length, 0);
-                    assert.equal(newState.poll_interval_sec, 900);
-                    getObjectLogs.restore();
+                putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake((params) => Promise.resolve());
+                const [logs, newState] = await collector.pawsGetLogs(curState);
+                assert.equal(true, reportSpy.calledOnce);
+                assert.equal(logs.length, 0);
+                assert.equal(newState.poll_interval_sec, 900);
+            } finally {
+                getObjectLogs.restore();
+                if (putMetricDataStub && putMetricDataStub.restore) {
                     putMetricDataStub.restore();
-                    done();
-                });
-
-            });
+                }
+            }
         });
     });
 
@@ -270,111 +263,95 @@ describe('Unit Tests', function () {
         beforeEach(function(){
             setAlServiceStub();
         });
-        it('get next state if more than 24 hours in the past', function (done) {
+        it('get next state if more than 24 hours in the past', async function () {
             const startDate = moment().subtract(10, 'days');
             const curState = {
                 since: startDate.toISOString(),
                 until: startDate.add(5, 'days').toISOString(),
                 poll_interval_sec: 1
             };
-            SalesforceCollector.load().then(function (creds) {
-                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
-                const newState = collector._getNextCollectionState(curState);
-                assert.equal(moment(newState.until).diff(newState.since, 'hours'), 24);
-                assert.equal(newState.poll_interval_sec, 1);
-                done();
-            });
+            const creds = await SalesforceCollector.load();
+            var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+            const newState = collector._getNextCollectionState(curState);
+            assert.equal(moment(newState.until).diff(newState.since, 'hours'), 24);
+            assert.equal(newState.poll_interval_sec, 1);
         });
 
 
-        it('get next state if more than 1 hours in the past', function (done) {
+        it('get next state if more than 1 hours in the past', async function () {
             const startDate = moment().subtract(5, 'hours');
             const curState = {
                 since: startDate.toISOString(),
                 until: startDate.add(3, 'hours').toISOString(),
                 poll_interval_sec: 1
             };
-            SalesforceCollector.load().then(function (creds) {
-                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
-                const newState = collector._getNextCollectionState(curState);
-                assert.equal(moment(newState.until).diff(newState.since, 'hours'), 1);
-                assert.equal(newState.poll_interval_sec, 1);
-                done();
-            });
+            const creds = await SalesforceCollector.load();
+            var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+            const newState = collector._getNextCollectionState(curState);
+            assert.equal(moment(newState.until).diff(newState.since, 'hours'), 1);
+            assert.equal(newState.poll_interval_sec, 1);
         });
 
 
-        it('get next state if less than 1 hour in the past but more than the polling interval', function (done) {
+        it('get next state if less than 1 hour in the past but more than the polling interval', async function () {
             const startDate = moment().subtract(20, 'minutes');
-            SalesforceCollector.load().then(function (creds) {
-                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(collector.pollInterval, 'seconds').toISOString(),
-                    poll_interval_sec: 1
-                };
-                const newState = collector._getNextCollectionState(curState);
-                assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                assert.equal(newState.poll_interval_sec, 1);
-                done();
-            });
+            const creds = await SalesforceCollector.load();
+            var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(collector.pollInterval, 'seconds').toISOString(),
+                poll_interval_sec: 1
+            };
+            const newState = collector._getNextCollectionState(curState);
+            assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
+            assert.equal(newState.poll_interval_sec, 1);
         });
 
-        it('get next state if within polling interval', function (done) {
-            SalesforceCollector.load().then(function (creds) {
-                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
-                const startDate = moment().subtract(collector.pollInterval * 2, 'seconds');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(collector.pollInterval, 'seconds').toISOString(),
-                    poll_interval_sec: 1
-                };
-                const newState = collector._getNextCollectionState(curState);
-                assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
-                assert.equal(newState.poll_interval_sec, collector.pollInterval);
-                done();
-            });
+        it('get next state if within polling interval', async function () {
+            const creds = await SalesforceCollector.load();
+            var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+            const startDate = moment().subtract(collector.pollInterval * 2, 'seconds');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(collector.pollInterval, 'seconds').toISOString(),
+                poll_interval_sec: 1
+            };
+            const newState = collector._getNextCollectionState(curState);
+            assert.equal(moment(newState.until).diff(newState.since, 'seconds'), collector.pollInterval);
+            assert.equal(newState.poll_interval_sec, collector.pollInterval);
         });
     });
 
     describe('Format Tests', function () {
-        it('log format success', function (done) {
+        it('log format success', async function () {
             setAlServiceStub();
             let ctx = {
                 invokedFunctionArn: salesforceMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
-            SalesforceCollector.load().then(function (creds) {
-                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
-                collector.tsPaths = [{ path: ["LastLoginDate"] }];
-                let fmt = collector.pawsFormatLog(salesforceMock.LOG_EVENT);
-                assert.equal(fmt.progName, 'SalesforceCollector');
-                assert.ok(fmt.messageType);
-                done();
-            });
+            const creds = await SalesforceCollector.load();
+            var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+            collector.tsPaths = [{ path: ["LastLoginDate"] }];
+            let fmt = collector.pawsFormatLog(salesforceMock.LOG_EVENT);
+            assert.equal(fmt.progName, 'SalesforceCollector');
+            assert.ok(fmt.messageType);
         });
     });
 
 
     describe('NextCollectionStateWithNextPage', function () {
-        it('Get Next Collection State With NextPage Success', function (done) {
+        it('Get Next Collection State With NextPage Success', async function () {
             setAlServiceStub();
             let ctx = {
                 invokedFunctionArn: salesforceMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
             const startDate = moment().subtract(5, 'minutes');
@@ -385,28 +362,23 @@ describe('Unit Tests', function () {
                 poll_interval_sec: 1
             };
             const nextPage = "lastValue";
-            SalesforceCollector.load().then(function (creds) {
-                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
-                let nextState = collector._getNextCollectionStateWithNextPage(curState, nextPage);
-                assert.ok(nextState.since);
-                done();
-            });
+            const creds = await SalesforceCollector.load();
+            var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+            let nextState = collector._getNextCollectionStateWithNextPage(curState, nextPage);
+            assert.ok(nextState.since);
         });
     });
 
     describe('Paws Get Logs check  errors',function(){
        
-        it('Paws Get Logs check Client error', function (done) {
+        it('Paws Get Logs check Client error', async function () {
 
             let ctx = {
                 invokedFunctionArn: salesforceMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
             token = sinon.stub(jwt, 'sign').callsFake(
                 function fakeFn(path) {
@@ -440,7 +412,8 @@ describe('Unit Tests', function () {
                     });
                 });
 
-            SalesforceCollector.load().then(function (creds) {
+            try {
+                const creds = await SalesforceCollector.load();
                 var collector = new SalesforceCollector(ctx, creds, 'salesforce');
                 const startDate = moment().subtract(3, 'days');
                 const curState = {
@@ -450,13 +423,63 @@ describe('Unit Tests', function () {
                     poll_interval_sec: 1
                 };
 
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.strictEqual(err.errorCode, 'invalid_client_id');
-                    getObjectLogs.restore();
-                    done();
+                await assert.rejects(
+                    async () => collector.pawsGetLogs(curState),
+                    (err) => {
+                        assert.strictEqual(err.errorCode, 'invalid_client_id');
+                        return true;
+                    }
+                );
+            } finally {
+                getObjectLogs.restore();
+            }
+        });
+
+        it('Paws Get Logs maps token error status to errorCode', async function () {
+            let ctx = {
+                invokedFunctionArn: salesforceMock.FUNCTION_ARN,
+                fail: function (error) {
+                    assert.fail(error);
+                },
+                succeed: function () {}
+            };
+
+            token = sinon.stub(jwt, 'sign').callsFake(
+                function fakeFn(path) {
+                    return {};
                 });
 
-            });
+            requestPost = sinon.stub(RestServiceClient.prototype, 'post').callsFake(
+                function fakeFn(path, extraOptions) {
+                    return Promise.reject({
+                        response: {
+                            status: 401
+                        }
+                    });
+                });
+
+            try {
+                const creds = await SalesforceCollector.load();
+                var collector = new SalesforceCollector(ctx, creds, 'salesforce');
+                const startDate = moment().subtract(3, 'days');
+                const curState = {
+                    object: "LoginHistory",
+                    since: startDate.toISOString(),
+                    until: startDate.add(2, 'days').toISOString(),
+                    poll_interval_sec: 1
+                };
+
+                await assert.rejects(
+                    async () => collector.pawsGetLogs(curState),
+                    (err) => {
+                        assert.strictEqual(err.errorCode, 401);
+                        return true;
+                    }
+                );
+            } finally {
+                requestPost.restore();
+                token.restore();
+            }
         });
     });
 });

--- a/collectors/sentinelone/.jshintrc
+++ b/collectors/sentinelone/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "esversion": 6,
+  "esversion": 11,
   "shadow": "outer",
   "undef": true,
   "unused": "vars",

--- a/collectors/sentinelone/collector.js
+++ b/collectors/sentinelone/collector.js
@@ -26,7 +26,7 @@ class SentineloneCollector extends PawsCollector {
         super(context, creds, packageJson.version);
     }
 
-    pawsInitCollectionState(event, callback) {
+    async pawsInitCollectionState(event) {
         const startTs = process.env.paws_collection_start_ts ?
             process.env.paws_collection_start_ts :
             moment().toISOString();
@@ -37,14 +37,14 @@ class SentineloneCollector extends PawsCollector {
             nextPage: null,
             poll_interval_sec: 1
         };
-        return callback(null, initialState, 1);
+        return { state: initialState, nextInvocationTimeout: 1 };
     }
 
-    pawsGetLogs(state, callback) {
+    async pawsGetLogs(state) {
         let collector = this;
         const clientSecret = collector.secret;
         if (!clientSecret) {
-            return callback("The Client Secret was not found!");
+            throw new Error("The Client Secret was not found!");
         }
 
         const baseUrl = process.env.paws_endpoint.replace(/^https:\/\/|\/$/g, '');
@@ -61,28 +61,38 @@ class SentineloneCollector extends PawsCollector {
             limit: 100
         });
 
-        utils.getAPILogs(baseUrl, clientSecret, params, [], process.env.paws_max_pages_per_invocation)
-            .then(({ accumulator, nextPage }) => {
-                let newState;
-                if (nextPage === undefined) {
-                    newState = this._getNextCollectionState(state);
-                } else {
-                    newState = this._getNextCollectionStateWithNextPage(state, nextPage);
-                }
-                AlLogger.info(`SONE000002 Next collection in ${newState.poll_interval_sec} seconds`);
-                return callback(null, accumulator, newState, newState.poll_interval_sec);
-            }).catch((error) => {
-                // set the errorCode for client DD metrics
-                if (error.response && error.response.data) {
-                    error.response.data.errorCode = error.response.data.errors[0].code;
-                    return callback(error.response.data);
-                }
-                else {
-                    error.errorCode = error.response.status;
-                    return callback(error);
-                }
-            });
+        try {
+            const { accumulator, nextPage } = await utils.getAPILogs(baseUrl, clientSecret, params, [], process.env.paws_max_pages_per_invocation);
+            let newState;
+            if (nextPage === undefined) {
+                newState = this._getNextCollectionState(state);
+            } else {
+                newState = this._getNextCollectionStateWithNextPage(state, nextPage);
+            }
+            AlLogger.info(`SONE000002 Next collection in ${newState.poll_interval_sec} seconds`);
+            return [accumulator, newState, newState.poll_interval_sec];
+        } catch (error) {
+            this._throwNormalizedClientError(error);
+        }
+    }
 
+    _throwNormalizedClientError(error) {
+        // set the errorCode for client DD metrics
+        if (error && error.response && error.response.data && typeof error.response.data === 'object') {
+            const responseErrors = error.response.data.errors;
+            const responseError = Array.isArray(responseErrors) ? responseErrors[0] : undefined;
+            if (!error.response.data.errorCode) {
+                error.response.data.errorCode = responseError && responseError.code ?
+                    responseError.code :
+                    error.response.status ||
+                    'CLIENT_ERROR';
+            }
+            throw error.response.data;
+        }
+        if (error && error.response) {
+            error.errorCode = error.errorCode || error.response.status || 'CLIENT_ERROR';
+        }
+        throw error;
     }
 
     _getNextCollectionState(curState) {

--- a/collectors/sentinelone/index.js
+++ b/collectors/sentinelone/index.js
@@ -12,11 +12,15 @@ const debug = require('debug') ('index');
 const AlLogger = require('@alertlogic/al-aws-collector-js').Logger;
 const SentineloneCollector = require('./collector').SentineloneCollector;
 
-exports.handler = SentineloneCollector.makeHandler(function(event, context) {
+exports.handler = SentineloneCollector.makeHandler(async function(event, context) {
     debug('input event: ', event);
     AlLogger.defaultMeta = { requestId: context.awsRequestId };
-    SentineloneCollector.load().then(function(creds) {
-        var sentinelonec = new SentineloneCollector(context, creds);
-        sentinelonec.handleEvent(event);
-    });
+    try {
+        const creds = await SentineloneCollector.load();
+        let sentinelonec = new SentineloneCollector(context, creds);
+        await sentinelonec.handleEvent(event);
+    } catch (error) {
+        AlLogger.error(`Unhandled error in handling event: ${error.message}`);
+        throw error;
+    }
 });

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.0.60",
+  "version": "1.2.0",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.777.0",
-    "@aws-sdk/client-cloudwatch": "^3.777.0",
-    "@aws-sdk/client-dynamodb": "^3.777.0",
-    "@aws-sdk/client-kms": "^3.777.0",
-    "@aws-sdk/client-lambda": "^3.777.0",
-    "@aws-sdk/client-s3": "^3.779.0",
-    "@aws-sdk/client-sqs": "^3.777.0",
-    "@aws-sdk/client-ssm": "^3.777.0",
+    "@aws-sdk/client-cloudformation": "^3.1000.0",
+    "@aws-sdk/client-cloudwatch": "^3.1000.0",
+    "@aws-sdk/client-dynamodb": "^3.1000.0",
+    "@aws-sdk/client-kms": "^3.1000.0",
+    "@aws-sdk/client-lambda": "^3.1000.0",
+    "@aws-sdk/client-s3": "^3.1000.0",
+    "@aws-sdk/client-sqs": "^3.1000.0",
+    "@aws-sdk/client-ssm": "^3.1000.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -25,13 +25,14 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.2.11",
-    "async": "3.2.6",
+    "@alertlogic/paws-collector": "2.3.2",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "minimatch": "^3.1.4",
+    "serialize-javascript": "^7.0.3"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/sentinelone/test/sentinelone_test.js
+++ b/collectors/sentinelone/test/sentinelone_test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const m_response = require('cfn-response');
-const sentineloneMock = require('./sentinelone_mock');
+const m_response = require('@alertlogic/al-aws-collector-js').CfnResponse;
+const sentineloneMock = require('./sentinelone_mock');  
 var SentineloneCollector = require('../collector').SentineloneCollector;
 const moment = require('moment');
 const utils = require("../utils");
@@ -11,26 +11,33 @@ const { KMS } = require("@aws-sdk/client-kms"),
 var responseStub = {};
 let getAPILogs;
 
+function restoreApiLogsStub() {
+    if (getAPILogs && getAPILogs.restore) {
+        getAPILogs.restore();
+    }
+}
+
 describe('Unit Tests', function () {
     beforeEach(function () {
-        sinon.stub(SSM.prototype, 'getParameter').callsFake(function (params, callback) {
+        sinon.stub(SSM.prototype, 'getParameter').callsFake(function (params) {
             const data = Buffer.from('test-secret');
-            return callback(null, { Parameter: { Value: data.toString('base64') } });
+            return Promise.resolve({ Parameter: { Value: data.toString('base64') } });
         });
-        sinon.stub(KMS.prototype, 'decrypt').callsFake(function (params, callback) {
+        sinon.stub(KMS.prototype, 'decrypt').callsFake(function (params) {
             const data = {
                 Plaintext: Buffer.from('{}')
             };
-            return callback(null, data);
+            return Promise.resolve(data);
         });
 
         responseStub = sinon.stub(m_response, 'send').callsFake(
             function fakeFn(event, mockContext, responseStatus, responseData, physicalResourceId) {
-                mockContext.succeed();
+                return Promise.resolve();
             });
     });
 
     afterEach(function () {
+        restoreApiLogsStub();
         responseStub.restore();
         KMS.prototype.decrypt.restore();
         SSM.prototype.getParameter.restore();
@@ -44,16 +51,15 @@ describe('Unit Tests', function () {
             },
             succeed: function () { }
         };
-        it('Paws Init Collection State Success', function (done) {
-            SentineloneCollector.load().then(function (creds) {
-                var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
-                const startDate = moment().subtract(1, 'days').toISOString();
-                process.env.paws_collection_start_ts = startDate;
-                collector.pawsInitCollectionState(null, (err, initialState, nextPoll) => {
-                    assert.equal(moment(initialState.until).diff(initialState.since, 'seconds'), 60);
-                    done();
-                });
-            });
+
+        it('Paws Init Collection State Success', async function () {
+            const creds = await SentineloneCollector.load();
+            var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
+            const startDate = moment().subtract(1, 'days').toISOString();
+            process.env.paws_collection_start_ts = startDate;
+
+            const { state: initialState } = await collector.pawsInitCollectionState(null);
+            assert.equal(moment(initialState.until).diff(initialState.since, 'seconds'), 60);
         });
     });
 
@@ -65,151 +71,162 @@ describe('Unit Tests', function () {
             },
             succeed: function () { }
         };
-        it('Paws Get Logs Success', function (done) {
+
+        it('Paws Get Logs Success', async function () {
             getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
                 function fakeFn(baseUrl, token, params, accumulator, paws_max_pages_per_invocation) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [sentineloneMock.LOG_EVENT, sentineloneMock.LOG_EVENT] });
-                    });
-                });
-            SentineloneCollector.load().then(function (creds) {
-                var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(logs.length, 2);
-                    assert.equal(newState.poll_interval_sec, 1);
-                    assert.ok(logs[0].id);
-                    getAPILogs.restore();
-                    done();
+                    return Promise.resolve({ accumulator: [sentineloneMock.LOG_EVENT, sentineloneMock.LOG_EVENT] });
                 });
 
-            });
-        });
-        it('Paws Get Logs with nextPage Success', function (done) {
-            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
-                function fakeFn(baseUrl, token, params, accumulator, paws_max_pages_per_invocation) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [sentineloneMock.LOG_EVENT, sentineloneMock.LOG_EVENT], nextPage: "nextPage" });
-                    });
-                });
-            SentineloneCollector.load().then(function (creds) {
-                var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(logs.length, 2);
-                    assert.equal(newState.poll_interval_sec, 1);
-                    assert.ok(logs[0].id);
-                    getAPILogs.restore();
-                    done();
-                });
-            });
+            const creds = await SentineloneCollector.load();
+            var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                poll_interval_sec: 1
+            };
+
+            const [logs, newState] = await collector.pawsGetLogs(curState);
+            assert.equal(logs.length, 2);
+            assert.equal(newState.poll_interval_sec, 1);
+            assert.ok(logs[0].id);
         });
 
-        it('Paws Get Logs failed and show client errors', function (done) {
+        it('Paws Get Logs with nextPage Success', async function () {
             getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
                 function fakeFn(baseUrl, token, params, accumulator, paws_max_pages_per_invocation) {
-                    return new Promise(function (resolve, reject) {
-                        return reject({
-                            response: {
-                                status: 401, data:
-                                    { "errors": [{ "code": 4010010, "detail": null, "title": "Authentication Failed" }] }
-                            }
-                        });
+                    return Promise.resolve({ accumulator: [sentineloneMock.LOG_EVENT, sentineloneMock.LOG_EVENT], nextPage: "nextPage" });
+                });
+
+            const creds = await SentineloneCollector.load();
+            var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                poll_interval_sec: 1
+            };
+
+            const [logs, newState] = await collector.pawsGetLogs(curState);
+            assert.equal(logs.length, 2);
+            assert.equal(newState.poll_interval_sec, 1);
+            assert.ok(logs[0].id);
+            assert.equal(newState.nextPage, 'nextPage');
+        });
+
+        it('Paws Get Logs failed and show client errors', async function () {
+            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
+                function fakeFn(baseUrl, token, params, accumulator, paws_max_pages_per_invocation) {
+                    return Promise.reject({
+                        response: {
+                            status: 401,
+                            data: { errors: [{ code: 4010010, detail: null, title: 'Authentication Failed' }] }
+                        }
                     });
                 });
-            SentineloneCollector.load().then(function (creds) {
-                var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
+
+            const creds = await SentineloneCollector.load();
+            var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                poll_interval_sec: 1
+            };
+
+            await assert.rejects(
+                async () => collector.pawsGetLogs(curState),
+                (err) => {
                     assert.equal(err.errorCode, 4010010);
-                    getAPILogs.restore();
-                    done();
+                    return true;
+                }
+            );
+        });
+
+        it('Paws Get Logs maps status-only errors', async function () {
+            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
+                function fakeFn(baseUrl, token, params, accumulator, paws_max_pages_per_invocation) {
+                    return Promise.reject({
+                        response: {
+                            status: 401
+                        }
+                    });
                 });
-            });
+
+            const creds = await SentineloneCollector.load();
+            var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                poll_interval_sec: 1
+            };
+
+            await assert.rejects(
+                async () => collector.pawsGetLogs(curState),
+                (err) => {
+                    assert.equal(err.errorCode, 401);
+                    return true;
+                }
+            );
         });
     });
 
     describe('Next state tests', function () {
-        it('log format success', function (done) {
+        it('log format success', async function () {
             let ctx = {
                 invokedFunctionArn: sentineloneMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
-            SentineloneCollector.load().then(function (creds) {
-                var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
-                const startDate = moment();
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(collector.pollInterval, 'seconds').toISOString(),
-                    poll_interval_sec: 1
-                };
-                let nextState = collector._getNextCollectionState(curState);
-                assert.equal(moment(nextState.until).diff(nextState.since, 'seconds'), collector.pollInterval);
-                assert.equal(nextState.poll_interval_sec, process.env.paws_poll_interval_delay);
-                done();
-            });
+            const creds = await SentineloneCollector.load();
+            var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
+            const startDate = moment();
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(collector.pollInterval, 'seconds').toISOString(),
+                poll_interval_sec: 1
+            };
+            let nextState = collector._getNextCollectionState(curState);
+            assert.equal(moment(nextState.until).diff(nextState.since, 'seconds'), collector.pollInterval);
+            assert.equal(nextState.poll_interval_sec, process.env.paws_poll_interval_delay);
         });
     });
 
     describe('Format Tests', function () {
-        it('log format success', function (done) {
+        it('log format success', async function () {
             let ctx = {
                 invokedFunctionArn: sentineloneMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
-            SentineloneCollector.load().then(function (creds) {
-                var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
-                let fmt = collector.pawsFormatLog(sentineloneMock.LOG_EVENT);
-                assert.equal(fmt.progName, 'SentineloneCollector');
-                assert.ok(fmt.message);
-                done();
-            });
+            const creds = await SentineloneCollector.load();
+            var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
+            let fmt = collector.pawsFormatLog(sentineloneMock.LOG_EVENT);
+            assert.equal(fmt.progName, 'SentineloneCollector');
+            assert.ok(fmt.message);
         });
     });
 
     describe('NextCollectionStateWithNextPage', function () {
-        it('Get Next Collection State With NextPage Success', function (done) {
+        it('Get Next Collection State With NextPage Success', async function () {
             let ctx = {
                 invokedFunctionArn: sentineloneMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
             const startDate = moment().subtract(5, 'minutes');
@@ -219,13 +236,11 @@ describe('Unit Tests', function () {
                 poll_interval_sec: 1
             };
             const nextPage = "cursor";
-            SentineloneCollector.load().then(function (creds) {
-                var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
-                let nextState = collector._getNextCollectionStateWithNextPage(curState, nextPage);
-                assert.ok(nextState.nextPage);
-                assert.equal(nextState.nextPage, nextPage);
-                done();
-            });
+            const creds = await SentineloneCollector.load();
+            var collector = new SentineloneCollector(ctx, creds, 'sentinelone');
+            let nextState = collector._getNextCollectionStateWithNextPage(curState, nextPage);
+            assert.ok(nextState.nextPage);
+            assert.equal(nextState.nextPage, nextPage);
         });
     });
 });

--- a/collectors/sophos/.jshintrc
+++ b/collectors/sophos/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "esversion": 6,
+  "esversion": 11,
   "shadow": "outer",
   "undef": true,
   "unused": "vars",

--- a/collectors/sophos/collector.js
+++ b/collectors/sophos/collector.js
@@ -30,7 +30,7 @@ class SophosCollector extends PawsCollector {
         super(context, creds, packageJson.version);
     }
 
-    pawsInitCollectionState(event, callback) {
+    async pawsInitCollectionState(event) {
         const startTs = process.env.paws_collection_start_ts ?
             process.env.paws_collection_start_ts :
             moment().toISOString();
@@ -42,92 +42,101 @@ class SophosCollector extends PawsCollector {
             apiQuotaResetDate: null,
             poll_interval_sec: 1
         };
-        return callback(null, initialState, 1);
+        return { state: initialState, nextInvocationTimeout: 1 };
     }
 
-    pawsGetLogs(state, callback) {
+    async pawsGetLogs(state) {
         let collector = this;
 
         const clientSecret = collector.secret;
         if (!clientSecret) {
-            return callback("The Client Secret was not found!");
+            throw new Error("The Client Secret was not found!");
         }
         const clientId = collector.clientId;
         if (!clientId) {
-            return callback("The Client ID was not found!");
+            throw new Error("The Client ID was not found!");
         }
-        
+
         AlLogger.info(`SOPH000001 Collecting data from ${state.since} till ${state.until}`);
 
         if (state.apiQuotaResetDate && moment().isBefore(state.apiQuotaResetDate)) {
             AlLogger.info(`API Request Limit Exceeded. The quota will be reset at ${state.apiQuotaResetDate}`);
-            collector.reportApiThrottling(function () {
-                return callback(null, [], state, state.poll_interval_sec);
-            });
+            await collector.reportApiThrottling();
+            return [[], state, state.poll_interval_sec];
         }
-        else {
+        let token;
+        try {
+            token = await utils.authenticate(SOPHOS_AUTH_BASE_URL, clientId, clientSecret);
+        } catch (error) {
+            const errorObject = collector.createErrorObject(error);
 
-            utils.authenticate(SOPHOS_AUTH_BASE_URL, clientId, clientSecret).then((token) => {
-                // while runing on live api server pass getTenantIdAndDataRegion hostname value "api.central.sophos.com"
-                utils.getTenantIdAndDataRegion(SOPHOS_API_BASE_URL, token).then((response) => {
-                    if (!response.apiHosts.dataRegion) {
-                        return callback("Please generate credentials for the tenant. Currently we do not support credentials for Organization and Partner.");
-                    }
-                    const apiHostsURL = response.apiHosts.dataRegion.replace(/^https:\/\/|\/$/g, '');
-                    utils.getAPILogs(apiHostsURL, token, response.id, state, [], process.env.paws_max_pages_per_invocation)
-                        .then(({ accumulator, nextPage }) => {
-                            let newState;
-                            if (nextPage === undefined) {
-                                newState = this._getNextCollectionState(state);
-                            } else {
-                                newState = this._getNextCollectionStateWithNextPage(state, nextPage);
-                            }
-                            AlLogger.info(`SOPH000002 Next collection in ${newState.poll_interval_sec} seconds`);
-                            return callback(null, accumulator, newState, newState.poll_interval_sec);
-                        }).catch((error) => {
-                            if ((error.response && error.response.data && error.response.data.errorCode === "TooManyRequests") || error.response.status === 429) {
-                                state.apiQuotaResetDate = moment().add(1, "hours").toISOString();
-                                state.poll_interval_sec = 900;
-                                AlLogger.info(`API Request Limit Exceeded. The quota will be reset at ${state.apiQuotaResetDate}`);
-                                collector.reportApiThrottling(function () {
-                                    return callback(null, [], state, state.poll_interval_sec);
-                                });
-                            }
-                            else {
-                                return callback(collector.createErrorObject(error));
-                            }
-                        });
-                }).catch((error) => {
-                    return callback(collector.createErrorObject(error));
-                });
-            }).catch((error) => {         
-                const errorObject = collector.createErrorObject(error);
-                
-                if (error.response && error.response.data) {
-                    const errorCode = error.response.data.errorCode;
-                    if (errorCode === "oauth.invalid_client_secret" || errorCode === "customer.validation") {
-                        errorObject.message = `Error code [${error.response.status}]. Invalid client secret is provided.`;
-                    }
-                    if (errorCode === "oauth.client_app_does_not_exist") {
-                        errorObject.message = `Error code [${error.response.status}]. Invalid client ID is provided.`;
-                    }
-                } else if (!errorObject.message || errorObject.message === "Unknown error") {
-                    errorObject.message = "Unknown authentication error";
+            if (error && error.response && error.response.data) {
+                const errorCode = error.response.data.errorCode;
+                if (errorCode === "oauth.invalid_client_secret" || errorCode === "customer.validation") {
+                    errorObject.message = `Error code [${error.response.status}]. Invalid client secret is provided.`;
                 }
-                
-                return callback(errorObject);
-            });
+                if (errorCode === "oauth.client_app_does_not_exist") {
+                    errorObject.message = `Error code [${error.response.status}]. Invalid client ID is provided.`;
+                }
+            } else if (!errorObject.message || errorObject.message === "Unknown error") {
+                errorObject.message = "Unknown authentication error";
+            }
+
+            throw errorObject;
+        }
+
+        let tenantResponse;
+        try {
+            // while runing on live api server pass getTenantIdAndDataRegion hostname value "api.central.sophos.com"
+            tenantResponse = await utils.getTenantIdAndDataRegion(SOPHOS_API_BASE_URL, token);
+        } catch (error) {
+            throw collector.createErrorObject(error);
+        }
+
+        if (!(tenantResponse && tenantResponse.apiHosts && tenantResponse.apiHosts.dataRegion)) {
+            throw new Error("Please generate credentials for the tenant. Currently we do not support credentials for Organization and Partner.");
+        }
+
+        const apiHostsURL = tenantResponse.apiHosts.dataRegion.replace(/^https:\/\/|\/$/g, '');
+
+        try {
+            const { accumulator, nextPage } = await utils.getAPILogs(
+                apiHostsURL,
+                token,
+                tenantResponse.id,
+                state,
+                [],
+                process.env.paws_max_pages_per_invocation
+            );
+
+            let newState;
+            if (nextPage === undefined) {
+                newState = this._getNextCollectionState(state);
+            } else {
+                newState = this._getNextCollectionStateWithNextPage(state, nextPage);
+            }
+            AlLogger.info(`SOPH000002 Next collection in ${newState.poll_interval_sec} seconds`);
+            return [accumulator, newState, newState.poll_interval_sec];
+        } catch (error) {
+            if ((error.response && error.response.data && error.response.data.errorCode === "TooManyRequests") || (error.response && error.response.status === 429)) {
+                state.apiQuotaResetDate = moment().add(1, "hours").toISOString();
+                state.poll_interval_sec = 900;
+                AlLogger.info(`API Request Limit Exceeded. The quota will be reset at ${state.apiQuotaResetDate}`);
+                await collector.reportApiThrottling();
+                return [[], state, state.poll_interval_sec];
+            }
+            throw collector.createErrorObject(error);
         }
     }
 
     createErrorObject(error) {
         const errorObject = {
-            message: error.message || (error.response && error.response.data && error.response.data.message) || (error.response && error.response.message) || "Unknown error",
-            errorCode: error.errorCode || (error.response && error.response.data && error.response.data.errorCode) || (error.response && error.response.status) || error.code,
-            status: error.status || (error.response && error.response.status),
-            statusText: error.statusText || (error.response && error.response.statusText),
-            code: error.code,
-            errno: error.errno
+            message: (error && error.message) || (error && error.response && error.response.data && error.response.data.message) || (error && error.response && error.response.message) || "Unknown error",
+            errorCode: (error && error.errorCode) || (error && error.response && error.response.data && error.response.data.errorCode) || (error && error.response && error.response.status) || (error && error.code),
+            status: (error && error.status) || (error && error.response && error.response.status),
+            statusText: (error && error.statusText) || (error && error.response && error.response.statusText),
+            code: error && error.code,
+            errno: error && error.errno
         };
         return errorObject;
     }

--- a/collectors/sophos/index.js
+++ b/collectors/sophos/index.js
@@ -12,11 +12,15 @@ const debug = require('debug') ('index');
 const AlLogger = require('@alertlogic/al-aws-collector-js').Logger;
 const SophosCollector = require('./collector').SophosCollector;
 
-exports.handler = SophosCollector.makeHandler(function(event, context) {
+exports.handler = SophosCollector.makeHandler(async function(event, context) {
     debug('input event: ', event);
     AlLogger.defaultMeta = { requestId: context.awsRequestId };
-    SophosCollector.load().then(function(creds) {
-        var sophosc = new SophosCollector(context, creds);
-        sophosc.handleEvent(event);
-    });
+    try {
+        const creds = await SophosCollector.load();
+        let sophosc = new SophosCollector(context, creds);
+        await sophosc.handleEvent(event);
+    } catch (error) {
+        AlLogger.error("Unhandled error in handler execution", error);
+        throw error;
+    };
 });

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.0.60",
+  "version": "1.1.0",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -10,14 +10,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.777.0",
-    "@aws-sdk/client-cloudwatch": "^3.777.0",
-    "@aws-sdk/client-dynamodb": "^3.777.0",
-    "@aws-sdk/client-kms": "^3.777.0",
-    "@aws-sdk/client-lambda": "^3.777.0",
-    "@aws-sdk/client-s3": "^3.779.0",
-    "@aws-sdk/client-sqs": "^3.777.0",
-    "@aws-sdk/client-ssm": "^3.777.0",
+    "@aws-sdk/client-cloudformation": "^3.1000.0",
+    "@aws-sdk/client-cloudwatch": "^3.1000.0",
+    "@aws-sdk/client-dynamodb": "^3.1000.0",
+    "@aws-sdk/client-kms": "^3.1000.0",
+    "@aws-sdk/client-lambda": "^3.1000.0",
+    "@aws-sdk/client-s3": "^3.1000.0",
+    "@aws-sdk/client-sqs": "^3.1000.0",
+    "@aws-sdk/client-ssm": "^3.1000.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "mockserver": "^3.1.1",
@@ -27,13 +27,14 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.2.11",
-    "async": "3.2.6",
+    "@alertlogic/paws-collector": "2.3.2",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "minimatch": "^3.1.4",
+    "serialize-javascript": "^7.0.3"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/sophos/test/sophos_test.js
+++ b/collectors/sophos/test/sophos_test.js
@@ -10,29 +10,44 @@ const { CloudWatch } = require("@aws-sdk/client-cloudwatch"),
     { SSM } = require("@aws-sdk/client-ssm");
 
 var responseStub = {};
-let authenticate, getTenantIdAndDataRegion, getAPILogs;
+let authenticate;
+let getTenantIdAndDataRegion;
+let getAPILogs;
+
+function restoreApiStubs() {
+    if (authenticate && authenticate.restore) {
+        authenticate.restore();
+    }
+    if (getTenantIdAndDataRegion && getTenantIdAndDataRegion.restore) {
+        getTenantIdAndDataRegion.restore();
+    }
+    if (getAPILogs && getAPILogs.restore) {
+        getAPILogs.restore();
+    }
+}
 
 describe('Unit Tests', function () {
 
     beforeEach(function () {
-        sinon.stub(SSM.prototype, 'getParameter').callsFake(function (params, callback) {
+        sinon.stub(SSM.prototype, 'getParameter').callsFake(function () {
             const data = Buffer.from('test-secret');
-            return callback(null, { Parameter: { Value: data.toString('base64') } });
+            return Promise.resolve({ Parameter: { Value: data.toString('base64') } });
         });
-        sinon.stub(KMS.prototype, 'decrypt').callsFake(function (params, callback) {
+        sinon.stub(KMS.prototype, 'decrypt').callsFake(function () {
             const data = {
                 Plaintext: Buffer.from('{}')
             };
-            return callback(null, data);
+            return Promise.resolve(data);
         });
 
         responseStub = sinon.stub(m_response, 'send').callsFake(
-            function fakeFn(event, mockContext, responseStatus, responseData, physicalResourceId) {
-                mockContext.succeed();
+            function fakeFn() {
+                return Promise.resolve();
             });
     });
 
     afterEach(function () {
+        restoreApiStubs();
         responseStub.restore();
         KMS.prototype.decrypt.restore();
         SSM.prototype.getParameter.restore();
@@ -46,20 +61,18 @@ describe('Unit Tests', function () {
             },
             succeed: function () { }
         };
-        it('Paws Init Collection State Success', function (done) {
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment().subtract(1, 'days').toISOString();
-                process.env.paws_collection_start_ts = startDate;
 
-                collector.pawsInitCollectionState({}, (err, initialState, nextPoll) => {
-                    assert.equal(initialState.since, startDate, "Dates are not equal");
-                    assert.equal(moment(initialState.until).diff(initialState.since, 'seconds'), 60);
-                    assert.equal(initialState.poll_interval_sec, 1);
-                    assert.equal(nextPoll, 1);
-                    done();
-                });
-            });
+        it('Paws Init Collection State Success', async function () {
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment().subtract(1, 'days').toISOString();
+            process.env.paws_collection_start_ts = startDate;
+
+            const { state: initialState, nextInvocationTimeout } = await collector.pawsInitCollectionState({});
+            assert.equal(initialState.since, startDate, "Dates are not equal");
+            assert.equal(moment(initialState.until).diff(initialState.since, 'seconds'), 60);
+            assert.equal(initialState.poll_interval_sec, 1);
+            assert.equal(nextInvocationTimeout, 1);
         });
     });
 
@@ -71,396 +84,315 @@ describe('Unit Tests', function () {
             },
             succeed: function () { }
         };
-        it('Paws Get Logs Success', function (done) {
-            authenticate = sinon.stub(utils, 'authenticate').callsFake(
-                function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve("token");
-                    });
-                });
-            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
-                function fakeFn(hostName, token) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({
-                            "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
-                            "idType": "tenant",
-                            "apiHosts": {
-                                "global": "https://api.central.sophos.com",
-                                "dataRegion": "https://api-us03.central.sophos.com"
-                            }
-                        });
-                    });
-                });
-            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
-                function fakeFn(baseUrl, token, tenant_Id, state, accumulator, maxPagesPerInvocation) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [sophosMock.LOG_EVENT, sophosMock.LOG_EVENT] });
-                    });
-                });
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: null,
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(logs.length, 2);
-                    assert.equal(newState.poll_interval_sec, 1);
-                    assert.ok(logs[0].id);
-                    getAPILogs.restore();
-                    getTenantIdAndDataRegion.restore();
-                    authenticate.restore();
-                    done();
-                });
 
+        it('Paws Get Logs Success', async function () {
+            authenticate = sinon.stub(utils, 'authenticate').resolves("token");
+            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').resolves({
+                "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
+                "idType": "tenant",
+                "apiHosts": {
+                    "global": "https://api.central.sophos.com",
+                    "dataRegion": "https://api-us03.central.sophos.com"
+                }
             });
+            getAPILogs = sinon.stub(utils, 'getAPILogs').resolves({
+                accumulator: [sophosMock.LOG_EVENT, sophosMock.LOG_EVENT]
+            });
+
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                apiQuotaResetDate: null,
+                poll_interval_sec: 1
+            };
+
+            const [logs, newState] = await collector.pawsGetLogs(curState);
+            assert.equal(logs.length, 2);
+            assert.equal(newState.poll_interval_sec, 1);
+            assert.ok(logs[0].id);
         });
 
-        it('Paws Get Logs with nextPage Success', function (done) {
-            authenticate = sinon.stub(utils, 'authenticate').callsFake(
-                function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve("token");
-                    });
-                });
-            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
-                function fakeFn(hostName, token) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({
-                            "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
-                            "idType": "tenant",
-                            "apiHosts": {
-                                "global": "https://api.central.sophos.com",
-                                "dataRegion": "https://api-us03.central.sophos.com"
-                            }
-                        });
-                    });
-                });
-            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
-                function fakeFn(baseUrl, token, tenant_Id, state, accumulator, maxPagesPerInvocation) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [sophosMock.LOG_EVENT, sophosMock.LOG_EVENT], nextPage: "nextPage" });
-                    });
-                });
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: null,
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(logs.length, 2);
-                    assert.equal(newState.poll_interval_sec, 1);
-                    assert.ok(logs[0].id);
-                    getAPILogs.restore();
-                    getTenantIdAndDataRegion.restore();
-                    authenticate.restore();
-                    done();
-                });
-
+        it('Paws Get Logs with nextPage Success', async function () {
+            authenticate = sinon.stub(utils, 'authenticate').resolves("token");
+            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').resolves({
+                "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
+                "idType": "tenant",
+                "apiHosts": {
+                    "global": "https://api.central.sophos.com",
+                    "dataRegion": "https://api-us03.central.sophos.com"
+                }
             });
+            getAPILogs = sinon.stub(utils, 'getAPILogs').resolves({
+                accumulator: [sophosMock.LOG_EVENT, sophosMock.LOG_EVENT],
+                nextPage: "nextPage"
+            });
+
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                apiQuotaResetDate: null,
+                poll_interval_sec: 1
+            };
+
+            const [logs, newState] = await collector.pawsGetLogs(curState);
+            assert.equal(logs.length, 2);
+            assert.equal(newState.poll_interval_sec, 1);
+            assert.equal(newState.nextPage, 'nextPage');
+            assert.ok(logs[0].id);
         });
 
-        it('Paws Get Logs testing credentials type error', function (done) {
-            authenticate = sinon.stub(utils, 'authenticate').callsFake(
-                function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve("token");
-                    });
-                });
-            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
-                function fakeFn(hostName, token) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({
-                            "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
-                            "idType": "ORG",
-                            "apiHosts": {
-                                "global": "https://api.central.sophos.com",
-                            }
-                        });
-                    });
-                });
-            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
-                function fakeFn(baseUrl, token, tenant_Id, state, accumulator, maxPagesPerInvocation) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [sophosMock.LOG_EVENT, sophosMock.LOG_EVENT] });
-                    });
-                });
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: null,
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.ok(err);
-                    assert.equal(err,"Please generate credentials for the tenant. Currently we do not support credentials for Organization and Partner.");
-                    getAPILogs.restore();
-                    getTenantIdAndDataRegion.restore();
-                    authenticate.restore();
-                    done();
-                });
-
+        it('Paws Get Logs testing credentials type error', async function () {
+            authenticate = sinon.stub(utils, 'authenticate').resolves("token");
+            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').resolves({
+                "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
+                "idType": "ORG",
+                "apiHosts": {
+                    "global": "https://api.central.sophos.com"
+                }
             });
+            getAPILogs = sinon.stub(utils, 'getAPILogs').resolves({
+                accumulator: [sophosMock.LOG_EVENT, sophosMock.LOG_EVENT]
+            });
+
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                apiQuotaResetDate: null,
+                poll_interval_sec: 1
+            };
+
+            await assert.rejects(
+                async () => collector.pawsGetLogs(curState),
+                (err) => {
+                    assert.equal(err.message, "Please generate credentials for the tenant. Currently we do not support credentials for Organization and Partner.");
+                    return true;
+                }
+            );
         });
 
-        it('Paws Get Logs checking invalid client secret error', function (done) {
-            authenticate = sinon.stub(utils, 'authenticate').callsFake(
-                function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return reject({
-                            response: {
-                                status: 400,
-                                data: {
-                                    "errorCode": "customer.validation", "message": "Bad Request"
-                                }
-                            }
-                        });
-                    });
-                });
-           
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: null,
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.ok(err);
+        it('Paws Get Logs checking invalid client secret error', async function () {
+            authenticate = sinon.stub(utils, 'authenticate').rejects({
+                response: {
+                    status: 400,
+                    data: {
+                        "errorCode": "customer.validation",
+                        "message": "Bad Request"
+                    }
+                }
+            });
+
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                apiQuotaResetDate: null,
+                poll_interval_sec: 1
+            };
+
+            await assert.rejects(
+                async () => collector.pawsGetLogs(curState),
+                (err) => {
                     assert.equal(err.message, "Error code [400]. Invalid client secret is provided.");
-                    authenticate.restore();
-                    done();
-                });
-
-            });
+                    return true;
+                }
+            );
         });
 
-        it('Paws Get Logs checking invalid client ID error', function (done) {
-            authenticate = sinon.stub(utils, 'authenticate').callsFake(
-                function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return reject({response:{ "status": 401, "data": { "errorCode": "oauth.client_app_does_not_exist",message:"Unauthorized" } }});
-                    });
-                });
-           
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: null,
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.ok(err);
+        it('Paws Get Logs checking invalid client ID error', async function () {
+            authenticate = sinon.stub(utils, 'authenticate').rejects({
+                response: {
+                    "status": 401,
+                    "data": {
+                        "errorCode": "oauth.client_app_does_not_exist",
+                        message: "Unauthorized"
+                    }
+                }
+            });
+
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                apiQuotaResetDate: null,
+                poll_interval_sec: 1
+            };
+
+            await assert.rejects(
+                async () => collector.pawsGetLogs(curState),
+                (err) => {
                     assert.equal(err.message, "Error code [401]. Invalid client ID is provided.");
-                    authenticate.restore();
-                    done();
-                });
-
-            });
+                    return true;
+                }
+            );
         });
 
-        it('Paws Get Logs testing throttling error', function (done) {
-            authenticate = sinon.stub(utils, 'authenticate').callsFake(
-                function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve("token");
-                    });
-                });
-            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
-                function fakeFn(hostName, token) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({
-                            "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
-                            "idType": "tenant",
-                            "apiHosts": {
-                                "global": "https://api.central.sophos.com",
-                                "dataRegion": "https://api-us03.central.sophos.com"
-                            }
-                        });
-                    });
-                });
-            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
-                function fakeFn(baseUrl, token, tenant_Id, state, accumulator, maxPagesPerInvocation) {
-                    return new Promise(function (resolve, reject) {
-                        return reject({ response: { status: 429, data: { errorCode: "TooManyRequests" } } });
-                    });
-                });
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: null,
-                    poll_interval_sec: 1
-                };
-
-                var reportSpy = sinon.spy(collector, 'reportApiThrottling');
-                let putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake((params, callback) => callback(null));
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(true, reportSpy.calledOnce);
-                    assert.ok(newState.apiQuotaResetDate);
-                    assert.notEqual(newState.apiQuotaResetDate,null);
-                    assert.equal(logs.length, 0);
-                    assert.equal(newState.poll_interval_sec, 900);           
-                    getAPILogs.restore();
-                    getTenantIdAndDataRegion.restore();
-                    authenticate.restore();
-                    putMetricDataStub.restore();
-                    done();
-                });
-
+        it('Paws Get Logs testing throttling error', async function () {
+            authenticate = sinon.stub(utils, 'authenticate').resolves("token");
+            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').resolves({
+                "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
+                "idType": "tenant",
+                "apiHosts": {
+                    "global": "https://api.central.sophos.com",
+                    "dataRegion": "https://api-us03.central.sophos.com"
+                }
             });
+            getAPILogs = sinon.stub(utils, 'getAPILogs').rejects({
+                response: { status: 429, data: { errorCode: "TooManyRequests" } }
+            });
+
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                apiQuotaResetDate: null,
+                poll_interval_sec: 1
+            };
+
+            var reportSpy = sinon.spy(collector, 'reportApiThrottling');
+            let putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake(() => Promise.resolve());
+            try {
+                const [logs, newState] = await collector.pawsGetLogs(curState);
+                assert.equal(true, reportSpy.calledOnce);
+                assert.ok(newState.apiQuotaResetDate);
+                assert.notEqual(newState.apiQuotaResetDate, null);
+                assert.equal(logs.length, 0);
+                assert.equal(newState.poll_interval_sec, 900);
+            } finally {
+                putMetricDataStub.restore();
+            }
         });
 
-        it('Paws Get Logs with API Quota Reset Date', function (done) {
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: moment().add(1, 'hours').toISOString(),
-                    poll_interval_sec: 900
-                };
+        it('Paws Get Logs with API Quota Reset Date', async function () {
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                apiQuotaResetDate: moment().add(1, 'hours').toISOString(),
+                poll_interval_sec: 900
+            };
 
-                var reportSpy = sinon.spy(collector, 'reportApiThrottling');
-                let putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake((params, callback) => callback(null));
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(true, reportSpy.calledOnce);
-                    assert.equal(logs.length, 0);
-                    assert.equal(newState.poll_interval_sec, 900);
-                    putMetricDataStub.restore();
-                    done();
-                });
-
-            });
+            var reportSpy = sinon.spy(collector, 'reportApiThrottling');
+            let putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake(() => Promise.resolve());
+            try {
+                const [logs, newState] = await collector.pawsGetLogs(curState);
+                assert.equal(true, reportSpy.calledOnce);
+                assert.equal(logs.length, 0);
+                assert.equal(newState.poll_interval_sec, 900);
+            } finally {
+                putMetricDataStub.restore();
+            }
         });
 
-        it('Paws Get Logs check client error', function (done) {
-            authenticate = sinon.stub(utils, 'authenticate').callsFake(
-                function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve("token");
-                    });
-                });
-            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
-                function fakeFn(hostName, token) {
-                    return new Promise(function (resolve, reject) {
-                        return reject({ response: { data: { errorCode: "Unauthorized", code: "USR00004c5", message: "The client needs to authenticate before making the API call. Either your credentials are invalid or blacklisted, or your JWT authorization token has expired", requestId: "6DB1D8AC-1BFA-448B-8439-5486E6D25A74" } } });
-                    });
-                });
-           
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment().subtract(3, 'days');
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(2, 'days').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: null,
-                    poll_interval_sec: 1
-                };
-
-
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(err.errorCode , 'Unauthorized');
-                    getTenantIdAndDataRegion.restore();
-                    authenticate.restore();
-                    done();
-                });
-
+        it('Paws Get Logs check client error', async function () {
+            authenticate = sinon.stub(utils, 'authenticate').resolves("token");
+            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').rejects({
+                response: {
+                    data: {
+                        errorCode: "Unauthorized",
+                        code: "USR00004c5",
+                        message: "The client needs to authenticate before making the API call. Either your credentials are invalid or blacklisted, or your JWT authorization token has expired",
+                        requestId: "6DB1D8AC-1BFA-448B-8439-5486E6D25A74"
+                    }
+                }
             });
+
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment().subtract(3, 'days');
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(2, 'days').toISOString(),
+                nextPage: null,
+                apiQuotaResetDate: null,
+                poll_interval_sec: 1
+            };
+
+            await assert.rejects(
+                async () => collector.pawsGetLogs(curState),
+                (err) => {
+                    assert.equal(err.errorCode, 'Unauthorized');
+                    return true;
+                }
+            );
         });
     });
 
     describe('Next state tests', function () {
-        it('log format success', function (done) {
+        it('log format success', async function () {
             let ctx = {
                 invokedFunctionArn: sophosMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                const startDate = moment();
-                const curState = {
-                    since: startDate.toISOString(),
-                    until: startDate.add(collector.pollInterval, 'seconds').toISOString(),
-                    nextPage: null,
-                    apiQuotaResetDate: null,
-                    poll_interval_sec: 1
-                };
-                let nextState = collector._getNextCollectionState(curState);
-                assert.equal(moment(nextState.until).diff(nextState.since, 'seconds'), collector.pollInterval);
-                assert.equal(nextState.poll_interval_sec, process.env.paws_poll_interval_delay);
-                done();
-            });
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            const startDate = moment();
+            const curState = {
+                since: startDate.toISOString(),
+                until: startDate.add(collector.pollInterval, 'seconds').toISOString(),
+                nextPage: null,
+                apiQuotaResetDate: null,
+                poll_interval_sec: 1
+            };
+            let nextState = collector._getNextCollectionState(curState);
+            assert.equal(moment(nextState.until).diff(nextState.since, 'seconds'), collector.pollInterval);
+            assert.equal(nextState.poll_interval_sec, process.env.paws_poll_interval_delay);
         });
     });
 
     describe('Format Tests', function () {
-        it('log format success', function (done) {
+        it('log format success', async function () {
             let ctx = {
                 invokedFunctionArn: sophosMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                let fmt = collector.pawsFormatLog(sophosMock.LOG_EVENT);
-                assert.equal(fmt.progName, 'SophosCollector');
-                assert.ok(fmt.message);
-                done();
-            });
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            let fmt = collector.pawsFormatLog(sophosMock.LOG_EVENT);
+            assert.equal(fmt.progName, 'SophosCollector');
+            assert.ok(fmt.message);
         });
     });
 
     describe('NextCollectionStateWithNextPage', function () {
-        it('Get Next Collection State With NextPage Success', function (done) {
+        it('Get Next Collection State With NextPage Success', async function () {
             let ctx = {
                 invokedFunctionArn: sophosMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
             const startDate = moment().subtract(5, 'minutes');
@@ -470,13 +402,12 @@ describe('Unit Tests', function () {
                 poll_interval_sec: 1
             };
             const nextPage = "nextKey";
-            SophosCollector.load().then(function (creds) {
-                var collector = new SophosCollector(ctx, creds, 'sophos');
-                let nextState = collector._getNextCollectionStateWithNextPage(curState, nextPage);
-                assert.ok(nextState.nextPage);
-                assert.equal(nextState.nextPage, nextPage);
-                done();
-            });
+
+            const creds = await SophosCollector.load();
+            var collector = new SophosCollector(ctx, creds, 'sophos');
+            let nextState = collector._getNextCollectionStateWithNextPage(curState, nextPage);
+            assert.ok(nextState.nextPage);
+            assert.equal(nextState.nextPage, nextPage);
         });
     });
 

--- a/collectors/sophossiem/.jshintrc
+++ b/collectors/sophossiem/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "esversion": 6,
+  "esversion": 11,
   "shadow": "outer",
   "undef": true,
   "unused": "vars",

--- a/collectors/sophossiem/collector.js
+++ b/collectors/sophossiem/collector.js
@@ -30,7 +30,7 @@ class SophossiemCollector extends PawsCollector {
         super(context, creds, packageJson.version);
     }
 
-    pawsInitCollectionState(event, callback) {
+    async pawsInitCollectionState(event) {
         const startTs = process.env.paws_collection_start_ts ?
             process.env.paws_collection_start_ts :
             moment().toISOString();
@@ -50,20 +50,19 @@ class SophossiemCollector extends PawsCollector {
                 stream,
                 from_date: from_date_unix,
                 poll_interval_sec: 1
-            }
+            };
         });
 
-        return callback(null, initialStates, 1);
+        return { state: initialStates, nextInvocationTimeout: 1 };
     }
 
-    pawsGetRegisterParameters(event, callback) {
-        const regValues = {
+    async pawsGetRegisterParameters(event) {
+        return {
             sophosSiemObjectNames: process.env.collector_streams
         };
-        callback(null, regValues);
     }
 
-    pawsGetLogs(state, callback) {
+    async pawsGetLogs(state) {
         let collector = this;
         // This code can remove once exsisting code set stream and collector_streams env variable
         if (!process.env.collector_streams) {
@@ -92,91 +91,100 @@ class SophossiemCollector extends PawsCollector {
         const isGatewayHost = APIHostName && APIHostName.includes("/gateway");
         const clientSecret = collector.secret;
         if (!clientSecret) {
-            return callback(isGatewayHost ? "The Authorization token was not found!" : "The Client Secret was not found!");
+            throw new Error(isGatewayHost ? "The Authorization token was not found!" : "The Client Secret was not found!");
         }
 
         const clientId = collector.clientId;
         if (!clientId) {
-            return callback(isGatewayHost ? "The x-api-key was not found!" : "The Client ID was not found!");
+            throw new Error(isGatewayHost ? "The x-api-key was not found!" : "The Client ID was not found!");
         }
 
         let messageString = state.nextPage ? collector.decodebase64string(state.nextPage) : `from ${moment.unix(parseInt(state.from_date)).format("YYYY-MM-DDTHH:mm:ssZ")}`;
         AlLogger.info(`SIEM000001 Collecting data for ${state.stream} ${messageString}`);
+
         // TODO: Remove this isGatewayHostccondition once the new collectors are created and stable.
         if (isGatewayHost) {
             const headers = {
                 "x-api-key": clientId,
                 Authorization: clientSecret
             };
-
-            utils.getAPILogs(APIHostName, headers, state, [], process.env.paws_max_pages_per_invocation)
-                .then(({ accumulator, nextPage, has_more }) => {
-                    const newState = collector._getNextCollectionState(state, nextPage, has_more);
-                    AlLogger.info(`SIEM000002 Next collection in ${newState.poll_interval_sec} seconds`);
-                    return callback(null, accumulator, newState, newState.poll_interval_sec);
-                })
-                .catch((error) => collector.handleApiError(error, state, callback));
+            try {
+                const { accumulator, nextPage, has_more } = await utils.getAPILogs(APIHostName, headers, state, [], process.env.paws_max_pages_per_invocation);
+                const newState = collector._getNextCollectionState(state, nextPage, has_more);
+                AlLogger.info(`SIEM000002 Next collection in ${newState.poll_interval_sec} seconds`);
+                return [accumulator, newState, newState.poll_interval_sec];
+            } catch (error) {
+                return this._handleApiError(error, state);
+            }
         } else {
-            utils.authenticate(SOPHOS_AUTH_BASE_URL, clientId, clientSecret).then((token) => {
-                utils.getTenantIdAndDataRegion(SOPHOS_API_BASE_URL, token).then((response) => {
-                    if (!response.id) {
-                        return callback("TenantId not found.");
-                    }
-                    let tenantId = response.id;
-                    if (!response.apiHosts.dataRegion) {
-                        return callback("Please generate credentials for the tenant. Currently, we do not support credentials for Organization and Partner.");
-                    }
-                    const apiHostsURL = response.apiHosts.dataRegion.replace(/^https:\/\/|\/$/g, "");
-                    let headers = { "X-Tenant-ID": tenantId, Authorization: `Bearer ${token}`};
-                    utils.getAPILogs(apiHostsURL, headers, state, [], process.env.paws_max_pages_per_invocation)
-                        .then(({ accumulator, nextPage, has_more }) => {
-                            const newState = collector._getNextCollectionState(state, nextPage, has_more);
-                            AlLogger.info(`SIEM000002 Next collection in ${newState.poll_interval_sec} seconds`);
-                            return callback(null, accumulator, newState, newState.poll_interval_sec);
-                        })
-                        .catch((error) => collector.handleApiError(error, state, callback));
-                }).catch((error) => collector.handleErrors(error, callback));
-            }).catch((error) => collector.handleAuthError(error, callback));
+            let token;
+            try {
+                token = await utils.authenticate(SOPHOS_AUTH_BASE_URL, clientId, clientSecret);
+            } catch (error) {
+                this._throwAuthError(error);
+            }
+
+            let response;
+            try {
+                response = await utils.getTenantIdAndDataRegion(SOPHOS_API_BASE_URL, token);
+            } catch (error) {
+                throw this.createErrorObject(error);
+            }
+
+            if (!response.id) {
+                throw new Error("TenantId not found.");
+            }
+            if (!response.apiHosts.dataRegion) {
+                throw new Error("Please generate credentials for the tenant. Currently, we do not support credentials for Organization and Partner.");
+            }
+
+            const tenantId = response.id;
+            const apiHostsURL = response.apiHosts.dataRegion.replace(/^https:\/\/|\/$/g, "");
+            const headers = { "X-Tenant-ID": tenantId, Authorization: `Bearer ${token}` };
+            try {
+                const { accumulator, nextPage, has_more } = await utils.getAPILogs(apiHostsURL, headers, state, [], process.env.paws_max_pages_per_invocation);
+                const newState = collector._getNextCollectionState(state, nextPage, has_more);
+                AlLogger.info(`SIEM000002 Next collection in ${newState.poll_interval_sec} seconds`);
+                return [accumulator, newState, newState.poll_interval_sec];
+            } catch (error) {
+                return this._handleApiError(error, state);
+            }
         }
     }
 
     createErrorObject(error) {
         const errorObject = {
-            message: error.message || (error.response && error.response.data && error.response.data.message) || (error.response && error.response.message) || "Unknown error",
-            errorCode: error.errorCode || (error.response && error.response.data && error.response.data.errorCode) || (error.response && error.response.status) || error.code,
-            status: error.status || (error.response && error.response.status),
-            statusText: error.statusText || (error.response && error.response.statusText),
-            code: error.code,
-            errno: error.errno
+            message: (error && error.message) || (error && error.response && error.response.data && error.response.data.message) || (error && error.response && error.response.message) || "Unknown error",
+            errorCode: (error && error.errorCode) || (error && error.response && error.response.data && error.response.data.errorCode) || (error && error.response && error.response.status) || (error && error.code),
+            status: (error && error.status) || (error && error.response && error.response.status),
+            statusText: (error && error.statusText) || (error && error.response && error.response.statusText),
+            code: error && error.code,
+            errno: error && error.errno
         };
         return errorObject;
     }
 
-    handleApiError(error, state, callback) {
+    async _handleApiError(error, state) {
         if (error.response) {
             if (error.response.status === 401) {
                 const errorObject = this.createErrorObject(error);
                 errorObject.message = "Invalid Credentials or Token expired or customer not authorized to make API call";
-                return callback(errorObject);
+                throw errorObject;
             }
             if (error.response.status === 429) {
                 state.poll_interval_sec = 900;
                 AlLogger.info("API Request Limit Exceeded.");
-                this.reportApiThrottling(() => callback(null, [], state, state.poll_interval_sec));
-                return;
+                await this.reportApiThrottling();
+                return [[], state, state.poll_interval_sec];
             }
         }
-        return callback(this.createErrorObject(error));
+        throw this.createErrorObject(error);
     }
 
-    handleErrors(error, callback) {
-        return callback(this.createErrorObject(error));
-    }
-
-    handleAuthError(error, callback) {
+    _throwAuthError(error) {
         const errorObject = this.createErrorObject(error);
-        
-        if (error.response && error.response.data) {
+
+        if (error && error.response && error.response.data) {
             const errorCode = error.response.data.errorCode;
             if (errorCode === "oauth.invalid_client_secret" || errorCode === "customer.validation") {
                 errorObject.message = `Error code [${error.response.status}]. Invalid client secret is provided.`;
@@ -187,8 +195,8 @@ class SophossiemCollector extends PawsCollector {
         } else if (!errorObject.message || errorObject.message === "Unknown error") {
             errorObject.message = "Unknown authentication error";
         }
-        
-        return callback(errorObject);
+
+        throw errorObject;
     }
 
     _getNextCollectionState(curState, nextPage, has_more) {

--- a/collectors/sophossiem/index.js
+++ b/collectors/sophossiem/index.js
@@ -8,15 +8,19 @@
  * -----------------------------------------------------------------------------
  */
 
-const debug = require('debug') ('index');
+const debug = require('debug')('index');
 const AlLogger = require('@alertlogic/al-aws-collector-js').Logger;
 const SophossiemCollector = require('./collector').SophossiemCollector;
 
-exports.handler = SophossiemCollector.makeHandler(function(event, context) {
+exports.handler = SophossiemCollector.makeHandler(async function (event, context) {
     debug('input event: ', event);
     AlLogger.defaultMeta = { requestId: context.awsRequestId };
-    SophossiemCollector.load().then(function(creds) {
-        var sophossiemc = new SophossiemCollector(context, creds);
-        sophossiemc.handleEvent(event);
-    });
+    try {
+        const creds = await SophossiemCollector.load();
+        let sophossiemc = new SophossiemCollector(context, creds);
+        await sophossiemc.handleEvent(event);
+    } catch (error) {
+        AlLogger.error("Unhandled error in handler execution", error);
+        throw error;
+    }
 });

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.2.21",
+  "version": "1.3.0",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.777.0",
-    "@aws-sdk/client-cloudwatch": "^3.777.0",
-    "@aws-sdk/client-dynamodb": "^3.777.0",
-    "@aws-sdk/client-kms": "^3.777.0",
-    "@aws-sdk/client-lambda": "^3.777.0",
-    "@aws-sdk/client-s3": "^3.779.0",
-    "@aws-sdk/client-sqs": "^3.777.0",
-    "@aws-sdk/client-ssm": "^3.777.0",
+    "@aws-sdk/client-cloudformation": "^3.1000.0",
+    "@aws-sdk/client-cloudwatch": "^3.1000.0",
+    "@aws-sdk/client-dynamodb": "^3.1000.0",
+    "@aws-sdk/client-kms": "^3.1000.0",
+    "@aws-sdk/client-lambda": "^3.1000.0",
+    "@aws-sdk/client-s3": "^3.1000.0",
+    "@aws-sdk/client-sqs": "^3.1000.0",
+    "@aws-sdk/client-ssm": "^3.1000.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -25,13 +25,14 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.2.11",
-    "async": "^3.2.6",
+    "@alertlogic/paws-collector": "2.3.2",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "minimatch": "^3.1.4",
+    "serialize-javascript": "^7.0.3"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/sophossiem/test/sophossiem_test.js
+++ b/collectors/sophossiem/test/sophossiem_test.js
@@ -11,27 +11,35 @@ const { CloudWatch } = require("@aws-sdk/client-cloudwatch"),
 
 var responseStub = {};
 let authenticate, getTenantIdAndDataRegion, getAPILogs;
+
+function restoreUtilStubs() {
+    if (authenticate && authenticate.restore) authenticate.restore();
+    if (getTenantIdAndDataRegion && getTenantIdAndDataRegion.restore) getTenantIdAndDataRegion.restore();
+    if (getAPILogs && getAPILogs.restore) getAPILogs.restore();
+}
+
 describe('Unit Tests', function () {
 
     beforeEach(function () {
-        sinon.stub(SSM.prototype, 'getParameter').callsFake(function (params, callback) {
+        sinon.stub(SSM.prototype, 'getParameter').callsFake(function (params) {
             const data = Buffer.from('test-secret');
-            return callback(null, { Parameter: { Value: data.toString('base64') } });
+            return Promise.resolve({ Parameter: { Value: data.toString('base64') } });
         });
-        sinon.stub(KMS.prototype, 'decrypt').callsFake(function (params, callback) {
+        sinon.stub(KMS.prototype, 'decrypt').callsFake(function (params) {
             const data = {
                 Plaintext: Buffer.from('{}')
             };
-            return callback(null, data);
+            return Promise.resolve(data);
         });
 
         responseStub = sinon.stub(m_response, 'send').callsFake(
             function fakeFn(event, mockContext, responseStatus, responseData, physicalResourceId) {
-                mockContext.succeed();
+                return Promise.resolve();
             });
     });
 
     afterEach(function () {
+        restoreUtilStubs();
         responseStub.restore();
         KMS.prototype.decrypt.restore();
         SSM.prototype.getParameter.restore();
@@ -45,63 +53,53 @@ describe('Unit Tests', function () {
             },
             succeed: function () { }
         };
-        it('Paws Init Collection State with start date behind 22 hours Success', function (done) {
-            SophossiemCollector.load().then(function (creds) {
-                var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
-                const startDate = moment().subtract(22, 'hours').toISOString();
-                process.env.paws_collection_start_ts = startDate;
-                collector.pawsInitCollectionState({}, (err, initialStates, nextPoll) => {
-                    initialStates.forEach((state) => {
-                        assert.equal(state.poll_interval_sec, 1);
-                        assert.ok(state.from_date);
-                        assert(moment().diff(moment(moment.unix(parseInt(state.from_date)).format("YYYY-MM-DDTHH:mm:ssZ")), 'hours') < 24 ,"From date must be within last 24 hours");
-                    });
-                    done();
-                });
+        it('Paws Init Collection State with start date behind 22 hours Success', async function () {
+            const creds = await SophossiemCollector.load();
+            var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
+            const startDate = moment().subtract(22, 'hours').toISOString();
+            process.env.paws_collection_start_ts = startDate;
+
+            const { state: initialStates } = await collector.pawsInitCollectionState({});
+            initialStates.forEach((state) => {
+                assert.equal(state.poll_interval_sec, 1);
+                assert.ok(state.from_date);
+                assert(moment().diff(moment(moment.unix(parseInt(state.from_date)).format("YYYY-MM-DDTHH:mm:ssZ")), 'hours') < 24, "From date must be within last 24 hours");
             });
         });
 
-        it('Paws Init Collection State with start date behind 2 days Success', function (done) {
-            SophossiemCollector.load().then(function (creds) {
-                var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
-                const startDate = moment().subtract(2, 'days').toISOString();
-                process.env.paws_collection_start_ts = startDate;
-                collector.pawsInitCollectionState({}, (err, initialStates, nextPoll) => {
-                    initialStates.forEach((state) => {
-                        assert.equal(state.poll_interval_sec, 1);
-                        assert.ok(state.from_date);
-                        assert(moment().diff(moment(moment.unix(parseInt(state.from_date)).format("YYYY-MM-DDTHH:mm:ssZ")), 'hours') < 24 ,"From date must be within last 24 hours");     
-                    });
-                    done();
-                });
+        it('Paws Init Collection State with start date behind 2 days Success', async function () {
+            const creds = await SophossiemCollector.load();
+            var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
+            const startDate = moment().subtract(2, 'days').toISOString();
+            process.env.paws_collection_start_ts = startDate;
+
+            const { state: initialStates } = await collector.pawsInitCollectionState({});
+            initialStates.forEach((state) => {
+                assert.equal(state.poll_interval_sec, 1);
+                assert.ok(state.from_date);
+                assert(moment().diff(moment(moment.unix(parseInt(state.from_date)).format("YYYY-MM-DDTHH:mm:ssZ")), 'hours') < 24, "From date must be within last 24 hours");
             });
         });
     });
 
     describe('Paws Get Register Parameters', function () {
-        it('Paws Get Register Parameters Success', function (done) {
+        it('Paws Get Register Parameters Success', async function () {
             let ctx = {
                 invokedFunctionArn: sophossiemMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
 
-            SophossiemCollector.load().then(function (creds) {
-                var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
-                const sampleEvent = { ResourceProperties: { StackName: 'a-stack-name' } };
-                collector.pawsGetRegisterParameters(sampleEvent, (err, regValues) => {
-                    const expectedRegValues = {
-                        sophosSiemObjectNames: "[\"Events\", \"Alerts\"]",
-                    };
-                    assert.deepEqual(regValues, expectedRegValues);
-                    done();
-                });
-            });
+            const creds = await SophossiemCollector.load();
+            var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
+            const sampleEvent = { ResourceProperties: { StackName: 'a-stack-name' } };
+            const regValues = await collector.pawsGetRegisterParameters(sampleEvent);
+            const expectedRegValues = {
+                sophosSiemObjectNames: "[\"Events\", \"Alerts\"]",
+            };
+            assert.deepEqual(regValues, expectedRegValues);
         });
     });
 
@@ -113,134 +111,103 @@ describe('Unit Tests', function () {
             },
             succeed: function () { }
         };
-        it('Paws Get Logs Success', function (done) {
-
+        it('Paws Get Logs Success', async function () {
             authenticate = sinon.stub(utils, 'authenticate').callsFake(
                 function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve("token");
-                    });
+                    return Promise.resolve("token");
                 });
             getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
                 function fakeFn(hostName, token) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({
-                            "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
-                            "idType": "tenant",
-                            "apiHosts": {
-                                "global": "https://api.central.sophos.com",
-                                "dataRegion": "https://api-us03.central.sophos.com"
-                            }
-                        });
-                    });
-                });
-
-            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
-                function fakeFn(BaseAPIURL, headers, state, accumulator, maxPagesPerInvocation) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [sophossiemMock.LOG_EVENT, sophossiemMock.LOG_EVENT], nextPage: "nextPage", has_more: false });
-                    });
-                });
-
-            SophossiemCollector.load().then(function (creds) {
-                var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
-                const startDate = moment().subtract(23, 'hours');
-                const curState = {
-                    stream: "Events",
-                    from_date: startDate.unix(),
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(logs.length, 2);
-                    assert.equal(newState.poll_interval_sec, 60);
-                    assert.equal(newState.nextPage, "nextPage");
-                    assert.ok(logs[0].id);
-                    getAPILogs.restore();
-                    getTenantIdAndDataRegion.restore();
-                    authenticate.restore();
-                    done();
-                });
-
-            });
-        });
-
-        it('Paws Get Logs with has more true Success', function (done) {
-            authenticate = sinon.stub(utils, 'authenticate').callsFake(
-                function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve("token");
-                    });
-                });
-            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
-                function fakeFn(hostName, token) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({
-                            "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
-                            "idType": "tenant",
-                            "apiHosts": {
-                                "global": "https://api.central.sophos.com",
-                                "dataRegion": "https://api-us03.central.sophos.com"
-                            }
-                        });
+                    return Promise.resolve({
+                        "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
+                        "idType": "tenant",
+                        "apiHosts": {
+                            "global": "https://api.central.sophos.com",
+                            "dataRegion": "https://api-us03.central.sophos.com"
+                        }
                     });
                 });
             getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
                 function fakeFn(BaseAPIURL, headers, state, accumulator, maxPagesPerInvocation) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({ accumulator: [sophossiemMock.LOG_EVENT, sophossiemMock.LOG_EVENT], nextPage: "nextPage", has_more: true });
-                    });
+                    return Promise.resolve({ accumulator: [sophossiemMock.LOG_EVENT, sophossiemMock.LOG_EVENT], nextPage: "nextPage", has_more: false });
                 });
 
-            SophossiemCollector.load().then(function (creds) {
-                var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
-                const curState = {
-                    stream: "Events",
-                    nextPage: "nextPage",
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(logs.length, 2);
-                    assert.equal(newState.poll_interval_sec, 1);
-                    assert.equal(newState.nextPage, "nextPage");
-                    assert.ok(logs[0].id);
-                    getAPILogs.restore();
-                    getTenantIdAndDataRegion.restore();
-                    authenticate.restore();
-                    done();
-                });
+            const creds = await SophossiemCollector.load();
+            var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
+            const startDate = moment().subtract(23, 'hours');
+            const curState = {
+                stream: "Events",
+                from_date: startDate.unix(),
+                poll_interval_sec: 1
+            };
 
-            });
+            const [logs, newState] = await collector.pawsGetLogs(curState);
+            assert.equal(logs.length, 2);
+            assert.equal(newState.poll_interval_sec, 60);
+            assert.equal(newState.nextPage, "nextPage");
+            assert.ok(logs[0].id);
         });
 
-        it('Get Logs check API throttling error', function (done) {
-
+        it('Paws Get Logs with has more true Success', async function () {
             authenticate = sinon.stub(utils, 'authenticate').callsFake(
                 function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve("token");
-                    });
+                    return Promise.resolve("token");
                 });
             getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
                 function fakeFn(hostName, token) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve({
-                            "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
-                            "idType": "tenant",
-                            "apiHosts": {
-                                "global": "https://api.central.sophos.com",
-                                "dataRegion": "https://api-us03.central.sophos.com"
-                            }
-                        });
+                    return Promise.resolve({
+                        "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
+                        "idType": "tenant",
+                        "apiHosts": {
+                            "global": "https://api.central.sophos.com",
+                            "dataRegion": "https://api-us03.central.sophos.com"
+                        }
+                    });
+                });
+            getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
+                function fakeFn(BaseAPIURL, headers, state, accumulator, maxPagesPerInvocation) {
+                    return Promise.resolve({ accumulator: [sophossiemMock.LOG_EVENT, sophossiemMock.LOG_EVENT], nextPage: "nextPage", has_more: true });
+                });
+
+            const creds = await SophossiemCollector.load();
+            var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
+            const curState = {
+                stream: "Events",
+                nextPage: "nextPage",
+                poll_interval_sec: 1
+            };
+
+            const [logs, newState] = await collector.pawsGetLogs(curState);
+            assert.equal(logs.length, 2);
+            assert.equal(newState.poll_interval_sec, 1);
+            assert.equal(newState.nextPage, "nextPage");
+            assert.ok(logs[0].id);
+        });
+
+        it('Get Logs check API throttling error', async function () {
+            authenticate = sinon.stub(utils, 'authenticate').callsFake(
+                function fakeFn(hostName, clientId, clientSecret) {
+                    return Promise.resolve("token");
+                });
+            getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
+                function fakeFn(hostName, token) {
+                    return Promise.resolve({
+                        "id": "57ca9a6b-885f-4e36-95ec-290548c26059",
+                        "idType": "tenant",
+                        "apiHosts": {
+                            "global": "https://api.central.sophos.com",
+                            "dataRegion": "https://api-us03.central.sophos.com"
+                        }
                     });
                 });
             getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
                 function fakeFn(baseUrl, token, tenant_Id, state, accumulator, maxPagesPerInvocation) {
-                    return new Promise(function (resolve, reject) {
-                        return reject({ response: { status: 429, data: { errorCode: "TooManyRequests" } } });
-                    });
+                    return Promise.reject({ response: { status: 429, data: { errorCode: "TooManyRequests" } } });
                 });
 
-            SophossiemCollector.load().then(function (creds) {
+            let putMetricDataStub;
+            try {
+                const creds = await SophossiemCollector.load();
                 var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
                 const startDate = moment().subtract(23, 'hours');
                 const curState = {
@@ -250,70 +217,57 @@ describe('Unit Tests', function () {
                 };
 
                 var reportSpy = sinon.spy(collector, 'reportApiThrottling');
-                let putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake((params, callback) => callback(null));
-                collector.pawsGetLogs(curState, (err, logs, newState, newPollInterval) => {
-                    assert.equal(true, reportSpy.calledOnce);
-                    assert.equal(logs.length, 0);
-                    assert.equal(newState.poll_interval_sec, 900);
-                    getAPILogs.restore();
-                    putMetricDataStub.restore();
-                    getTenantIdAndDataRegion.restore();
-                    authenticate.restore();
-                    done();
-                });
-
-            });
+                putMetricDataStub = sinon.stub(CloudWatch.prototype, 'putMetricData').callsFake((params) => Promise.resolve());
+                const [logs, newState] = await collector.pawsGetLogs(curState);
+                assert.equal(true, reportSpy.calledOnce);
+                assert.equal(logs.length, 0);
+                assert.equal(newState.poll_interval_sec, 900);
+            } finally {
+                if (putMetricDataStub && putMetricDataStub.restore) putMetricDataStub.restore();
+            }
         });
 
-        it('Paws Get Logs api Failed and show client error on DDMetric', function (done) {
+        it('Paws Get Logs api Failed and show client error on DDMetric', async function () {
             authenticate = sinon.stub(utils, 'authenticate').callsFake(
                 function fakeFn(hostName, clientId, clientSecret) {
-                    return new Promise(function (resolve, reject) {
-                        return resolve("token");
-                    });
+                    return Promise.resolve("token");
                 });
             getTenantIdAndDataRegion = sinon.stub(utils, 'getTenantIdAndDataRegion').callsFake(
                 function fakeFn(hostName, token) {
-                    return new Promise(function (resolve, reject) {
-                        return reject({ response: { data: { errorCode: "Unauthorized", code: "USR00004c5", message: "The client needs to authenticate before making the API call. Either your credentials are invalid or blacklisted, or your JWT authorization token has expired", requestId: "6DB1D8AC-1BFA-448B-8439-5486E6D25A74" } } });
-                    });
+                    return Promise.reject({ response: { data: { errorCode: "Unauthorized", code: "USR00004c5", message: "The client needs to authenticate before making the API call. Either your credentials are invalid or blacklisted, or your JWT authorization token has expired", requestId: "6DB1D8AC-1BFA-448B-8439-5486E6D25A74" } } });
                 });
-
             getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(
                 function fakeFn(BaseAPIURL, headers, state, accumulator, maxPagesPerInvocation) {
-                    return new Promise(function (resolve, reject) {
-                        return reject({
-                            response: {
-                                status: 403,
-                                data: {
-                                    error: "Forbidden",
-                                    message: "Forbidden",
-                                    correlationId: "59763C8E-B687-47D0-8F7B-88113425CE3B",
-                                    code: "USR00004c5",
-                                    createdAt: "2019-08-15T11:25:45.987Z"
-                                }
+                    return Promise.reject({
+                        response: {
+                            status: 403,
+                            data: {
+                                error: "Forbidden",
+                                message: "Forbidden",
+                                correlationId: "59763C8E-B687-47D0-8F7B-88113425CE3B",
+                                code: "USR00004c5",
+                                createdAt: "2019-08-15T11:25:45.987Z"
                             }
-                        });
+                        }
                     });
                 });
 
-            SophossiemCollector.load().then(function (creds) {
-                var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
-                const startDate = moment().subtract(23, 'hours');
-                const curState = {
-                    stream: "Events",
-                    from_date: startDate.unix(),
-                    poll_interval_sec: 1
-                };
-                collector.pawsGetLogs(curState, (err) => {
-                    assert.equal(err.errorCode,"Unauthorized");
-                    getAPILogs.restore();
-                    getTenantIdAndDataRegion.restore();
-                    authenticate.restore();
-                    done();
-                });
+            const creds = await SophossiemCollector.load();
+            var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
+            const startDate = moment().subtract(23, 'hours');
+            const curState = {
+                stream: "Events",
+                from_date: startDate.unix(),
+                poll_interval_sec: 1
+            };
 
-            });
+            await assert.rejects(
+                async () => collector.pawsGetLogs(curState),
+                (err) => {
+                    assert.equal(err.errorCode, "Unauthorized");
+                    return true;
+                }
+            );
         });
     });
 
@@ -327,62 +281,53 @@ describe('Unit Tests', function () {
             }
         };
 
-        it('Next state tests success with has more false', function (done) {
-            SophossiemCollector.load().then(function (creds) {
-                var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
-                const startDate = moment();
-                const curState = {
-                    stream: "Events",
-                    from_date: startDate.unix(),
-                    poll_interval_sec: 1
-                };
-                const nextPage = "nextPage";
-                const has_more = false;
-                let nextState = collector._getNextCollectionState(curState, nextPage, has_more);
-                assert.equal(nextState.poll_interval_sec, collector.pollInterval);
-                assert.equal(nextState.nextPage, "nextPage");
-                done();
-            });
+        it('Next state tests success with has more false', async function () {
+            const creds = await SophossiemCollector.load();
+            var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
+            const startDate = moment();
+            const curState = {
+                stream: "Events",
+                from_date: startDate.unix(),
+                poll_interval_sec: 1
+            };
+            const nextPage = "nextPage";
+            const has_more = false;
+            let nextState = collector._getNextCollectionState(curState, nextPage, has_more);
+            assert.equal(nextState.poll_interval_sec, collector.pollInterval);
+            assert.equal(nextState.nextPage, "nextPage");
         });
 
-        it('Next state tests success with has more true', function (done) {
-            SophossiemCollector.load().then(function (creds) {
-                var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
-                const startDate = moment();
-                const curState = {
-                    stream: "Events",
-                    from_date: startDate.unix(),
-                    poll_interval_sec: 1
-                };
-                const nextPage = "nextPage";
-                const has_more = true;
-                let nextState = collector._getNextCollectionState(curState, nextPage, has_more);
-                assert.equal(nextState.poll_interval_sec, 1);
-                assert.equal(nextState.nextPage, "nextPage");
-                done();
-            });
+        it('Next state tests success with has more true', async function () {
+            const creds = await SophossiemCollector.load();
+            var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
+            const startDate = moment();
+            const curState = {
+                stream: "Events",
+                from_date: startDate.unix(),
+                poll_interval_sec: 1
+            };
+            const nextPage = "nextPage";
+            const has_more = true;
+            let nextState = collector._getNextCollectionState(curState, nextPage, has_more);
+            assert.equal(nextState.poll_interval_sec, 1);
+            assert.equal(nextState.nextPage, "nextPage");
         });
     });
 
     describe('Format Tests', function () {
-        it('log format success', function (done) {
+        it('log format success', async function () {
             let ctx = {
                 invokedFunctionArn: sophossiemMock.FUNCTION_ARN,
                 fail: function (error) {
                     assert.fail(error);
-                    done();
                 },
-                succeed: function () {
-                    done();
-                }
+                succeed: function () {}
             };
-            SophossiemCollector.load().then(function (creds) {
-                var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
-                let fmt = collector.pawsFormatLog(sophossiemMock.LOG_EVENT);
-                assert.equal(fmt.progName, 'SophossiemCollector');
-                assert.ok(fmt.message);
-                done();
-            });
+            const creds = await SophossiemCollector.load();
+            var collector = new SophossiemCollector(ctx, creds, 'sophossiem');
+            let fmt = collector.pawsFormatLog(sophossiemMock.LOG_EVENT);
+            assert.equal(fmt.progName, 'SophossiemCollector');
+            assert.ok(fmt.message);
         });
     });
 });

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -269,7 +269,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-salesforce-collector"
-      ALPS_SERVICE_VERSION: "1.1.63" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh salesforce
@@ -291,7 +291,7 @@ stages:
       - ./build_collector.sh sentinelone
     env:
       ALPS_SERVICE_NAME: "paws-sentinelone-collector"
-      ALPS_SERVICE_VERSION: "1.0.60" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
     outputs:
       file: ./sentinelone-collector*
     packagers:
@@ -307,7 +307,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-sophos-collector"
-      ALPS_SERVICE_VERSION: "1.0.60" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.1.0" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh sophos
@@ -329,7 +329,7 @@ stages:
       - ./build_collector.sh sophossiem
     env:
       ALPS_SERVICE_NAME: "paws-sophossiem-collector"
-      ALPS_SERVICE_VERSION: "1.2.21" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.0" #set the value from collector package json
     outputs:
       file: ./sophossiem-collector*
     packagers:


### PR DESCRIPTION
**Problem Description**
Currently, our collector is using Node.js 22 with AWS SDK v3, which support both callback and async/await both. However, it appears that support for callback will be deprecated in Node.js 24 or later versions

**Solution Description**

1. Refactor the code to use async/promise AWS functions and update the test cases for **Salesforce, Sophos SIEM,** **Sophos** and **SentinelOne** collectors.
2. updated the the al-aws-collector and paws-collector lib version to sync latest async/promise changes .reference https://github.com/alertlogic/paws-collector/pull/404 , [pr 409](https://github.com/alertlogic/paws-collector/pull/412#409)
3. Migrated the Googlestackdriver, Gsuite and Mimecast collector from callback to promise.
