### PR TITLE
[VTT-7404]: Migration to /alerts API for incident-based data use cases and removed support for /Incident and /detection endpoints

### DIFF
--- a/collectors/crowdstrike/README.md
+++ b/collectors/crowdstrike/README.md
@@ -3,7 +3,7 @@ Alert Logic Crowdstrike AWS Based API Poll (PAWS) Log Collector Library.
 
 # Overview
 This repository contains the AWS JavaScript Lambda function and CloudFormation 
-Template (CFT) for deploying a log collector in AWS which will poll Crowdstrike(Incident, Detection) service API to collect and 
+Template (CFT) for deploying a log collector in AWS which will poll Crowdstrike Alerts API to collect and 
 forward logs to the Alert Logic CloudInsight backend services.
 
 # Installation
@@ -24,14 +24,13 @@ Role required: CrowdStrike Falcon administrator
 | ------------- |:-------------|
 | Client Name     | Enter the client name. This is a required field. |
 | Description     | Enter the description for the client name.      |
-| API Scopes |<ul>Defining the scopes is required. Enable the following API scopes:<li>Enable Read scope for Incident API</li><li>Enable Read scope for Detection API</li></ul>|
+| API Scopes |<ul>Defining the scopes is required. Enable the following API scopes:<li>Enable Read scope for Alerts API</li></ul>|
 
 4. Click Add to save the API client and generate the client ID and secret key.
 
 ### 2. API Docs
