### PR TITLE
[Paws Lib]: Harden dedupe/retry flow and simplify throttling handling & Vulnerability in NPM inspected by AWS inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {
@@ -21,14 +21,14 @@
     "rel": "npm publish --access=public"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.985.0",
-    "@aws-sdk/client-cloudwatch": "^3.985.0",
-    "@aws-sdk/client-dynamodb": "^3.985.0",
-    "@aws-sdk/client-kms": "^3.985.0",
-    "@aws-sdk/client-lambda": "^3.985.0",
-    "@aws-sdk/client-s3": "^3.985.0",
-    "@aws-sdk/client-sqs": "^3.985.0",
-    "@aws-sdk/client-ssm": "^3.985.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "clone": "*",
     "jshint": "^2.13.6",
     "mocha": "^11.7.5",
@@ -38,9 +38,8 @@
     "yargs": "^18.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.2.4",
+    "@alertlogic/al-aws-collector-js": "4.2.5",
     "@smithy/node-http-handler": "^4.4.8",
-    "async": "^3.2.6",
     "datadog-lambda-js": "^9.120.0",
     "debug": "^4.4.3",
     "moment": "^2.30.1"
@@ -48,12 +47,13 @@
   "overrides": {
     "diff": "^8.0.3",
     "jshint": {
-      "minimatch": "^3.1.4"
+      "minimatch": "^3.1.4",
+      "lodash": "^4.18.0"
     },
     "test-exclude": {
       "minimatch": "^3.1.4"
     },
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.5"
   },
   "author": "Alert Logic Inc."
 }

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -235,6 +235,28 @@ class PawsCollector extends AlAwsCollectorV2 {
         );
     }
 
