### PR TITLE
Bump the package to publish fix for cloud watch metrics throttling error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/paws-collector",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "license": "MIT",
   "description": "Alert Logic AWS based API Poll Log Collector Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
Last pr merge but not able to publish paws package due to access issue . [Fix the cloud watch metrics throttling error
](https://github.com/alertlogic/paws-collector/pull/419)

### Solution Description
Bump the package version again to publish package to npmjs.
 