-1. [Authentication](https://developer.crowdstrike.com/crowdstrike/reference/oauth2-1#oauth2accesstoken-1)
-2. [Incident](https://developer.crowdstrike.com/crowdstrike/reference/incidents-1#queryincidents-1)
-3. [Detection](https://developer.crowdstrike.com/crowdstrike/reference/detects-1#querydetects-1)
+
+1. [General crowdstrike api document](https://developer.crowdstrike.com/docs/sdks/)
 
 API URL required for Crowdstrike collector
 https://api.crowdstrike.com/

--- a/collectors/crowdstrike/cfn/README.md
+++ b/collectors/crowdstrike/cfn/README.md
@@ -28,6 +28,7 @@ Currently, we support US regions only: `us-east-1`, `us-east-2`, `us-west-1`,
    - `AlertlogicCustomerId` - Optional. Alert Logic customer ID which collected data should be reported for. If not set customer ID is derived from AIMs tokens
    - `AlertlogicSecretKey` - `secret_key` returned from AIMS
    - `CrowdstrikeAPINames` - Define API names. Please pass JSON formatted list. Possible values are ["Alerts"]
+   - `ProductTypes` - Optional. Define product types to filter alerts for. Please pass JSON formatted list. Default: `["epp", "automated-lead", "thirdparty"]`
    - `CrowdstrikeClientId` - Crowdstrike Client ID 
    - `CrowdstrikeEndpoint` - Crowdstrike Endpoint
    - `CrowdstrikeSecret` - Crowdstrike Secret 

--- a/collectors/crowdstrike/cfn/README.md
+++ b/collectors/crowdstrike/cfn/README.md
@@ -27,7 +27,7 @@ Currently, we support US regions only: `us-east-1`, `us-east-2`, `us-west-1`,
    - `AlertlogicAccessKeyId` - `access_key_id` returned from AIMS
    - `AlertlogicCustomerId` - Optional. Alert Logic customer ID which collected data should be reported for. If not set customer ID is derived from AIMs tokens
    - `AlertlogicSecretKey` - `secret_key` returned from AIMS
-   - `CrowdstrikeAPINames` - Define API names. Please pass JSON formatted list. Possible values are ["Incident", "Detection"]
+   - `CrowdstrikeAPINames` - Define API names. Please pass JSON formatted list. Possible values are ["Alerts"]
    - `CrowdstrikeClientId` - Crowdstrike Client ID 
    - `CrowdstrikeEndpoint` - Crowdstrike Endpoint
    - `CrowdstrikeSecret` - Crowdstrike Secret 

--- a/collectors/crowdstrike/cfn/crowdstrike-collector.template
+++ b/collectors/crowdstrike/cfn/crowdstrike-collector.template
@@ -60,9 +60,9 @@
             "NoEcho": true
         },
         "CrowdstrikeAPINames": {
-            "Description": "Define API names. Please pass JSON formatted list. Possible values are [\"Incident\", \"Detection\",\"Alerts\"]",
+            "Description": "Define API names. Please pass JSON formatted list. Possible values are [\"Alerts\"]",
             "Type": "String",
-            "Default": "[\"Incident\", \"Detection\", \"Alerts\"]"
+            "Default": "[\"Alerts\"]"
         },
         "CollectionStartTs": {
             "Description": "Timestamp when log collection starts. For example, 2019-11-21T16:00:00Z",

--- a/collectors/crowdstrike/collector.js
+++ b/collectors/crowdstrike/collector.js
@@ -95,15 +95,7 @@ class CrowdstrikeCollector extends PawsCollector {
         const newState = collector._getNextCollectionStateWithOffset(state, offset, receivedAll);
 
         try {
-            if (state.stream === 'Incident') {
-                const data = await utils.getIncidents(accumulator, APIHostName, token);
-                AlLogger.info(`CROW000004 Next collection in ${newState.poll_interval_sec} seconds for ${state.stream}`);
-                return [data.resources, newState, newState.poll_interval_sec];
-            } else if (state.stream === 'Detection') {
-                const data = await utils.getDetections(accumulator, APIHostName, token);
-                AlLogger.info(`CROW000004 Next collection in ${newState.poll_interval_sec} seconds for ${state.stream}`);
-                return [data.resources, newState, newState.poll_interval_sec];
-            } else if (state.stream === 'Alerts') {
+            if (state.stream === 'Alerts') {
                 const data = await utils.getAlerts(accumulator, APIHostName, token);
                 AlLogger.info(`CROW000004 Next collection in ${newState.poll_interval_sec} seconds for ${state.stream}`);
                 return [data.resources, newState, newState.poll_interval_sec];

--- a/collectors/crowdstrike/local/env.json.tmpl
+++ b/collectors/crowdstrike/local/env.json.tmpl
@@ -17,6 +17,7 @@
     "paws_api_client_id":"paws_api_client_id",
     "paws_endpoint": "https://some-endpoint.com/",
     "collector_streams": "[\"Alerts\"]",
+    "product_types": "[\"epp\", \"automated-lead\", \"thirdparty\"]",
     "collector_id": "557D90CB-0BA2-40EC-8A9D-94184612C084",
     "paws_ddb_table_name":"PawsCollectorStates",
     "customer_id":"134224120"

--- a/collectors/crowdstrike/local/env.json.tmpl
+++ b/collectors/crowdstrike/local/env.json.tmpl
@@ -16,7 +16,7 @@
     "paws_secret_param_name": "paws_secret_param_name",
     "paws_api_client_id":"paws_api_client_id",
     "paws_endpoint": "https://some-endpoint.com/",
-    "collector_streams": "[\"Incident\", \"Detection\"]",
+    "collector_streams": "[\"Alerts\"]",
     "collector_id": "557D90CB-0BA2-40EC-8A9D-94184612C084",
     "paws_ddb_table_name":"PawsCollectorStates",
     "customer_id":"134224120"

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/crowdstrike/test/crowd-strike-mock.js
+++ b/collectors/crowdstrike/test/crowd-strike-mock.js
@@ -17,7 +17,7 @@ process.env.paws_poll_interval = 60;
 process.env.paws_type_name = "crowdstrike";
 process.env.paws_api_client_id = "client-id";
 process.env.paws_api_secret = "client-secret";
-process.env.collector_streams = "[\"Incident\", \"Detection\", \"Alerts\"]";
+process.env.collector_streams = "[\"Alerts\"]";
 process.env.paws_endpoint = "https://api.crowdstrike.com";
 
 const AIMS_TEST_CREDS = {
@@ -46,48 +46,6 @@ const LIST = {
     "errors" : []
 };
 
-const DETECTION_LOG_EVENT = {
-    "meta" : {
-        "query_time" : 0.01414002,
-        "powered_by" : "msa-api",
-        "trace_id" : "d4d3158c-731c-4cb6-97ed-8b999f65fedf"
-    },
-    "resources" : [
-        {
-            "detection_id":"ldt:4c3db6145a704a179a6dacd924f6e8cc:73087931424",
-            "created_timestamp":"2021-08-13T07:20:20.77857433Z",
-            "first_behavior":"2021-08-13T07:20:08Z",
-            "last_behavior":"2021-08-13T07:20:16Z",
-            "max_confidence":100,
-            "max_severity":70,
-            "max_severity_displayname":"High",
-            "show_in_ui":true,
-            "status":"new"
-        }
-    ],
-    "errors" : []
-};
-
-const INCIDENT_LOG_EVENT = {
-    "meta" : {
-        "query_time" : 0.01414002,
-        "powered_by" : "msa-api",
-        "trace_id" : "d4d3158c-731c-4cb6-97ed-8b999f65fedf"
-    },
-    "resources" : [
-        {
-            "incident_id":"inc:3fd9b8a8a7ba426a9bf3aaa2ddfc5b02:36f66221fa044c74a9e3ffa5ba8ab2d3",
-            "incident_type":1,
-            "created":"2021-06-09T14:53:05Z",
-            "start":"2021-06-09T14:53:05Z",
-            "end":"2021-06-09T14:53:05Z",
-            "state":"closed",
-            "status":20
-        }
-    ],
-    "errors" : []
-};
-
 const ALERTS_LOG_EVENT = {
     "meta": {
         "query_time": 0.01414002,
@@ -107,7 +65,35 @@ const ALERTS_LOG_EVENT = {
             "severity": 70,
             "severity_name": "High",
             "status": "new",
-            "product": "epp",
+            "product": "epp"
+        },
+        {
+            "agent_id": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+            "aggregate_id": "9c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f",
+            "composite_id": "ab12cd34ef56ab78cd90ef12:ind:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6:5480897322003-20446-22311383",
+            "context_timestamp": "2025-08-17T16:15:00.000Z",
+            "crawled_timestamp": "2025-08-17T17:15:03.456789012Z",
+            "created_timestamp": "2025-08-17T16:16:00.000000000Z",
+            "show_in_ui": true,
+            "confidence": 90,
+            "severity": 80,
+            "severity_name": "Critical",
+            "status": "new",
+            "product": "automated-lead"
+        },
+        {
+            "agent_id": "f1e2d3c4b5a6f7e8d9c0b1a2f3e4d5c6",
+            "aggregate_id": "3f4e5d6c7b8a9f0e1d2c3b4a5f6e7d8c9b0a1f2e",
+            "composite_id": "cd34ef56ab78cd90ef12ab34:ind:f1e2d3c4b5a6f7e8d9c0b1a2f3e4d5c6:6591908433114-31557-33422494",
+            "context_timestamp": "2025-08-17T17:00:00.000Z",
+            "crawled_timestamp": "2025-08-17T18:00:05.789012345Z",
+            "created_timestamp": "2025-08-17T17:01:00.000000000Z",
+            "show_in_ui": true,
+            "confidence": 70,
+            "severity": 60,
+            "severity_name": "Medium",
+            "status": "in_progress",
+            "product": "thirdparty"
         }
     ],
     "errors": []
@@ -121,8 +107,6 @@ module.exports = {
     AIMS_TEST_CREDS: AIMS_TEST_CREDS,
     FUNCTION_ARN: FUNCTION_ARN,
     FUNCTION_NAME: FUNCTION_NAME,
-    DETECTION_LOG_EVENT: DETECTION_LOG_EVENT,
-    INCIDENT_LOG_EVENT: INCIDENT_LOG_EVENT,
     ALERTS_LOG_EVENT: ALERTS_LOG_EVENT,
     LIST: LIST,
     AUTHENTICATE: AUTHENTICATE

--- a/collectors/crowdstrike/test/crowd-strike-test.js
+++ b/collectors/crowdstrike/test/crowd-strike-test.js
@@ -12,8 +12,6 @@ var responseStub = {};
 let authenticate;
 let getList;
 let getAPIDetails;
-let getIncidents;
-let getDetections;
 let getAlerts;
 
 function setAlServiceStub() {
@@ -30,18 +28,6 @@ function setAlServiceStub() {
                 return resolve({ accumulator: crowdstrikeMock.LIST.resources, total: 1 });
             });
         });
-    getIncidents = sinon.stub(utils, 'getIncidents').callsFake(
-        function fakeFn(ids, apiEndpoint, token) {
-            return new Promise(function (resolve, reject) {
-                return resolve({ resources: crowdstrikeMock.INCIDENT_LOG_EVENT.resources});
-            });
-        });
-    getDetections = sinon.stub(utils, 'getDetections').callsFake(
-        function fakeFn(ids, apiEndpoint, token) {
-            return new Promise(function (resolve, reject) {
-                return resolve({ resources: crowdstrikeMock.DETECTION_LOG_EVENT.resources});
-            });
-        });
     getAlerts = sinon.stub(utils, 'getAlerts').callsFake(
         function fakeFn(ids, apiEndpoint, token) {
             return new Promise(function (resolve, reject) {
@@ -54,7 +40,7 @@ function setAlServiceStub() {
                 url: "url",
                 method: "GET",
                 requestBody: "sortFieldName",
-                typeIdPaths: [{ path: ["detection_id"] }],
+                typeIdPaths: [{ path: ["composite_id"] }],
                 tsPaths: [{ path: ["created_timestamp"] }]
             };
         });
@@ -64,8 +50,6 @@ function setAlServiceStub() {
 function restoreAlServiceStub() {
     if (authenticate && typeof authenticate.restore === 'function') authenticate.restore();
     if (getList && typeof getList.restore === 'function') getList.restore();
-    if (getDetections && typeof getDetections.restore === 'function') getDetections.restore();
-    if (getIncidents && typeof getIncidents.restore === 'function') getIncidents.restore();
     if (getAPIDetails && typeof getAPIDetails.restore === 'function') getAPIDetails.restore();
     if (getAlerts && typeof getAlerts.restore === 'function') getAlerts.restore();
 }
@@ -136,7 +120,7 @@ describe('Unit Tests', function () {
             const sampleEvent = { ResourceProperties: { StackName: 'a-stack-name' } };
             const regValues = collector.pawsGetRegisterParameters(sampleEvent);
             const expectedRegValues = {
-                crowdstrikeAPINames: '["Incident", "Detection", "Alerts"]'
+                crowdstrikeAPINames: '["Alerts"]'
             };
             assert.deepEqual(regValues, expectedRegValues);
         });
@@ -156,7 +140,7 @@ describe('Unit Tests', function () {
             var collector = new CrowdstrikeCollector(ctx, creds, 'crowdstrike');
             const startDate = moment().subtract(3, 'days');
             const curState = {
-                stream: "Detection",
+                stream: "Alerts",
                 since: startDate.toISOString(),
                 until: startDate.add(2, 'days').toISOString(),
                 offset: 0,
@@ -164,9 +148,9 @@ describe('Unit Tests', function () {
             };
 
             const [logs, newState] = await collector.pawsGetLogs(curState);
-            assert.equal(logs.length, 1);
+            assert.equal(logs.length, 3);
             assert.equal(newState.poll_interval_sec, 1);
-            assert.ok(logs[0].detection_id);
+            assert.ok(logs[0].composite_id);
         });
 
         it('Get Alerts Logs Success', async function () {
@@ -183,9 +167,12 @@ describe('Unit Tests', function () {
             };
 
             const [logs, newState] = await collector.pawsGetLogs(curState);
-            assert.equal(logs.length, 1);
+            assert.equal(logs.length, 3);
             assert.equal(newState.poll_interval_sec, 1);
             assert.ok(logs[0].composite_id);
+            assert.equal(logs[0].product, 'epp');
+            assert.equal(logs[1].product, 'automated-lead');
+            assert.equal(logs[2].product, 'thirdparty');
         });
     });
 
@@ -202,7 +189,7 @@ describe('Unit Tests', function () {
 
             const creds = await CrowdstrikeCollector.load();
             var collector = new CrowdstrikeCollector(ctx, creds, 'crowdstrike');
-            let fmt = collector.pawsFormatLog(crowdstrikeMock.DETECTION_LOG_EVENT.resources[0]);
+            let fmt = collector.pawsFormatLog(crowdstrikeMock.ALERTS_LOG_EVENT.resources[0]);
             assert.equal(fmt.progName, 'CrowdstrikeCollector');
             assert.ok(fmt.messageType);
         });
@@ -221,7 +208,7 @@ describe('Unit Tests', function () {
 
             const startDate = moment().subtract(5, 'minutes');
             const curState = {
-                stream: "Detection",
+                stream: "Alerts",
                 since: startDate.toISOString(),
                 until: startDate.add(5, 'minutes').toISOString(),
                 offset: 0,
@@ -271,7 +258,7 @@ describe('Unit Tests', function () {
                         url: "url",
                         method: "GET",
                         requestBody: "sortFieldName",
-                        typeIdPaths: [{ path: ["detection_id"] }],
+                        typeIdPaths: [{ path: ["composite_id"] }],
                         tsPaths: [{ path: ["created_timestamp"] }]
                     };
                 });
@@ -287,7 +274,7 @@ describe('Unit Tests', function () {
             var collector = new CrowdstrikeCollector(ctx, creds, 'crowdstrike');
             const startDate = moment().subtract(3, 'days');
             const curState = {
-                stream: "Detection",
+                stream: "Alerts",
                 since: startDate.toISOString(),
                 until: startDate.add(2, 'days').toISOString(),
                 offset: 0,
@@ -334,7 +321,7 @@ describe('Unit Tests', function () {
             var collector = new CrowdstrikeCollector(ctx, creds, 'crowdstrike');
             const startDate = moment().subtract(3, 'days');
             const curState = {
-                stream: "Detection",
+                stream: "Alerts",
                 since: startDate.toISOString(),
                 until: startDate.add(2, 'days').toISOString(),
                 offset: 0,

--- a/collectors/crowdstrike/test/utils-test.js
+++ b/collectors/crowdstrike/test/utils-test.js
@@ -36,8 +36,8 @@ describe('Unit Tests', function () {
                 url: "url",
                 method: "GET",
                 requestBody:"",
-                typeIdPaths: [{ path: ["incident_type"] }],
-                tsPaths: [{ path: ["created"] }]
+                typeIdPaths: [{ path: ["composite_id"] }],
+                tsPaths: [{ path: ["created_timestamp"] }]
             };
             let accumulator = [];
             const apiEndpoint = process.env.paws_endpoint;
@@ -45,82 +45,6 @@ describe('Unit Tests', function () {
 
             utils.getList(apiDetails, accumulator, apiEndpoint, token).then(data => {
                 assert(data.accumulator.length == 2, "accumulator length is wrong");
-                done();
-            });
-        });
-    });
-
-    describe('POST Detections Request', function () {
-        it('POST Detection Request', function (done) {
-            exeStub();
-            let apiDetails = {
-                url: "url",
-                method: "GET",
-                requestBody:"",
-                typeIdPaths: [{ path: ["detection_id"] }],
-                tsPaths: [{ path: ["created_timestamp"] }]
-            };
-            const token = crowdstrikeMock.AUTHENTICATE.access_token;
-
-            utils.getDetections(crowdstrikeMock.LIST.resources, apiDetails, token).then(data => {
-                assert(data.resources.length == 2, "accumulator length is wrong");
-                done();
-            });
-        });
-    });
-
-    describe('POST Detections Request with empty IDs array', function () {
-        it('POST Detection Request', function (done) {
-            exeStub();
-            let apiDetails = {
-                url: "url",
-                method: "GET",
-                requestBody:"",
-                typeIdPaths: [{ path: ["detection_id"] }],
-                tsPaths: [{ path: ["created_timestamp"] }]
-            };
-            const token = crowdstrikeMock.AUTHENTICATE.access_token;
-
-            utils.getDetections([], apiDetails, token).then(data => {
-                assert(data.resources.length == 0, "accumulator length is wrong");
-                done();
-            });
-        });
-    });
-
-    describe('POST Incident Request', function () {
-        it('POST Incident Request', function (done) {
-            exeStub();
-            let apiDetails = {
-                url: "url",
-                method: "GET",
-                requestBody:"",
-                typeIdPaths: [{ path: ["incident_type"] }],
-                tsPaths: [{ path: ["created"] }]
-            };
-            const token = crowdstrikeMock.AUTHENTICATE.access_token;
-
-            utils.getIncidents(crowdstrikeMock.LIST.resources, apiDetails, token).then(data => {
-                assert(data.resources.length == 2, "accumulator length is wrong");
-                done();
-            });
-        });
-    });
-
-    describe('POST Incident Request with empty IDs array', function () {
-        it('POST Incident Request', function (done) {
-            exeStub();
-            let apiDetails = {
-                url: "url",
-                method: "GET",
-                requestBody:"",
-                typeIdPaths: [{ path: ["incident_type"] }],
-                tsPaths: [{ path: ["created"] }]
-            };
-            const token = crowdstrikeMock.AUTHENTICATE.access_token;
-
-            utils.getIncidents([], apiDetails, token).then(data => {
-                assert(data.resources.length == 0, "accumulator length is wrong");
                 done();
             });
         });

--- a/collectors/crowdstrike/test/utils-test.js
+++ b/collectors/crowdstrike/test/utils-test.js
@@ -116,6 +116,23 @@ describe('Unit Tests', function () {
             assert(apiDetails.length == apiNames.length, "apiDetails length is wrong");
             done();
         });
+
+        it('Get API Details with custom product types', function (done) {
+            exeStub();
+            process.env.product_types = "[\"epp\",\"automated-lead\"]";
+            const startDate = moment().subtract(5, 'minutes');
+            const state = {
+                stream: 'Alerts',
+                since: startDate.toISOString(),
+                until: startDate.add(5, 'minutes').toISOString(),
+                offset: 0,
+                poll_interval_sec: 1
+            };
+            const apiDetails = utils.getAPIDetails(state);
+            assert(apiDetails.url.includes(encodeURIComponent("product:['epp','automated-lead']")), "custom product filter applied");
+            process.env.product_types = undefined;
+            done();
+        });
     });
 });
 

--- a/collectors/crowdstrike/utils.js
+++ b/collectors/crowdstrike/utils.js
@@ -1,8 +1,5 @@
 const RestServiceClient = require('@alertlogic/al-collector-js').RestServiceClient;
 const AlLogger = require('@alertlogic/al-aws-collector-js').Logger;
-
-const INCIDENT = 'Incident';
-const DETECTION = 'Detection';
 const ALERTS = 'Alerts';
 const USERAGENT = 'alertlogic_security_1.0';
 
@@ -28,79 +25,28 @@ function authenticate(baseUrl, clientId, clientSecret) {
 
 function getList(apiDetails, accumulator, apiEndpoint, token) {
     let restServiceClient = new RestServiceClient(apiEndpoint);
-    if (apiDetails.method === "GET") {
-        return new Promise(function (resolve, reject) {
-            restServiceClient.get(apiDetails.url, {
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'User-Agent': USERAGENT
-                }
-            }).then(response => {
-                const total = response.meta.pagination.total;
-                if (response.resources.length === 0) {
-                    return resolve({ accumulator, total });
-                }
-                accumulator = response.resources;
-                return resolve({accumulator, total});
 
-            }).catch(err => {
-                return reject(err);
-            });
-        });
-    }
-}
-
-function getIncidents(ids, apiHostName, token) {
-    let restServiceClient = new RestServiceClient(`${apiHostName}/incidents/entities/incidents/GET/v1`);
-    if (!ids || !ids.length) {
-        return new Promise((resolve, reject) => {
-            resolve({
-                resources: []
-            });
-        });
-    }
     return new Promise(function (resolve, reject) {
-        return restServiceClient.post('', {
+        restServiceClient.get(apiDetails.url, {
             headers: {
-                'Authorization': 'Bearer ' + token,
+                'Authorization': `Bearer ${token}`,
                 'User-Agent': USERAGENT
-            },
-            data: {
-                ids: ids
             }
         }).then(response => {
-            resolve(response);
-        }).catch(err => {
-            reject(err);
-        });
-    });
-}
-// @deprecated: The Detection API endpoints are deprecated and will be decommissioned on September 30th, 2025. Please remove or refactor this code if it begins to fail.
-function getDetections(ids, APIHostName, token) {
-    let restServiceClient = new RestServiceClient(`${APIHostName}/detects/entities/summaries/GET/v1`);
-    if (!ids || !ids.length) {
-        return new Promise((resolve, reject) => {
-            resolve({
-                resources: []
-            });
-        });
-    }
-    return new Promise(function (resolve, reject) {
-        return restServiceClient.post('', {
-            headers: {
-                'Authorization': 'Bearer ' + token,
-                'User-Agent': USERAGENT
-            },
-            data: {
-                ids: ids
+            const total = response.meta.pagination.total;
+            if (response.resources.length === 0) {
+                return resolve({ accumulator, total });
             }
-        }).then(response => {
-            resolve(response);
+            accumulator = response.resources;
+            return resolve({ accumulator, total });
+
         }).catch(err => {
-            reject(err);
+            return reject(err);
         });
     });
+
 }
+
 /**
  * 
  * @param {*} ids - The ids of the alerts to retrieve.
@@ -147,20 +93,8 @@ function getAPIDetails(state) {
     let tsPaths = [];
     let filter = '';
     switch (state.stream) {
-        case INCIDENT:
-            filter = `end:>"${state.since}"+end:<"${state.until}"`;
-            url = `/incidents/queries/incidents/v1?limit=500&offset=${state.offset}&filter=${encodeURIComponent(filter)}`;
-            typeIdPaths = [{ path: ["incident_type"] }];
-            tsPaths = [{ path: ["created"] }];
-            break;
-        case DETECTION:
-            filter = `last_behavior:>"${state.since}"+last_behavior:<"${state.until}"`;
-            url = `/detects/queries/detects/v1?limit=1000&offset=${state.offset}&filter=${encodeURIComponent(filter)}`;
-            typeIdPaths = [];
-            tsPaths = [{ path: ["created_timestamp"] }];
-            break;
         case ALERTS:
-            filter = `product:'epp'+created_timestamp:>"${state.since}"+created_timestamp:<"${state.until}"`;
+            filter = `product:['epp','automated-lead','thirdparty']+created_timestamp:>"${state.since}"+created_timestamp:<"${state.until}"`;
             url = `/alerts/queries/alerts/v2?limit=100&offset=${state.offset}&filter=${encodeURIComponent(filter)}`;
             typeIdPaths = [{ path: ["composite_id"] }];
             tsPaths = [{ path: ["created_timestamp"] }];
@@ -180,8 +114,6 @@ function getAPIDetails(state) {
 
 module.exports = {
     authenticate: authenticate,
-    getIncidents: getIncidents,
-    getDetections: getDetections,
     getAPIDetails: getAPIDetails,
     getList: getList,
     getAlerts: getAlerts

--- a/collectors/crowdstrike/utils.js
+++ b/collectors/crowdstrike/utils.js
@@ -94,7 +94,9 @@ function getAPIDetails(state) {
     let filter = '';
     switch (state.stream) {
         case ALERTS:
-            filter = `product:['epp','automated-lead','thirdparty']+created_timestamp:>"${state.since}"+created_timestamp:<"${state.until}"`;
+            const productTypes = process.env.product_types ? JSON.parse(process.env.product_types) : ['epp', 'automated-lead', 'thirdparty'];
+            const productFilter = productTypes.map(p => `'${p}'`).join(',');
+            filter = `product:[${productFilter}]+created_timestamp:>"${state.since}"+created_timestamp:<"${state.until}"`;
             url = `/alerts/queries/alerts/v2?limit=100&offset=${state.offset}&filter=${encodeURIComponent(filter)}`;
             typeIdPaths = [{ path: ["composite_id"] }];
             tsPaths = [{ path: ["created_timestamp"] }];

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -155,7 +155,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-crowdstrike-collector"
-      ALPS_SERVICE_VERSION: "1.2.1" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.2" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 22
       - ./build_collector.sh crowdstrike


### PR DESCRIPTION
### Problem Description
Existing collector logic depended on deprecated Incident/Detection endpoints, creating long-term support and reliability risk.

### Solution Description
CrowdStrike has deprecated `/Incident` and `/Detection` APIs endpoints.
This change evaluates `/Alerts` API as the replacement, updates collector flow to Alerts-only, removes deprecated API handling, and aligns tests/docs accordingly.

### Acceptance Criteria for Contributors

- No Incident/Detection API calls remain in CrowdStrike collector runtime.
- Collector runs successfully with Alerts-only stream configuration.
- Test suite passes for Alerts success path, empty response, auth failure, and API failure scenarios.
- Documentation clearly states Alerts-only support and migration guidance.
- Field parity mapping is documented for key attributes previously used from Incident/Detection
 