### PR TITLE
[Cisco Duo and Cisco meraki]: Fixed the issue facing during async migration

### DIFF
--- a/collectors/ciscoduo/collector.js
+++ b/collectors/ciscoduo/collector.js
@@ -61,7 +61,7 @@ class CiscoduoCollector extends PawsCollector {
         return { state: initialStates, nextInvocationTimeout: pollInterval };
     }
 
-    pawsGetRegisterParameters(event) {
+    async pawsGetRegisterParameters(event) {
         const regValues = {
             ciscoduoObjectNames: process.env.collector_streams
         };
@@ -126,8 +126,13 @@ class CiscoduoCollector extends PawsCollector {
                 return [[], state, state.poll_interval_sec];
             }
             else {
-                // set errorCode if not available in error object to showcase client error on DDMetrics
-                error.errorCode = error.code;
+                // set errorCode only for object errors to avoid type errors with string/primitive throws
+                if (error && (typeof error === 'object')) {
+                    if (error.errorCode === undefined) {
+                        error.errorCode = error.code || error.status;
+                    }
+
+                }
                 throw error;
             }
         }

--- a/collectors/ciscoduo/collector.js
+++ b/collectors/ciscoduo/collector.js
@@ -115,27 +115,41 @@ class CiscoduoCollector extends PawsCollector {
             AlLogger.info(`CDUO000002 Next collection in ${newState.poll_interval_sec} seconds`);
             return [accumulator, newState, newState.poll_interval_sec];
         } catch (error) {
-            // Cisco duo api has some rate limits that we might run into.
-            // If we run into a rate limit error, instead of returning the error,
-            // We return the state back to the queue with an additional 60 secs.
-            if (error.code && error.code === API_THROTTLING_ERROR) {
-                state.poll_interval_sec = state.poll_interval_sec < MAX_POLL_INTERVAL ?
-                    state.poll_interval_sec + POLL_INTERVAL_SECS : MAX_POLL_INTERVAL;
-                AlLogger.warn(`CDUO000003 API Request Limit Exceeded ${JSON.stringify(error)}`);
-                await collector.reportApiThrottling();
-                return [[], state, state.poll_interval_sec];
+            if (this._isThrottlingError(error)) {
+                return await this.handleThrottlingError(error, state);
             }
-            else {
-                // set errorCode only for object errors to avoid type errors with string/primitive throws
-                if (error && (typeof error === 'object')) {
-                    if (error.errorCode === undefined) {
-                        error.errorCode = error.code || error.status;
-                    }
-
-                }
-                throw error;
-            }
+            throw this.handleOtherErrors(error);
         }
+    }
+
+    _isThrottlingError(error) {
+        return !!(error && typeof error === 'object' &&
+            (error.code === API_THROTTLING_ERROR || error.errorCode === API_THROTTLING_ERROR));
+    }
+
+    async handleThrottlingError(error, state) {
+        // Cisco duo api has some rate limits that we might run into.
+        // If we run into a rate limit error, instead of returning the error,
+        // We return the state back to the queue with an additional 60 secs.
+        state.poll_interval_sec = state.poll_interval_sec < MAX_POLL_INTERVAL ?
+            state.poll_interval_sec + POLL_INTERVAL_SECS : MAX_POLL_INTERVAL;
+        AlLogger.warn(`CDUO000003 API Request Limit Exceeded ${JSON.stringify(error)}`);
+        await this.reportApiThrottling();
+        return [[], state, state.poll_interval_sec];
+    }
+
+    handleOtherErrors(error) {
+        if (error && typeof error === 'object') {
+            if (error.errorCode === undefined) {
+                error.errorCode = error.code || error.status;
+            }
+            return error;
+        }
+
+        return {
+            errorCode: null,
+            message: typeof error === 'string' ? error : String(error)
+        };
     }
 
     _getNextCollectionState(curState) {

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoduo/test/ciscoduo_test.js
+++ b/collectors/ciscoduo/test/ciscoduo_test.js
@@ -78,7 +78,7 @@ describe('Unit Tests', function () {
             const creds = await CiscoduoCollector.load();
             var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
             const sampleEvent = { ResourceProperties: { StackName: 'a-stack-name' } };
-            const regValues = collector.pawsGetRegisterParameters(sampleEvent);
+            const regValues = await collector.pawsGetRegisterParameters(sampleEvent);
             const expectedRegValues = {
                 ciscoduoObjectNames: '[\"Authentication\", \"Administrator\",\"Telephony\", \"OfflineEnrollment\"]',
             };

--- a/collectors/ciscomeraki/collector.js
+++ b/collectors/ciscomeraki/collector.js
@@ -86,12 +86,12 @@ class CiscomerakiCollector extends PawsCollector {
                     case 'SelfUpdate':
                         await collector.handleUpdateStreamsFromNetworks();
                         await collector.handleUpdate();
-                        break;
+                        return;
                     default:
-                        await super.handleEvent(event);
+                        return await super.handleEvent(event);
                 }
             default:
-                await super.handleEvent(event);
+                return await super.handleEvent(event);
         }
     }
 
@@ -187,9 +187,12 @@ class CiscomerakiCollector extends PawsCollector {
                 throw error;
             }
         } else if (error && error.response && error.response.data) {
-            AlLogger.debug(`CMRI0000022 error ${error.response.data.errors} - status: ${error.response.status}`);
-            error.response.data.errorCode = error.response.status;
-            throw error.response.data;
+            const data = (typeof error.response.data === 'object' && error.response.data !== null)
+                ? error.response.data
+                : { message: error.response.data };
+            AlLogger.debug(`CMRI0000022 error ${data.errors} - status: ${error.response.status}`);
+            data.errorCode = error.response.status;
+            throw data;
         } else {
             throw error;
         }

--- a/collectors/ciscomeraki/package.json
+++ b/collectors/ciscomeraki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscomeraki-collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Cisco Meraki Log Collector",
   "repository": {},
   "private": true,

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -120,7 +120,7 @@ stages:
       - ./build_collector.sh ciscoduo
     env:
       ALPS_SERVICE_NAME: "paws-ciscoduo-collector"
-      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
     outputs:
       file: ./ciscoduo-collector*
     packagers:
@@ -139,7 +139,7 @@ stages:
       - ./build_collector.sh ciscomeraki
     env:
       ALPS_SERVICE_NAME: "paws-ciscomeraki-collector"
-      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
     outputs:
       file: ./ciscomeraki-collector*
     packagers:


### PR DESCRIPTION
### Problem Description

1. Failing self-update in Cisco Duo.
2. Sometimes the third-party API returns errors in a non-standard format (for example, a plain string instead of an object). During self-update, we add [errorCode] for DD metrics, but this fails when the error is not an object. We need to validate the error type before assigning [errorCode] so string/primitive errors are handled safely and the original error context is preserved.

### Solution Description

1. Wait and return from lambda after successful selfupdate.
2. Added a type check before assigning errorCode.
3. If the caught error is an object, we safely append ErrorCode (when missing) and rethrow.
4. If the caught error is a string/primitive, we wrap it in a standard Error object and preserve the original value.