+    hasSufficientRemainingTime(minRemainingTimeInMs = REMAINING_CONTEXT_TIME_IN_MS) {
+        if (!this.context || typeof this.context.getRemainingTimeInMillis !== 'function') {
+            return true;
+        }
+
+        return this.context.getRemainingTimeInMillis() > minRemainingTimeInMs;
+    }
+
+    isThrottlingError(error) {
+        if (!error) {
+            return false;
+        }
+
+        const code = `${error.name || ''} ${error.Code || ''} ${error.code || ''} ${error.__type || ''}`.toLowerCase();
+        const message = typeof error.message === 'string' ? error.message.toLowerCase() : '';
+        const httpStatusCode = error.$metadata && error.$metadata.httpStatusCode;
+
+        return code.includes('throttl') ||
+            message.includes('rate exceeded') ||
+            httpStatusCode === 429;
+    }
+
     getProperties() {
         const baseProps = super.getProperties();
         let pawsProps = {
@@ -488,7 +510,7 @@ class PawsCollector extends AlAwsCollectorV2 {
 
                     // If remaining execution time is low, do not enqueue a new state message.
                     // Failing this invocation keeps the original SQS message for retry and prevents duplicate messages.
-                    if (remainingTimeInMillis < REMAINING_CONTEXT_TIME_IN_MS) {
+                    if (remainingTimeInMillis <= REMAINING_CONTEXT_TIME_IN_MS) {
                         AlLogger.error(`PAWS000303 Error handling poll request with low remaining time. Keeping original SQS message for retry: ${collector.stringifyError(handleError)}`);
                         await collector.done(handleError, pawsState, false);
                         return;
@@ -726,6 +748,13 @@ class PawsCollector extends AlAwsCollectorV2 {
     };
 
     async reportDuplicateLogCount(duplicateCount) {
+        this.reportDDMetric("duplicate_messages", duplicateCount);
+
+        if (!this.hasSufficientRemainingTime()) {
+            AlLogger.debug(`PAWS000409 Skipping CloudWatch duplicate metric due to low remaining lambda time`);
+            return null;
+        }
+
         var cloudwatch = new CloudWatch({ apiVersion: '2010-08-01' });
         const params = {
             MetricData: [
@@ -748,8 +777,15 @@ class PawsCollector extends AlAwsCollectorV2 {
             ],
             Namespace: 'PawsCollectors'
         };
-        this.reportDDMetric("duplicate_messages", duplicateCount);
-        return await cloudwatch.putMetricData(params);
+        try {
+            return await cloudwatch.putMetricData(params);
+        } catch (error) {
+            if (this.isThrottlingError(error)) {
+                AlLogger.debug(`PAWS000410 CloudWatch duplicate metric throttled; skipping metric publish`);
+                return null;
+            }
+            throw error;
+        }
     };
     /**
      * Report the collector status(ok/error)to dd metrics
@@ -916,7 +952,7 @@ class PawsCollector extends AlAwsCollectorV2 {
                 try {
                     await collector.reportDuplicateLogCount(duplicateCount);
                 } catch (err) {
-                    AlLogger.warn(`PAWS000405 error from custom cloud watch metrics ${JSON.stringify(err)}`);
+                    AlLogger.warn(`PAWS000405 Error publishing duplicate count metrics ${JSON.stringify(err)}`);
                 }
             }
             return uniqueLogs;

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -72,12 +72,22 @@ const DDB_OPTIONS = {
 
 const DDB = new DynamoDB(DDB_OPTIONS);
 
+const CW_OPTIONS = {
+    requestHandler: nodeHttpHandler
+};
+const CW = new CloudWatch(CW_OPTIONS);
+
+const SQS_OPTIONS = {
+    requestHandler: nodeHttpHandler
+};
+const SQS_CLIENT = new SQS(SQS_OPTIONS);
+
 const DDB_DELETE_BATCH_OPTIONS = {
     maxBatchSize: 25,
     maxBatchSizeBytes: 16 * 1024 * 1024
 };
 const MAX_ERROR_RETRIES = 5;
-let MAX_LOG_BATCH_SIZE = 10000;
+const MAX_LOG_BATCH_SIZE = 10000;
 const REMAINING_CONTEXT_TIME_IN_MS = 10 * 1000;
 
 async function getPawsParamStoreParam() {
@@ -407,7 +417,7 @@ class PawsCollector extends AlAwsCollectorV2 {
                 AlLogger.info(`PAWS000400 Duplicate state: ${stateSqsMsg.messageId}, already in progress. skipping`);
                 throw { errorCode: ERROR_CODE_DUPLICATE_STATE };
             }
-            AlLogger.error(`PAWS000402 ${this._pawsDdbTableName} table not found`);
+            AlLogger.error(`PAWS000402 DDB operation failed for table ${this._pawsDdbTableName}: ${this.stringifyError(error)}`);
             throw error;
         }
     }
@@ -436,11 +446,7 @@ class PawsCollector extends AlAwsCollectorV2 {
             TableName: this._pawsDdbTableName
         };
 
-        try {
-            return await DDB.updateItem(updateParams);
-        } catch (err) {
-            throw err;
-        }
+        return await DDB.updateItem(updateParams);
     }
 
 
@@ -569,12 +575,13 @@ class PawsCollector extends AlAwsCollectorV2 {
      */
     async batchLogProcess(logs, privCollectorState, nextInvocationTimeout) {
         let collector = this;
+        let currentBatchSize = MAX_LOG_BATCH_SIZE;
 
         async function processBatch(logs) {
             let indexArray = [];
-            const batches = Math.ceil(logs.length / MAX_LOG_BATCH_SIZE);
+            const batches = Math.ceil(logs.length / currentBatchSize);
             for (let i = 0; i < batches; i++) {
-                indexArray.push({ start: MAX_LOG_BATCH_SIZE * i, stop: MAX_LOG_BATCH_SIZE * (i + 1) });
+                indexArray.push({ start: currentBatchSize * i, stop: currentBatchSize * (i + 1) });
             }
             let promises = indexArray.map(async (logpart) => {
                 try {
@@ -582,7 +589,7 @@ class PawsCollector extends AlAwsCollectorV2 {
                 } catch (err) {
                     if (typeof err === 'string' && err.includes("Maximum payload size exceeded")) {
                         let logsSlice = logs.slice(logpart.start, logpart.stop);
-                        MAX_LOG_BATCH_SIZE = Math.ceil(logsSlice.length / 2);
+                        currentBatchSize = Math.ceil(logsSlice.length / 2);
                         return await processBatch(logsSlice);
                     } else {
                         await collector.handleDeDupIngestError(err, logs.slice(logpart.start, logpart.stop));
@@ -620,7 +627,6 @@ class PawsCollector extends AlAwsCollectorV2 {
         return params;
     }
     async reportApiThrottling() {
-        var cloudwatch = new CloudWatch({ apiVersion: '2010-08-01' });
         const params = {
             MetricData: [
                 {
@@ -642,15 +648,14 @@ class PawsCollector extends AlAwsCollectorV2 {
             ],
             Namespace: 'PawsCollectors'
         };
-        this.reportDDMetric('api_throttling', 1)
-        return await cloudwatch.putMetricData(params);
+        this.reportDDMetric('api_throttling', 1);
+        return await CW.putMetricData(params);
     };
     /**
      * Report the error to Ingest api service and show case on DDMetrics
      * @param error 
      */
     async reportErrorToIngestApi(error) {
-        var cloudwatch = new CloudWatch({ apiVersion: '2010-08-01' });
         const params = {
             MetricData: [
                 {
@@ -679,7 +684,7 @@ class PawsCollector extends AlAwsCollectorV2 {
             errorCode = error.errorCode;
         }
         this.reportDDMetric("ingest_api", 1, [`result:error`, `error_code:${errorCode}`]);
-        return await cloudwatch.putMetricData(params);
+        return await CW.putMetricData(params);
     };
 
     /**
@@ -687,7 +692,6 @@ class PawsCollector extends AlAwsCollectorV2 {
      * @param error 
      */
     async reportClientError(error) {
-        var cloudwatch = new CloudWatch({ apiVersion: '2010-08-01' });
         const params = {
             MetricData: [
                 {
@@ -711,7 +715,7 @@ class PawsCollector extends AlAwsCollectorV2 {
         };
         let errorCode = typeof (error) === 'object' && error.errorCode ? error.errorCode : 'unknown';
         this.reportDDMetric("client", 1, [`result:error`, `error_code:${errorCode}`]);
-        return await cloudwatch.putMetricData(params);
+        return await CW.putMetricData(params);
     };
 
     async reportCollectionDelay(lastCollectedTs) {
@@ -721,7 +725,6 @@ class PawsCollector extends AlAwsCollectorV2 {
         const delayDuration = moment.duration(nowMoment.diff(lastCollectedMoment));
         const collectionDelaySec = Math.floor(delayDuration.asSeconds());
 
-        var cloudwatch = new CloudWatch({ apiVersion: '2010-08-01' });
         const params = {
             MetricData: [
                 {
@@ -744,7 +747,7 @@ class PawsCollector extends AlAwsCollectorV2 {
             Namespace: 'PawsCollectors'
         };
         this.reportDDMetric('collection_delay', collectionDelaySec);
-        return await cloudwatch.putMetricData(params);
+        return await CW.putMetricData(params);
     };
 
     async reportDuplicateLogCount(duplicateCount) {
@@ -755,7 +758,6 @@ class PawsCollector extends AlAwsCollectorV2 {
             return null;
         }
 
-        var cloudwatch = new CloudWatch({ apiVersion: '2010-08-01' });
         const params = {
             MetricData: [
                 {
@@ -778,7 +780,7 @@ class PawsCollector extends AlAwsCollectorV2 {
             Namespace: 'PawsCollectors'
         };
         try {
-            return await cloudwatch.putMetricData(params);
+            return await CW.putMetricData(params);
         } catch (error) {
             if (this.isThrottlingError(error)) {
                 AlLogger.debug(`PAWS000410 CloudWatch duplicate metric throttled; skipping metric publish`);
@@ -793,7 +795,6 @@ class PawsCollector extends AlAwsCollectorV2 {
      * @returns 
      */
     async reportCollectorStatus(status) {
-        var cloudwatch = new CloudWatch({ apiVersion: '2010-08-01' });
         const params = {
             MetricData: [
                 {
@@ -817,7 +818,7 @@ class PawsCollector extends AlAwsCollectorV2 {
         };
 
         this.reportDDMetric("collector_status", 1, [`status:${status}`]);
-        return await cloudwatch.putMetricData(params);
+        return await CW.putMetricData(params);
     };
 
     async _storeCollectionState(pawsState, privCollectorState, invocationTimeout) {
@@ -829,7 +830,6 @@ class PawsCollector extends AlAwsCollectorV2 {
     }
 
     async _storeCollectionStateArray(pawsState, privCollectorStates, invocationTimeout) {
-        const sqs = new SQS({ apiVersion: '2012-11-05' });
         const nextInvocationTimeout = invocationTimeout ? invocationTimeout : this.pollInterval;
 
         const SQSMsgs = privCollectorStates.map((privState, index) => {
@@ -850,7 +850,7 @@ class PawsCollector extends AlAwsCollectorV2 {
                 Entries: SQSMsgs.slice(i, i + SQS_BATCH_LIMIT),
                 QueueUrl: process.env.paws_state_queue_url
             };
-            promises.push(sqs.sendMessageBatch(params));
+            promises.push(SQS_CLIENT.sendMessageBatch(params));
         }
 
         // Current state message will be removed by Lambda trigger upon successful completion
@@ -859,7 +859,6 @@ class PawsCollector extends AlAwsCollectorV2 {
 
     async _storeCollectionStateSingle(pawsState, privCollectorState, invocationTimeout) {
         let collector = this;
-        var sqs = new SQS({ apiVersion: '2012-11-05' });
         const nextInvocationTimeout = invocationTimeout ? invocationTimeout : collector.pollInterval;
         pawsState.priv_collector_state = privCollectorState;
 
@@ -869,7 +868,7 @@ class PawsCollector extends AlAwsCollectorV2 {
             DelaySeconds: nextInvocationTimeout
         };
         // Current state message will be removed by Lambda trigger upon successful completion
-        await sqs.sendMessage(params);
+        await SQS_CLIENT.sendMessage(params);
     };
 
     /**
@@ -970,10 +969,10 @@ class PawsCollector extends AlAwsCollectorV2 {
         let collector = this;
         if (collector.pawsCollectorType === 'o365') {
             try {
-                await collector.deleteDedupLogItemEntry(logs)
-            } catch (error) {
-                AlLogger.warn(`PAWS000406 Error while delete item in DynamoDB ${err}`);
-                throw error;
+                await collector.deleteDedupLogItemEntry(logs);
+            } catch (deleteError) {
+                AlLogger.warn(`PAWS000406 Error while delete item in DynamoDB ${collector.stringifyError(deleteError)}`);
+                throw deleteError;
             }
         } else {
             throw error;
@@ -1006,11 +1005,7 @@ class PawsCollector extends AlAwsCollectorV2 {
             promises.push(collector.dDBBatchWriteItem(tableName, currentBatch));
         }
 
-        try {
-            return await Promise.all(promises);
-        } catch (error) {
-            throw error;
-        }
+        return await Promise.all(promises);
     }
     /**
      * Form the unique item id which used as primary key

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -482,6 +482,18 @@ class PawsCollector extends AlAwsCollectorV2 {
                     const pawsState = JSON.parse(stateSqsMsg.body);
                     await collector.updateStateDBEntry(stateSqsMsg, STATE_RECORD_FAILED);
 
+                    const remainingTimeInMillis = collector.context && collector.context.getRemainingTimeInMillis ?
+                        collector.context.getRemainingTimeInMillis() :
+                        0;
+
+                    // If remaining execution time is low, do not enqueue a new state message.
+                    // Failing this invocation keeps the original SQS message for retry and prevents duplicate messages.
+                    if (remainingTimeInMillis < REMAINING_CONTEXT_TIME_IN_MS) {
+                        AlLogger.error(`PAWS000303 Error handling poll request with low remaining time. Keeping original SQS message for retry: ${collector.stringifyError(handleError)}`);
+                        await collector.done(handleError, pawsState, false);
+                        return;
+                    }
+
                     // If collector failed to handle poll state we'd like to refresh the state message in SQS
                     // in order to avoid expiration of that message due to retention period.
                     // Here we just upload same state messaged into SQS and send error status to the backend.
@@ -493,20 +505,14 @@ class PawsCollector extends AlAwsCollectorV2 {
                     try {
                         await collector._storeCollectionState(pawsState, stateForRetry, 300);
 
-                        // if sqs message added successfully and lambda time is less than 10 seconds so return the context succeed; so it will delete the old sqs message.
-                        if (collector.context.getRemainingTimeInMillis() < REMAINING_CONTEXT_TIME_IN_MS) {
-                            AlLogger.error(`PAWS000303 Error handling poll request: ${collector.stringifyError(handleError)}`);
-                            await collector.done(null, pawsState);
-                        } else {
-                            let handleErrorString = collector.stringifyError(handleError);
-                            try {
-                                handleErrorString = await collector.reportErrorStatus(handleError, pawsState);
-                            } catch (reportError) {
-                                AlLogger.warn(`PAWS000408 Unable to report collector error status: ${collector.stringifyError(reportError)}`);
-                            }
-                            AlLogger.error(`PAWS000304 Error handling poll request: ${handleErrorString}`);
-                            await collector.done(null, pawsState);
+                        let handleErrorString = collector.stringifyError(handleError);
+                        try {
+                            handleErrorString = await collector.reportErrorStatus(handleError, pawsState);
+                        } catch (reportError) {
+                            AlLogger.warn(`PAWS000408 Unable to report collector error status: ${collector.stringifyError(reportError)}`);
                         }
+                        AlLogger.error(`PAWS000304 Error handling poll request: ${handleErrorString}`);
+                        await collector.done(null, pawsState);
                     } catch (storeError) {
                         await collector.done(storeError);
                     }

--- a/paws_collector.js
+++ b/paws_collector.js
@@ -375,11 +375,16 @@ class PawsCollector extends AlAwsCollectorV2 {
                         Status: { S: STATE_RECORD_INCOMPLETE },
                         ExpireDate: { N: moment().add(DDB_TTL_DAYS, 'days').unix().toString() }
                     },
-                    TableName: this._pawsDdbTableName
+                    TableName: this._pawsDdbTableName,
+                    ConditionExpression: 'attribute_not_exists(CollectorId) AND attribute_not_exists(MessageId)'
                 }
                 return await DDB.putItem(newRecord);
             }
         } catch (error) {
+            if (error && error.name === 'ConditionalCheckFailedException') {
+                AlLogger.info(`PAWS000400 Duplicate state: ${stateSqsMsg.messageId}, already in progress. skipping`);
+                throw { errorCode: ERROR_CODE_DUPLICATE_STATE };
+            }
             AlLogger.error(`PAWS000402 ${this._pawsDdbTableName} table not found`);
             throw error;
         }
@@ -419,9 +424,11 @@ class PawsCollector extends AlAwsCollectorV2 {
 
     async handlePollRequest(stateSqsMsg) {
         let collector = this;
+        let retryPrivCollectorState;
 
         try {
             let pawsState = JSON.parse(stateSqsMsg.body);
+            retryPrivCollectorState = pawsState.priv_collector_state;
 
             if (!collector.registered) {
                 throw new Error('PAWS000103 Collection attempt for unregistrered collector');
@@ -432,6 +439,7 @@ class PawsCollector extends AlAwsCollectorV2 {
             let logs, privCollectorState, nextInvocationTimeout;
             try {
                 [logs, privCollectorState, nextInvocationTimeout] = await collector.pawsGetLogs(pawsState.priv_collector_state);
+                retryPrivCollectorState = privCollectorState;
             } catch (err) {
                 await collector.reportClientError(err);
                 throw err;
@@ -449,7 +457,11 @@ class PawsCollector extends AlAwsCollectorV2 {
                             null;
 
             if (lastCollectedTs) {
-                await collector.reportCollectionDelay(lastCollectedTs);
+                try {
+                    await collector.reportCollectionDelay(lastCollectedTs);
+                } catch (metricError) {
+                    AlLogger.warn(`PAWS000407 Unable to report collection delay metric: ${collector.stringifyError(metricError)}`);
+                }
             }
 
             // Reset the retry count to 0 on successful log processing
@@ -476,16 +488,22 @@ class PawsCollector extends AlAwsCollectorV2 {
                     // The invocation is marked as succeed in order to clean up current state message in SQS.
                     // Increment/reset the retry count if error occured.
                     pawsState.retry_count = (!pawsState.retry_count || pawsState.retry_count >= MAX_ERROR_RETRIES) ? 1 : pawsState.retry_count + 1;
+                    const stateForRetry = retryPrivCollectorState ? retryPrivCollectorState : pawsState.priv_collector_state;
 
                     try {
-                        await collector._storeCollectionState(pawsState, pawsState.priv_collector_state, 300);
+                        await collector._storeCollectionState(pawsState, stateForRetry, 300);
 
                         // if sqs message added successfully and lambda time is less than 10 seconds so return the context succeed; so it will delete the old sqs message.
                         if (collector.context.getRemainingTimeInMillis() < REMAINING_CONTEXT_TIME_IN_MS) {
                             AlLogger.error(`PAWS000303 Error handling poll request: ${collector.stringifyError(handleError)}`);
                             await collector.done(null, pawsState);
                         } else {
-                            const handleErrorString = await collector.reportErrorStatus(handleError, pawsState);
+                            let handleErrorString = collector.stringifyError(handleError);
+                            try {
+                                handleErrorString = await collector.reportErrorStatus(handleError, pawsState);
+                            } catch (reportError) {
+                                AlLogger.warn(`PAWS000408 Unable to report collector error status: ${collector.stringifyError(reportError)}`);
+                            }
                             AlLogger.error(`PAWS000304 Error handling poll request: ${handleErrorString}`);
                             await collector.done(null, pawsState);
                         }

--- a/test/paws_mock.js
+++ b/test/paws_mock.js
@@ -7,10 +7,10 @@ process.env.azollect_api = 'azcollect.global-services.global.alertlogic.com';
 process.env.aims_access_key_id = 'aims-key-id';
 process.env.aims_secret_key = 'aims-secret-key-encrypted';
 process.env.log_group = 'logGroupName';
-process.env.paws_state_queue_arn = 'arn:aws:sqs:us-east-1:352283894008:test-queue';
-process.env.paws_state_queue_url = 'https://sqs.us-east-1.amazonaws.com/352283894008/test-queue';
+process.env.paws_state_queue_arn = 'arn:aws:sqs:us-east-1:352212345008:test-queue';
+process.env.paws_state_queue_url = 'https://sqs.us-east-1.amazonaws.com/352212345008/test-queue';
 process.env.paws_s3_object_path = "s3://joe-creds-test/paws_creds.json";
-process.env.paws_kms_key_arn = "arn:aws:kms:us-east-1:352283894008:key/cdda86d5-615b-4dcc-9319-77ab34510473";
+process.env.paws_kms_key_arn = "arn:aws:kms:us-east-1:352212345008:key/cdda86d5-615b-4dcc-9319-77ab34510473";
 process.env.paws_type_name = 'okta';
 process.env.paws_auth_type = 'auth';
 process.env.paws_poll_interval = 900;
@@ -42,10 +42,14 @@ const CWL_TEST_EVENT = {
     }
 };
 
-const STACK_ID = 'arn:aws:cloudformation:us-east-1:352283894008:stack/test/87b3dc90-bd7e-11e7-9e43-503abe701cfd';
-const FUNCTION_ARN = 'arn:aws:lambda:us-east-1:352283894008:function:test-01-CollectLambdaFunction-2CWNLPPW5XO8';
+const AWS_ACCOUNT_ID = '352212345008';
+const AWS_REGION = 'us-east-1';
+const TEST_QUEUE_NAME = 'test-queue';
+
+const STACK_ID = `arn:aws:cloudformation:${AWS_REGION}:${AWS_ACCOUNT_ID}:stack/test/87b3dc90-bd7e-11e7-9e43-503abe701cfd`;
+const FUNCTION_ARN = `arn:aws:lambda:${AWS_REGION}:${AWS_ACCOUNT_ID}:function:test-01-CollectLambdaFunction-2CWNLPPW5XO8`;
 const FUNCTION_NAME = 'test-TestCollectLambdaFunction-1JNNKQIPOTEST';
-const REGISTRATION_TEST_URL = '/aws/test/353333894008/us-east-1/' + encodeURIComponent(FUNCTION_NAME);
+const REGISTRATION_TEST_URL = `/aws/test/${AWS_ACCOUNT_ID}/us-east-1/` + encodeURIComponent(FUNCTION_NAME);
 const STACK_NAME = 'test-stack-01';
 const LOG_GROUP = 'username-logs-group';
 
@@ -53,7 +57,7 @@ const REGISTRATION_TEST_EVENT = {
     'RequestType': 'Create',
     'ServiceToken': FUNCTION_ARN,
     'ResponseURL': 'https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/resp',
-    'StackId': 'arn:aws:cloudformation:us-east-1:352283894008:stack/test-stack-01/92605900',
+    'StackId': `arn:aws:cloudformation:${AWS_REGION}:${AWS_ACCOUNT_ID}:stack/test-stack-01/92605900`,
     'RequestId': '255fe44d-af80-4c42-bf30-6a78aa244aad',
     'LogicalResourceId': 'RegistrationResource',
     'ResourceType': 'Custom::RegistrationResource',
@@ -61,7 +65,7 @@ const REGISTRATION_TEST_EVENT = {
     {
         'ServiceToken': FUNCTION_ARN,
         'StackName': STACK_NAME,
-        'AwsAccountId': '353333894008',
+        'AwsAccountId': AWS_ACCOUNT_ID,
         'LogGroup': LOG_GROUP
     }
 };
@@ -77,7 +81,7 @@ const DEREGISTRATION_TEST_EVENT = {
     'RequestType': 'Delete',
     'ServiceToken': FUNCTION_ARN,
     'ResponseURL': 'https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/resp',
-    'StackId': 'arn:aws:cloudformation:us-east-1:352283894008:stack/test-stack-01/92605900',
+    'StackId': `arn:aws:cloudformation:${AWS_REGION}:${AWS_ACCOUNT_ID}:stack/test-stack-01/92605900`,
     'RequestId': '255fe44d-af80-4c42-bf30-6a78aa244aad',
     'LogicalResourceId': 'RegistrationResource',
     'ResourceType': 'Custom::RegistrationResource',
@@ -85,7 +89,7 @@ const DEREGISTRATION_TEST_EVENT = {
     {
         'ServiceToken': FUNCTION_ARN,
         'StackName': STACK_NAME,
-        'AwsAccountId': '353333894008',
+        'AwsAccountId': AWS_ACCOUNT_ID,
         'LogGroup': LOG_GROUP
     }
 };
@@ -95,9 +99,9 @@ const DEREGISTRATION_PARAMS = REGISTRATION_PARAMS;
 const CHECKIN_TEST_EVENT = {
     'RequestType': 'ScheduledEvent',
     'Type': 'Checkin',
-    'AwsAccountId': '353333894008',
+    'AwsAccountId': AWS_ACCOUNT_ID,
     'StackName' : STACK_NAME,
-    'Region' : 'us-east-1'
+    'Region' : AWS_REGION
 };
 
 
@@ -137,6 +141,38 @@ const MOCK_LOGS = [
     },
 ];
 
+// Standard SQS record for state polling - used across multiple test scenarios
+const MOCK_SQS_RECORD = {
+    "body": '{\n  "priv_collector_state": {\n    "since": "123",\n    "until": "321"\n  }\n}',
+    "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
+    "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
+    "eventSourceARN": `arn:aws:sqs:${AWS_REGION}:${AWS_ACCOUNT_ID}:${TEST_QUEUE_NAME}`,
+};
+
+// Helper function to create custom SQS records with overrides
+const createMockSQSRecord = (overrides = {}) => {
+    return {
+        ...MOCK_SQS_RECORD,
+        ...overrides
+    };
+};
+
+// Helper function to create SQS record with retry count
+const createMockSQSRecordWithRetry = (retryCount = 0, overrides = {}) => {
+    const body = JSON.stringify({
+        priv_collector_state: {
+            since: "2021-07-01T02:37:37.617Z",
+            until: "2021-07-01T03:37:37.617Z"
+        },
+        retry_count: retryCount
+    });
+    return {
+        ...MOCK_SQS_RECORD,
+        body: body,
+        ...overrides
+    };
+};
+
 module.exports = {
     AIMS_TEST_CREDS : AIMS_TEST_CREDS,
     PAWS_TEST_CREDS : PAWS_TEST_CREDS,
@@ -152,5 +188,11 @@ module.exports = {
     HEALTCHECK_SUBSCRIPTION_FILTERS : HEALTCHECK_SUBSCRIPTION_FILTERS,
     STACK_ID : STACK_ID,
     REGISTRATION_TEST_URL : REGISTRATION_TEST_URL,
-    MOCK_LOGS : MOCK_LOGS
+    MOCK_LOGS : MOCK_LOGS,
+    AWS_ACCOUNT_ID : AWS_ACCOUNT_ID,
+    AWS_REGION : AWS_REGION,
+    TEST_QUEUE_NAME : TEST_QUEUE_NAME,
+    MOCK_SQS_RECORD : MOCK_SQS_RECORD,
+    createMockSQSRecord : createMockSQSRecord,
+    createMockSQSRecordWithRetry : createMockSQSRecordWithRetry
 };

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -171,6 +171,9 @@ class TestCollector extends PawsCollector {
     }
 
     pawsGetLogs(state) {
+        if (this._mockGetLogsError) {
+            return Promise.reject(new Error(this._mockGetLogsError));
+        }
         return Promise.resolve([['log1', 'log2'], { state: 'new-state' }, 900]);
     }
 
@@ -401,14 +404,7 @@ describe('Unit Tests', function() {
             };
 
             const testEvent = {
-                Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                        "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
-                        "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
-                ]
+                Records: [pawsMock.MOCK_SQS_RECORD]
             };
 
             const creds = await TestCollector.load();
@@ -419,17 +415,12 @@ describe('Unit Tests', function() {
             const updateItemArgs = updateItemStub.args[0][0];
             assert.equal(putItemStub.called, true, 'should put a new item in');
             assert.equal(updateItemStub.called, true, 'should update the item to complete');
-            assert.equal(putItemArgs.Item.MessageId.S, "5fea7756-0ea4-451a-a703-a558b933e274");
+            assert.equal(putItemArgs.Item.MessageId.S, pawsMock.MOCK_SQS_RECORD.messageId);
             assert.equal(putItemArgs.ConditionExpression, 'attribute_not_exists(CollectorId) AND attribute_not_exists(MessageId)');
-            assert.equal(updateItemArgs.Key.MessageId.S, "5fea7756-0ea4-451a-a703-a558b933e274");
+            assert.equal(updateItemArgs.Key.MessageId.S, pawsMock.MOCK_SQS_RECORD.messageId);
         });
         it('handles conditional put race by treating it as duplicate state', async function() {
-            const mockRecord = {
-                "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
-                "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
-                "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-            };
+            const mockRecord = pawsMock.MOCK_SQS_RECORD;
             const getItemStub = sinon.stub().callsFake(() => Promise.resolve({}));
             const putItemStub = sinon.stub().callsFake(() => Promise.reject({ name: 'ConditionalCheckFailedException' }));
             const updateItemStub = sinon.stub().callsFake(() => Promise.resolve({ data: null }));
@@ -457,12 +448,7 @@ describe('Unit Tests', function() {
             assert.equal(updateItemStub.notCalled, true, 'should not mark duplicate state as complete/failed');
         });
         it('skips the state if it is already completed', async function() {
-            const mockRecord = {
-                "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
-                "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
-                "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-            };
+            const mockRecord = pawsMock.MOCK_SQS_RECORD;
             const fakeGetFun = function(_params) {
                 return new Promise((resolve, reject) => {
                     const mockItem = {
@@ -503,12 +489,7 @@ describe('Unit Tests', function() {
             assert.equal(updateItemStub.notCalled, true, 'should not update the item to complete');
         });
         it('throws an error if the state is bing processed by another invocation', async function() {
-            const mockRecord = {
-                "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
-                "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
-                "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-            };
+            const mockRecord = pawsMock.MOCK_SQS_RECORD;
             const fakeGetFun = function(param) {
                 const mockItem = {
                     Item: {
@@ -563,14 +544,7 @@ describe('Unit Tests', function() {
             };
 
             const testEvent = {
-                Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                        "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
-                        "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
-                ]
+                Records: [pawsMock.MOCK_SQS_RECORD]
             };
 
             const creds = await TestCollector.load();
@@ -579,7 +553,7 @@ describe('Unit Tests', function() {
 
             const updateItemArgs = updateItemStub.args[0][0];
             assert.equal(updateItemStub.called, true, 'should update the item to complete');
-            assert.equal(updateItemArgs.Key.MessageId.S, "5fea7756-0ea4-451a-a703-a558b933e274");
+            assert.equal(updateItemArgs.Key.MessageId.S, pawsMock.MOCK_SQS_RECORD.messageId);
         });
     });
     describe('Poll Request Tests', function() {
@@ -610,12 +584,7 @@ describe('Unit Tests', function() {
             };
 
             const testEvent = {
-                Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
-                ]
+                Records: [pawsMock.createMockSQSRecord()]
             };
 
             const creds = await TestCollector.load();
@@ -624,7 +593,8 @@ describe('Unit Tests', function() {
         });
 
         it('poll request error, single state', async function() {
-            const getRemainingTimeInMillis = sinon.spy(() => 5000);
+            mockCloudWatch();
+            const getRemainingTimeInMillis = sinon.spy(() => 20000);
             let ctx = {
                 invokedFunctionArn: pawsMock.FUNCTION_ARN,
                 fail: function(error) {
@@ -637,10 +607,7 @@ describe('Unit Tests', function() {
 
             const testEvent = {
                 Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
+                    pawsMock.createMockSQSRecord()
                 ]
             };
 
@@ -664,12 +631,7 @@ describe('Unit Tests', function() {
             };
 
             const testEvent = {
-                Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
-                ]
+                Records: [pawsMock.createMockSQSRecord()]
             };
 
             const creds = await TestCollector.load();
@@ -704,10 +666,7 @@ describe('Unit Tests', function() {
 
             const testEvent = {
                 Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
+                    pawsMock.createMockSQSRecord()
                 ]
             };
 
@@ -741,10 +700,7 @@ describe('Unit Tests', function() {
 
             const testEvent = {
                 Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
+                    pawsMock.createMockSQSRecord()
                 ]
             };
 
@@ -781,10 +737,7 @@ describe('Unit Tests', function() {
 
             const testEvent = {
                 Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
+                    pawsMock.createMockSQSRecord()
                 ]
             };
 
@@ -825,10 +778,7 @@ describe('Unit Tests', function() {
 
             const testEvent = {
                 Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
+                    pawsMock.createMockSQSRecord()
                 ]
             };
 
@@ -892,12 +842,7 @@ describe('Unit Tests', function() {
 
             const testEvent = {
                 Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"2021-07-01T02:37:37.617Z\",\n    \"until\": \"2021-07-01T03:37:37.617Z\"\n  }\n}",
-                        "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
-                        "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
+                    pawsMock.createMockSQSRecord()
                 ]
             };
             const creds = await TestMaxLogSizeCollector.load();
@@ -935,14 +880,7 @@ describe('Unit Tests', function() {
             };
 
             const testEvent = {
-                Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"2021-07-01T02:37:37.617Z\",\n    \"until\": \"2021-07-01T03:37:37.617Z\"\n  }\n, \"retry_count\":4}",
-                        "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
-                        "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
-                ]
+                Records: [pawsMock.createMockSQSRecordWithRetry(4)]
             };
             const creds = await TestCollector.load();
             try {
@@ -984,14 +922,7 @@ describe('Unit Tests', function() {
             };
 
             const testEvent = {
-                Records: [
-                    {
-                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"2021-07-01T02:37:37.617Z\",\n    \"until\": \"2021-07-01T03:37:37.617Z\"\n  }\n, \"retry_count\":3}",
-                        "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
-                        "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
-                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
-                    }
-                ]
+                Records: [pawsMock.createMockSQSRecordWithRetry(3)]
             };
             const creds = await TestCollector.load();
             try {

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -420,7 +420,41 @@ describe('Unit Tests', function() {
             assert.equal(putItemStub.called, true, 'should put a new item in');
             assert.equal(updateItemStub.called, true, 'should update the item to complete');
             assert.equal(putItemArgs.Item.MessageId.S, "5fea7756-0ea4-451a-a703-a558b933e274");
+            assert.equal(putItemArgs.ConditionExpression, 'attribute_not_exists(CollectorId) AND attribute_not_exists(MessageId)');
             assert.equal(updateItemArgs.Key.MessageId.S, "5fea7756-0ea4-451a-a703-a558b933e274");
+        });
+        it('handles conditional put race by treating it as duplicate state', async function() {
+            const mockRecord = {
+                "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
+                "md5OfBody": "5d172f741470c05e3d2a45c8ffcd9ab3",
+                "messageId": "5fea7756-0ea4-451a-a703-a558b933e274",
+                "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
+            };
+            const getItemStub = sinon.stub().callsFake(() => Promise.resolve({}));
+            const putItemStub = sinon.stub().callsFake(() => Promise.reject({ name: 'ConditionalCheckFailedException' }));
+            const updateItemStub = sinon.stub().callsFake(() => Promise.resolve({ data: null }));
+
+            mockDDB(getItemStub, putItemStub, updateItemStub);
+
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: sinon.spy(),
+                succeed: sinon.spy()
+            };
+
+            const testEvent = {
+                Records: [
+                    mockRecord
+                ]
+            };
+
+            const creds = await TestCollector.load();
+            var collector = new TestCollector(ctx, creds);
+            await collector.handleEvent(testEvent).catch(() => null);
+
+            assert.equal(getItemStub.called, true, 'should read current state record');
+            assert.equal(putItemStub.called, true, 'should attempt conditional insert');
+            assert.equal(updateItemStub.notCalled, true, 'should not mark duplicate state as complete/failed');
         });
         it('skips the state if it is already completed', async function() {
             const mockRecord = {
@@ -615,6 +649,54 @@ describe('Unit Tests', function() {
             collector.mockGetLogsError = 'Error getting logs';
             await collector.handleEvent(testEvent);
             sinon.assert.calledOnce(updateItemStub);
+        });
+
+        it('requeues progressed state when a post-ingest step fails', async function() {
+            const getRemainingTimeInMillis = sinon.spy(() => 5000);
+            const updateStateStub = sinon.stub(TestCollector.prototype, 'updateStateDBEntry').callsFake(() => Promise.resolve({ data: null }));
+            const getLogsStub = sinon.stub(TestCollector.prototype, 'pawsGetLogs').callsFake(() => {
+                return Promise.resolve([['log1', 'log2'], { since: '2021-07-01T02:37:37.617Z', until: '2021-07-01T03:37:37.617Z' }, 900]);
+            });
+
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: function(error) {
+                    assert.fail('Invocation should succeed.');
+                },
+                succeed: function() {},
+                getRemainingTimeInMillis
+            };
+
+            const testEvent = {
+                Records: [
+                    {
+                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
+                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
+                    }
+                ]
+            };
+
+            const creds = await TestCollector.load();
+            const collector = new TestCollector(ctx, creds);
+            const reportCollectionDelayStub = sinon.stub(collector, 'reportCollectionDelay').resolves();
+            const storeCollectionStateStub = sinon.stub(collector, '_storeCollectionState');
+            storeCollectionStateStub.onFirstCall().rejects(new Error('SQS store failed after ingest'));
+            storeCollectionStateStub.onSecondCall().resolves();
+
+            try {
+                await collector.handleEvent(testEvent);
+                assert.equal(storeCollectionStateStub.callCount >= 2, true, 'should store success-path state then requeue on failure');
+                const retryStoreCallArgs = storeCollectionStateStub.args[1];
+                assert.equal(retryStoreCallArgs[1].since, '2021-07-01T02:37:37.617Z', 'should retry using progressed state returned by pawsGetLogs');
+                assert.equal(retryStoreCallArgs[0].retry_count, 1, 'should increment retry_count while re-queuing');
+                assert.equal(updateStateStub.callCount, 1, 'should mark state as FAILED on post-ingest failure');
+                assert.equal(updateStateStub.args[0][1], 'FAILED', 'should update DDB status to FAILED before re-queue');
+            } finally {
+                reportCollectionDelayStub.restore();
+                storeCollectionStateStub.restore();
+                getLogsStub.restore();
+                updateStateStub.restore();
+            }
         });
 
         it('poll request success, multiple state', async function() {

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -1225,6 +1225,90 @@ describe('Unit Tests', function() {
             });
         });
 
+        it('reportDuplicateLogCount skips cloudwatch publish on low remaining lambda time', function() {
+            const putMetricDataStub = pawsStub.mock(CloudWatch, 'putMetricData', (params) => Promise.resolve(null));
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: function(error) {
+                    assert.fail(error);
+                },
+                succeed: function() {
+                },
+                getRemainingTimeInMillis: function() {
+                    return 1000;
+                }
+            };
+
+            TestCollector.load().then(async function(creds) {
+                var collector = new TestCollector(ctx, creds);
+                await collector.reportDuplicateLogCount(6);
+                assert.equal(putMetricDataStub.notCalled, true, 'should skip optional cloudwatch metric publish on low time');
+                pawsStub.restore(CloudWatch, 'putMetricData');
+            });
+        });
+
+        it('reportDuplicateLogCount swallows cloudwatch throttling error', function() {
+            const throttlingError = {
+                message: 'Rate exceeded, Throttling',
+                name: 'ThrottlingException',
+                $fault: 'client',
+                $metadata: {
+                    httpStatusCode: 400
+                }
+            };
+            pawsStub.mock(CloudWatch, 'putMetricData', (_params) => Promise.reject(throttlingError));
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: function(error) {
+                    assert.fail(error);
+                },
+                succeed: function() {
+                },
+                getRemainingTimeInMillis: function() {
+                    return 20000;
+                }
+            };
+
+            TestCollector.load().then(async function(creds) {
+                var collector = new TestCollector(ctx, creds);
+                await collector.reportDuplicateLogCount(6);
+                pawsStub.restore(CloudWatch, 'putMetricData');
+            });
+        });
+
+        it('reportDuplicateLogCount detects throttling from structured fields without relying on message', function() {
+            const throttlingError = {
+                name: 'AccessDeniedException',
+                code: 'SomeOtherError',
+                message: 'request failed',
+                $fault: 'client',
+                $retryable: {
+                    throttling: true
+                },
+                $metadata: {
+                    httpStatusCode: 400
+                }
+            };
+            pawsStub.mock(CloudWatch, 'putMetricData', (_params) => Promise.reject(throttlingError));
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: function(error) {
+                    assert.fail(error);
+                },
+                succeed: function() {
+                },
+                getRemainingTimeInMillis: function() {
+                    return 20000;
+                }
+            };
+
+            TestCollector.load().then(async function(creds) {
+                var collector = new TestCollector(ctx, creds);
+                await collector.reportDuplicateLogCount(6);
+                pawsStub.restore(CloudWatch, 'putMetricData');
+            });
+        });
+
         it('reportCollectorStatus', function() {
             mockCloudWatch();
             let ctx = {

--- a/test/paws_test.js
+++ b/test/paws_test.js
@@ -651,8 +651,120 @@ describe('Unit Tests', function() {
             sinon.assert.calledOnce(updateItemStub);
         });
 
+        it('does not enqueue new SQS state when remaining time is low', async function() {
+            const getRemainingTimeInMillis = sinon.spy(() => 1000);
+            const updateStateStub = sinon.stub(TestCollector.prototype, 'updateStateDBEntry').callsFake(() => Promise.resolve({ data: null }));
+            const getLogsStub = sinon.stub(TestCollector.prototype, 'pawsGetLogs').callsFake(() => Promise.reject(new Error('third party API failed')));
+
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: function() {},
+                succeed: function() {},
+                getRemainingTimeInMillis
+            };
+
+            const testEvent = {
+                Records: [
+                    {
+                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
+                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
+                    }
+                ]
+            };
+
+            const creds = await TestCollector.load();
+            const collector = new TestCollector(ctx, creds);
+            const storeCollectionStateStub = sinon.stub(collector, '_storeCollectionState').resolves();
+
+            try {
+                await collector.handleEvent(testEvent).catch(() => null);
+                assert.equal(storeCollectionStateStub.notCalled, true, 'should not enqueue a new state when lambda is near timeout');
+                assert.equal(updateStateStub.called, true, 'should update state status before exiting');
+                assert.equal(updateStateStub.args[0][1], 'FAILED', 'should mark DDB state as FAILED');
+            } finally {
+                storeCollectionStateStub.restore();
+                getLogsStub.restore();
+                updateStateStub.restore();
+            }
+        });
+
+        it('enqueues exactly one retry state when third-party API call fails and time is sufficient', async function() {
+            mockCloudWatch();
+            const getRemainingTimeInMillis = sinon.spy(() => 20000);
+            const getLogsStub = sinon.stub(TestCollector.prototype, 'pawsGetLogs').callsFake(() => Promise.reject(new Error('third party API failed')));
+
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: function(error) {
+                    assert.fail('Invocation should succeed after requeue.');
+                },
+                succeed: function() {},
+                getRemainingTimeInMillis
+            };
+
+            const testEvent = {
+                Records: [
+                    {
+                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
+                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
+                    }
+                ]
+            };
+
+            const creds = await TestCollector.load();
+            const collector = new TestCollector(ctx, creds);
+            const storeCollectionStateStub = sinon.stub(collector, '_storeCollectionState').resolves();
+
+            try {
+                await collector.handleEvent(testEvent);
+                sinon.assert.calledOnce(storeCollectionStateStub);
+            } finally {
+                storeCollectionStateStub.restore();
+                getLogsStub.restore();
+                pawsStub.restore(CloudWatch, 'putMetricData');
+            }
+        });
+
+        it('enqueues exactly one retry state when ingest fails and time is sufficient', async function() {
+            mockCloudWatch();
+            const getRemainingTimeInMillis = sinon.spy(() => 20000);
+            const batchLogProcessStub = sinon.stub(TestCollector.prototype, 'batchLogProcess').callsFake(() => Promise.reject(new Error('ingest failed')));
+
+            let ctx = {
+                invokedFunctionArn: pawsMock.FUNCTION_ARN,
+                fail: function(error) {
+                    assert.fail('Invocation should succeed after requeue.');
+                },
+                succeed: function() {},
+                getRemainingTimeInMillis
+            };
+
+            const testEvent = {
+                Records: [
+                    {
+                        "body": "{\n  \"priv_collector_state\": {\n    \"since\": \"123\",\n    \"until\": \"321\"\n  }\n}",
+                        "eventSourceARN": "arn:aws:sqs:us-east-1:352283894008:test-queue",
+                    }
+                ]
+            };
+
+            const creds = await TestCollector.load();
+            const collector = new TestCollector(ctx, creds);
+            const storeCollectionStateStub = sinon.stub(collector, '_storeCollectionState').resolves();
+
+            try {
+                await collector.handleEvent(testEvent);
+                sinon.assert.calledOnce(storeCollectionStateStub);
+            } finally {
+                storeCollectionStateStub.restore();
+                batchLogProcessStub.restore();
+                pawsStub.restore(CloudWatch, 'putMetricData');
+            }
+        });
+
         it('requeues progressed state when a post-ingest step fails', async function() {
-            const getRemainingTimeInMillis = sinon.spy(() => 5000);
+            mockCloudWatch();
+            const getRemainingTimeInMillis = sinon.spy(() => 20000);
             const updateStateStub = sinon.stub(TestCollector.prototype, 'updateStateDBEntry').callsFake(() => Promise.resolve({ data: null }));
             const getLogsStub = sinon.stub(TestCollector.prototype, 'pawsGetLogs').callsFake(() => {
                 return Promise.resolve([['log1', 'log2'], { since: '2021-07-01T02:37:37.617Z', until: '2021-07-01T03:37:37.617Z' }, 900]);
@@ -696,6 +808,7 @@ describe('Unit Tests', function() {
                 storeCollectionStateStub.restore();
                 getLogsStub.restore();
                 updateStateStub.restore();
+                pawsStub.restore(CloudWatch, 'putMetricData');
             }
         });
 


### PR DESCRIPTION
### Problem Description

1. In error scenarios (third-party API failure, ingest failure, or low remaining Lambda time), the collector could create retry behaviour that increased the risk of duplicate SQS state handling. 
2. CloudWatch metric throttling also generated noisy warnings during duplicate-count reporting.
3. [ENG-60148](https://helpsystems.atlassian.net/browse/ENG-60148): Vulnerability in NPM inspected by AWS inspector

### Solution Description

1. The collector retry and dedup flow was hardened to avoid duplicate state processing and reduce unnecessary retries:
- Added safer state handling to prevent duplicate in-progress processing.
- Improved retry flow to reuse progressed state and avoid replaying stale state.
- Added low-time protection so the function does not enqueue extra retry state when remaining Lambda time is too low.
- Made duplicate-count metric reporting best-effort and throttling-tolerant.
- Simplified throttling detection using common AWS error indicators

2. Updated NPM dependancy to fix the Vulnerability.
 
