### PR TITLE
Bump collectors to fix vulnerabilities and async migration issues

### DIFF
--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^11.7.5",
     "nyc": "^17.1.0",
@@ -24,8 +24,8 @@
     "sinon": "^21.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "auth0": "^3.7.2",
     "debug": "^4.4.3",
     "moment": "^2.30.1"
@@ -33,7 +33,8 @@
   "overrides": {
     "diff": "^8.0.3",
     "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,9 +24,8 @@
     "sinon": "^21.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
-    "async": "^3.2.6",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "moment": "2.30.1",
     "test": "^3.3.0"
@@ -34,7 +33,8 @@
   "overrides": {
     "diff": "^8.0.3",
     "minimatch": "^3.1.3",
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,15 +24,16 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript": "^7.0.3",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,16 +24,17 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "@duosecurity/duo_api": "^1.4.0",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript":"^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript":"^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/ciscomeraki/package.json
+++ b/collectors/ciscomeraki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscomeraki-collector",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Alert Logic AWS based Cisco Meraki Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,15 +24,16 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
     "diff": "^8.0.3",
-    "serialize-javascript": "^7.0.3",
-    "minimatch": "^3.1.4"
+    "serialize-javascript": "^7.0.5",
+    "minimatch": "^3.1.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,15 +24,16 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript": "^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "google-auth-library": "^10.3.0",
     "googleapis": "^160.0.0",
@@ -33,8 +33,9 @@
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript": "^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "moment": "2.30.1",
@@ -25,16 +25,17 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "googleapis": "^160.0.0",
     "moment": "2.30.1"
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript": "^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.0.55",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "@types/adm-zip": "0.5.7",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
@@ -25,8 +25,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "adm-zip": "^0.5.16",
     "debug": "^4.4.3",
     "moment": "2.30.1",
@@ -34,8 +34,9 @@
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript":"^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript":"^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,9 +24,9 @@
     "sinon": "^21.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "4.2.4",
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-aws-collector-js": "4.2.5",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "@azure/ms-rest-azure-js": "2.1.0",
     "@azure/ms-rest-js": "2.7.0",
     "@azure/ms-rest-nodeauth": "3.1.1",
@@ -36,10 +36,11 @@
     "tiny-async-pool": "^2.1.0"
   },
   "overrides": {
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript": "^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nock": "^14.0.10",
@@ -25,16 +25,17 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "@okta/okta-sdk-nodejs": "~7.3.0",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
     "diff": "^8.0.3",
-    "serialize-javascript": "^7.0.2",
-    "minimatch": "^3.1.4"
+    "serialize-javascript": "^7.0.5",
+    "minimatch": "^3.1.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "jsforce": "^3.7.0",
     "jsonwebtoken": "^9.0.2",
@@ -33,8 +33,9 @@
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript": "^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,15 +24,16 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript": "^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -10,14 +10,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "mockserver": "^3.1.1",
@@ -26,15 +26,16 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript": "^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -9,14 +9,14 @@
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=text mocha --colors"
   },
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.1000.0",
-    "@aws-sdk/client-cloudwatch": "^3.1000.0",
-    "@aws-sdk/client-dynamodb": "^3.1000.0",
-    "@aws-sdk/client-kms": "^3.1000.0",
-    "@aws-sdk/client-lambda": "^3.1000.0",
-    "@aws-sdk/client-s3": "^3.1000.0",
-    "@aws-sdk/client-sqs": "^3.1000.0",
-    "@aws-sdk/client-ssm": "^3.1000.0",
+    "@aws-sdk/client-cloudformation": "^3.1027.0",
+    "@aws-sdk/client-cloudwatch": "^3.1027.0",
+    "@aws-sdk/client-dynamodb": "^3.1027.0",
+    "@aws-sdk/client-kms": "^3.1027.0",
+    "@aws-sdk/client-lambda": "^3.1027.0",
+    "@aws-sdk/client-s3": "^3.1027.0",
+    "@aws-sdk/client-sqs": "^3.1027.0",
+    "@aws-sdk/client-ssm": "^3.1027.0",
     "jshint": "^2.13.6",
     "mocha": "^10.7.3",
     "nyc": "^17.1.0",
@@ -24,15 +24,16 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
-    "@alertlogic/paws-collector": "2.3.2",
+    "@alertlogic/al-collector-js": "3.0.21",
+    "@alertlogic/paws-collector": "2.3.3",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },
   "overrides": {
     "diff": "^8.0.3",
-    "minimatch": "^3.1.4",
-    "serialize-javascript": "^7.0.3"
+    "minimatch": "^3.1.5",
+    "serialize-javascript": "^7.0.5",
+    "lodash": "^4.18.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -60,7 +60,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-auth0-collector"
-      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh auth0
@@ -82,7 +82,7 @@ stages:
       - ./build_collector.sh carbonblack
     env:
       ALPS_SERVICE_NAME: "paws-carbonblack-collector"
-      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
     outputs:
       file: ./carbonblack-collector*
     packagers:
@@ -98,7 +98,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-ciscoamp-collector"
-      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh ciscoamp
@@ -120,7 +120,7 @@ stages:
       - ./build_collector.sh ciscoduo
     env:
       ALPS_SERVICE_NAME: "paws-ciscoduo-collector"
-      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.2" #set the value from collector package json
     outputs:
       file: ./ciscoduo-collector*
     packagers:
@@ -139,7 +139,7 @@ stages:
       - ./build_collector.sh ciscomeraki
     env:
       ALPS_SERVICE_NAME: "paws-ciscomeraki-collector"
-      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.2" #set the value from collector package json
     outputs:
       file: ./ciscomeraki-collector*
     packagers:
@@ -155,7 +155,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-crowdstrike-collector"
-      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh crowdstrike
@@ -177,7 +177,7 @@ stages:
       - ./build_collector.sh googlestackdriver
     env:
       ALPS_SERVICE_NAME: "paws-googlestackdriver-collector"
-      ALPS_SERVICE_VERSION: "1.3.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.1" #set the value from collector package json
     outputs:
       file: ./googlestackdriver-collector*
     packagers:
@@ -193,7 +193,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-gsuite-collector"
-      ALPS_SERVICE_VERSION: "1.3.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.1" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh gsuite
@@ -215,7 +215,7 @@ stages:
       - ./build_collector.sh mimecast
     env:
       ALPS_SERVICE_NAME: "paws-mimecast-collector"
-      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
     outputs:
       file: ./mimecast-collector*
     packagers:
@@ -231,7 +231,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-o365-collector"
-      ALPS_SERVICE_VERSION: "1.3.1" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.2" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh o365
@@ -253,7 +253,7 @@ stages:
       - ./build_collector.sh okta
     env:
       ALPS_SERVICE_NAME: "paws-okta-collector"
-      ALPS_SERVICE_VERSION: "1.3.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.1" #set the value from collector package json
     outputs:
       file: ./okta-collector*
     packagers:
@@ -269,7 +269,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-salesforce-collector"
-      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh salesforce
@@ -291,7 +291,7 @@ stages:
       - ./build_collector.sh sentinelone
     env:
       ALPS_SERVICE_NAME: "paws-sentinelone-collector"
-      ALPS_SERVICE_VERSION: "1.2.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
     outputs:
       file: ./sentinelone-collector*
     packagers:
@@ -307,7 +307,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-sophos-collector"
-      ALPS_SERVICE_VERSION: "1.1.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.1.1" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh sophos
@@ -329,7 +329,7 @@ stages:
       - ./build_collector.sh sophossiem
     env:
       ALPS_SERVICE_NAME: "paws-sophossiem-collector"
-      ALPS_SERVICE_VERSION: "1.3.0" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.1" #set the value from collector package json
     outputs:
       file: ./sophossiem-collector*
     packagers:


### PR DESCRIPTION
### Problem Description
1. [[ENG-60148](https://helpsystems.atlassian.net/browse/ENG-60148)]Vulnerability inspected by AWS inspector
2. [[ENG-59621](https://helpsystems.atlassian.net/browse/ENG-59621)]Handle the dedupe/retry flow and simplify throttling handling after async migration.

### Solution Description
Dependency version bumps (all 15 collectors)

- @aws-sdk/client-* packages: ^3.1000.0 → ^3.1027.0 (security/bug fixes)
- @alertlogic/paws-collector: 2.3.2 → 2.3.3
- @alertlogic/al-collector-js: 3.0.20 → 3.0.21
- Updated/added lodash: ^4.18.0 and other dependancy in diffrence.
