### PR TITLE
Cisco duo collector  : v1 endpoint will be deprecated on September 30, 2026, so migrated admin API v1 to V2 endpoints

### DIFF
--- a/collectors/ciscoduo/README.md
+++ b/collectors/ciscoduo/README.md
@@ -34,10 +34,14 @@ repository.
 ### 2. API Docs
 
 1. [Ciscoduo_Node_Library](https://www.npmjs.com/package/@duosecurity/duo_api)
-2. [Authentication_Logs](https://duo.com/docs/adminapi#authentication-logs)
-3. [Administrator_Logs](https://duo.com/docs/adminapi#administrator-logs)
-4. [Telephony_Logs](https://duo.com/docs/adminapi#telephony-logs)
-5. [OfflineEnrollment_Logs](https://duo.com/docs/adminapi#offline-enrollment-logs)
+2. [Authentication Logs (v2)](https://duo.com/docs/adminapi#authentication-logs)
+3. [Activity Logs (v2)](https://duo.com/docs/adminapi#activity-logs) — used for both the `Administrator` and `OfflineEnrollment` streams; `OfflineEnrollment` keeps only items whose `action.name` starts with `o2fa_` and `Administrator` excludes those items to avoid duplicates.
+4. [Telephony Logs (v2)](https://duo.com/docs/adminapi#telephony-logs)
+5. Legacy reference: [Offline Enrollment Logs (v1)](https://duo.com/docs/adminapi#offline-enrollment-logs) (Duo's v1 endpoint is scheduled for deprecation; this collector now reads the same events from the v2 Activity endpoint above.)
+
+> All four streams use 13-character Unix-ms `mintime`/`maxtime` and page via
+> `metadata.next_offset`. Duo applies a 2-minute server-side delay to log
+> availability and recommends no more than ~1 request per minute per endpoint.
 
 ### 3. CloudFormation Template (CFT)
 

--- a/collectors/ciscoduo/al-ciscoduo-collector.json
+++ b/collectors/ciscoduo/al-ciscoduo-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/ciscoduo/collector.js
+++ b/collectors/ciscoduo/collector.js
@@ -40,23 +40,15 @@ class CiscoduoCollector extends PawsCollector {
         const endTs = moment(startTs).add(this.pollInterval, 'seconds').toISOString();
         const objectNames = JSON.parse(process.env.collector_streams);
         const pollInterval = objectNames.length * POLL_INTERVAL_SECS;
+        // All streams now use 13-digit millisecond timestamps to match v2 API requirements.
         const initialStates = objectNames.map(stream => {
-            if (stream === Authentication) {
-                return {
-                    stream,
-                    since: moment(startTs).valueOf(),
-                    until: moment(endTs).valueOf(),
-                    nextPage: null,
-                    poll_interval_sec: pollInterval
-                }
-            }
-            else {
-                return {
-                    stream,
-                    since: moment(startTs).unix(),
-                    poll_interval_sec: pollInterval
-                }
-            }
+            return {
+                stream,
+                since: moment(startTs).valueOf(),
+                until: moment(endTs).valueOf(),
+                nextPage: null,
+                poll_interval_sec: pollInterval
+            };
         });
         return { state: initialStates, nextInvocationTimeout: pollInterval };
     }
@@ -100,8 +92,9 @@ class CiscoduoCollector extends PawsCollector {
 
         typeIdPaths = objectDetails.typeIdPaths;
         tsPaths = objectDetails.tsPaths;
+        // All streams now store since/until as milliseconds — no stream-specific conversion needed.
         const stateUntil = state.until ? `till ${moment(parseInt(state.until)).toISOString()}` : ``;
-        const stateSince = state.stream === Authentication ? moment(parseInt(state.since)).toISOString() : moment(parseInt(state.since * 1000)).toISOString(); // Convert Epoch timestamp to milliseconds to get date in correct format
+        const stateSince = moment(parseInt(state.since)).toISOString();
 
         AlLogger.info(`CDUO000001 Collecting data for ${state.stream} from ${stateSince} ${stateUntil}`);
         try {
@@ -153,65 +146,54 @@ class CiscoduoCollector extends PawsCollector {
     }
 
     _getNextCollectionState(curState) {
+        // All streams use millisecond timestamps and hour-cap interval logic.
+        // Fall back to now if `until` is absent (old in-flight SQS message without `until`).
+        const untilRaw = curState.until != null ? parseInt(curState.until) : moment().valueOf();
+        const untilMs = untilRaw < utils.MIN_13_DIGIT_TIMESTAMP ? untilRaw * 1000 : untilRaw;
+        const untilMoment = moment(untilMs);
 
-        if (curState.stream === Authentication) {
+        
+        // Authentication is the high-traffic stream and uses the 60 s baseline so a single
+        // window stays small. Administrator, OfflineEnrollment and Telephony are low-traffic
+        // (and Administrator + OfflineEnrollment share /admin/v2/logs/activity), so we widen
+        // their window to 15 min per call to halve the request rate on that shared endpoint.
+        const isHighTrafficStream = curState.stream === Authentication;
+        const streamPollInterval = isHighTrafficStream ? this.pollInterval : MAX_POLL_INTERVAL;
 
-            const untilMoment = moment(parseInt(curState.until));
-            // As Cisco duo api allows one call per minute, we used an hour cap instead of making API calls for 1-minute intervals. This will help reduce collection delay and throttling.
-            const { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('hour-cap', untilMoment, this.pollInterval);
-            const nextPollIntervalSec = nextPollInterval >= POLL_INTERVAL_SECS ? nextPollInterval : POLL_INTERVAL_SECS;
-            return {
-                stream: curState.stream,
-                since: nextSinceMoment.valueOf(),
-                until: nextUntilMoment.valueOf(),
-                nextPage: null,
-                poll_interval_sec: nextPollIntervalSec
-            };
+        const { nextUntilMoment, nextSinceMoment, nextPollInterval } =
+            calcNextCollectionInterval('hour-cap', untilMoment, streamPollInterval);
+
+        // Per-stream cadence to respect Duo's per-endpoint ~1 call/min throttling limit.
+        let nextPollIntervalSec = nextPollInterval >= POLL_INTERVAL_SECS ? nextPollInterval : POLL_INTERVAL_SECS;
+
+        // For low-traffic streams that are caught up to real-time, force the next
+        // invocation to wait the full 15 min window — otherwise calcNextCollectionInterval
+        // would return paws_poll_interval_delay (default 300 s) and we'd poll a window
+        // whose `until` is still in the future. We only override when the next window is
+        // not in backfill territory (nextPollInterval > 1 means we are not far behind).
+        if (!isHighTrafficStream && nextPollInterval > 1) {
+            nextPollIntervalSec = MAX_POLL_INTERVAL;
         }
-        else {
-            // This condition works if next page getting null or undefined
-            const untilMoment = moment();
-            if (curState.since) {
-                // New since is either last hour or current.since if it is less than one hr.
-                // Set nextPoll interval to 15 min as it collecting data for last one hr
-                const nextUntilMoment = moment().subtract(1, 'hours').unix();
-                const newSince = Math.max(parseInt(curState.since) + 1, nextUntilMoment);
-                return {
-                    stream: curState.stream,
-                    since: newSince,
-                    poll_interval_sec: MAX_POLL_INTERVAL
-                };
-            }
-            else {
-                let { nextUntilMoment, nextSinceMoment, nextPollInterval } = calcNextCollectionInterval('no-cap', untilMoment, this.pollInterval);
-                return {
-                    stream: curState.stream,
-                    since: nextSinceMoment.unix(),
-                    poll_interval_sec: nextPollInterval
-                };
-            }
-        }
+
+        return {
+            stream: curState.stream,
+            since: nextSinceMoment.valueOf(),
+            until: nextUntilMoment.valueOf(),
+            nextPage: null,
+            poll_interval_sec: nextPollIntervalSec
+        };
     }
 
     _getNextCollectionStateWithNextPage(curState, nextPage) {
-
-        if (curState.stream === Authentication) {
-            return {
-                stream: curState.stream,
-                since: curState.since,
-                until: curState.until,
-                nextPage: nextPage,
-                poll_interval_sec: 60
-            };
-        } else {
-            //There is no next page concept for this API, So Setting up the next state since using the last log (Unix timestamp + 1).
-            // call after 60 sec to avoid multiple api call
-            return {
-                stream: curState.stream,
-                since: nextPage,
-                poll_interval_sec: 60
-            };
-        }
+        // All streams: preserve the same time window and store the cursor for the next invocation.
+        // nextPage is a next_offset cursor string, not a timestamp — never use it as `since`.
+        return {
+            stream: curState.stream,
+            since: curState.since,
+            until: curState.until,
+            nextPage: nextPage,
+            poll_interval_sec: POLL_INTERVAL_SECS
+        };
     }
 
     pawsFormatLog(msg) {

--- a/collectors/ciscoduo/collector.js
+++ b/collectors/ciscoduo/collector.js
@@ -171,14 +171,21 @@ class CiscoduoCollector extends PawsCollector {
         // would return paws_poll_interval_delay (default 300 s) and we'd poll a window
         // whose `until` is still in the future. We only override when the next window is
         // not in backfill territory (nextPollInterval > 1 means we are not far behind).
+        let until = nextUntilMoment.valueOf();
         if (!isHighTrafficStream && nextPollInterval > 1) {
             nextPollIntervalSec = MAX_POLL_INTERVAL;
+            // Only subtract 2 min if `until` extends into the future (real-time window) to avoid loss of data.
+            // If already in the past (collector is lagging), collect the full 15-min window as-is.
+            const TWO_MIN_DELAY_SEC = 120;
+            if (nextUntilMoment.isAfter(moment())) {
+                until = moment(nextUntilMoment).subtract(TWO_MIN_DELAY_SEC, 'seconds').valueOf();
+            }
         }
 
         return {
             stream: curState.stream,
             since: nextSinceMoment.valueOf(),
-            until: nextUntilMoment.valueOf(),
+            until: until,
             nextPage: null,
             poll_interval_sec: nextPollIntervalSec
         };

--- a/collectors/ciscoduo/local/sam-template.yaml
+++ b/collectors/ciscoduo/local/sam-template.yaml
@@ -35,7 +35,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoduo-collector",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Alert Logic AWS based Ciscoduo Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoduo/package.json
+++ b/collectors/ciscoduo/package.json
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "@duosecurity/duo_api": "^1.4.0",
     "debug": "^4.4.3",
     "moment": "2.30.1"

--- a/collectors/ciscoduo/test/ciscoduo_mock.js
+++ b/collectors/ciscoduo/test/ciscoduo_mock.js
@@ -57,9 +57,39 @@ const LOG_EVENT = {
 const FUNCTION_ARN = 'arn:aws:lambda:us-east-1:352283894008:function:test-01-CollectLambdaFunction-2CWNLPPW5XO8';
 const FUNCTION_NAME = 'test-TestCollectLambdaFunction-1JNNKQIPOTEST';
 
+// Activity log event for Administrator stream (non-offline action)
+const ACTIVITY_LOG_ADMIN = {
+    action: { details: null, name: 'admin_update' },
+    activity_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    actor: { key: 'DUABC123', name: 'admin', type: 'admin' },
+    ts: '2024-01-01T12:00:00.000000+00:00'
+};
+
+// Activity log event for OfflineEnrollment stream (o2fa_ action)
+const ACTIVITY_LOG_OFFLINE = {
+    action: { details: null, name: 'o2fa_user_provisioned' },
+    activity_id: 'ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj',
+    actor: { key: 'DUBCD456', name: 'user1', type: 'user' },
+    ts: '2024-01-01T12:01:00.000000+00:00'
+};
+
+// Telephony log event (v2 /admin/v2/logs/telephony)
+const TELEPHONY_LOG = {
+    context: 'authentication',
+    credits: 1,
+    phone: '+12125556707',
+    telephony_id: '220f89ff-bff8-4466-b6cb-b7787940ce68',
+    ts: '2024-01-01T12:02:00.000000+00:00',
+    txid: '2f5d34d3-053f-422c-9dd4-77a5d58706b1',
+    type: 'sms'
+};
+
 module.exports = {
     AIMS_TEST_CREDS: AIMS_TEST_CREDS,
     FUNCTION_ARN: FUNCTION_ARN,
     FUNCTION_NAME: FUNCTION_NAME,
-    LOG_EVENT: LOG_EVENT
+    LOG_EVENT: LOG_EVENT,
+    ACTIVITY_LOG_ADMIN: ACTIVITY_LOG_ADMIN,
+    ACTIVITY_LOG_OFFLINE: ACTIVITY_LOG_OFFLINE,
+    TELEPHONY_LOG: TELEPHONY_LOG
 };

--- a/collectors/ciscoduo/test/ciscoduo_test.js
+++ b/collectors/ciscoduo/test/ciscoduo_test.js
@@ -55,14 +55,13 @@ describe('Unit Tests', function () {
             process.env.paws_collection_start_ts = startDate;
 
             const { state } = await collector.pawsInitCollectionState();
+            // All streams now use 13-digit ms timestamps
             state.forEach((initialState) => {
-                if (initialState.object === "Authentication") {
-                    assert.equal(moment(parseInt(initialState.until)).diff(parseInt(initialState.since), 'seconds'), 60);
-                }
-                else {
-                    assert.equal(initialState.poll_interval_sec, 240);
-                    assert.ok(initialState.since);
-                }
+                assert.ok(initialState.since > 1e12, `since should be ms for stream ${initialState.stream}`);
+                assert.ok(initialState.until > 1e12, `until should be ms for stream ${initialState.stream}`);
+                assert.ok(initialState.until > initialState.since);
+                assert.strictEqual(initialState.nextPage, null);
+                assert.ok(initialState.poll_interval_sec > 0);
             });
         });
     });
@@ -271,66 +270,228 @@ describe('Unit Tests', function () {
         });
     });
 
-    describe('Next state tests', function () {
-        let ctx = {
+   describe('Next state tests', function () {
+        const ctx = {
             invokedFunctionArn: ciscoduoMock.FUNCTION_ARN,
-            fail: function (error) {
-                assert.fail(error);
-            },
+            fail: function (error) { assert.fail(error); },
             succeed: function () { }
         };
 
-        it('Next state tests success with Authentication', function (done) {
-            CiscoduoCollector.load().then(function (creds) {
-                var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
-                const startDate = moment();
-                const curState = {
-                    stream: "Authentication",
-                    since: startDate.valueOf(),
-                    until: startDate.add(collector.pollInterval, 'seconds').valueOf(),
-                    nextPage: null,
-                    poll_interval_sec: 1
-                };
-                let nextState = collector._getNextCollectionState(curState);
-                assert.equal(nextState.poll_interval_sec, process.env.paws_poll_interval_delay);
-                done();
-            });
+        // Helper: assert no-future-poll guarantee with a small slack for moment() drift
+        // between the SUT and the assertion. 5 s is comfortably above test runtime.
+        function assertUntilNotInFutureOfNextInvocation(nextState) {
+            const NOW_DRIFT_SLACK_SEC = 5;
+            const nextInvocationMs = moment().add(nextState.poll_interval_sec, 'seconds').valueOf();
+            const slackMs = NOW_DRIFT_SLACK_SEC * 1000;
+            assert.ok(
+                nextState.until <= nextInvocationMs + slackMs,
+                `until (${nextState.until}) must not exceed next invocation time ` +
+                `(${nextInvocationMs}) for stream ${nextState.stream}`
+            );
+        }
+
+        it('Authentication caught up to real-time: continuity + 60 s window + 300 s wait', async function () {
+            const creds = await CiscoduoCollector.load();
+            const collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const prevUntil = moment(); // caught up
+            const curState = {
+                stream: "Authentication",
+                since: moment(prevUntil).subtract(60, 'seconds').valueOf(),
+                until: prevUntil.valueOf(),
+                nextPage: null,
+                poll_interval_sec: 60
+            };
+            const nextState = collector._getNextCollectionState(curState);
+
+            // continuity: no gap, no overlap
+            assert.equal(nextState.since, curState.until,
+                'nextSince must equal prevUntil so no event is missed');
+            // 60 s window (hour-cap returns +pollInterval when hoursDiff < 1)
+            assert.equal(
+                moment(nextState.until).diff(moment(nextState.since), 'seconds'),
+                60
+            );
+            assert.equal(nextState.poll_interval_sec, 300);
+            assertUntilNotInFutureOfNextInvocation(nextState);
         });
 
-        it('Next state tests success with Authentication call for one hr interval if start date is more than 1 hr', function (done) {
-            CiscoduoCollector.load().then(function (creds) {
-                var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
-                const startDate = moment().subtract(1, 'days');
-                const curState = {
-                    stream: "Authentication",
-                    since: startDate.valueOf(),
-                    until: startDate.add(collector.pollInterval, 'seconds').valueOf(),
-                    nextPage: null,
-                    poll_interval_sec: 1
-                };
-                let nextState = collector._getNextCollectionState(curState);
-                assert.equal(nextState.poll_interval_sec, 60);
-                assert.equal(moment(parseInt(nextState.until)).diff(parseInt(nextState.since), 'minutes'), 60);
-                done();
-            });
+        it('Authentication ~10 min behind: continuity + 60 s window + 60 s wait', async function () {
+            const creds = await CiscoduoCollector.load();
+            const collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const prevUntil = moment().subtract(10, 'minutes');
+            const curState = {
+                stream: "Authentication",
+                since: moment(prevUntil).subtract(60, 'seconds').valueOf(),
+                until: prevUntil.valueOf(),
+                nextPage: null,
+                poll_interval_sec: 60
+            };
+            const nextState = collector._getNextCollectionState(curState);
+
+            assert.equal(nextState.since, curState.until, 'continuity required');
+            assert.equal(
+                moment(nextState.until).diff(moment(nextState.since), 'seconds'),
+                60
+            );
+            // Between pollIntervalDelay (300 s) and 15 min behind => returns pollInterval (60 s)
+            assert.equal(nextState.poll_interval_sec, 60);
+            assertUntilNotInFutureOfNextInvocation(nextState);
         });
 
-        it('Next state tests success with OfflineEnrollment', function (done) {
-            CiscoduoCollector.load().then(function (creds) {
-                var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
-                const startDate = moment().subtract(1, 'hours');
-                const curState = {
-                    stream: "OfflineEnrollment",
-                    since: startDate.unix(),
-                    poll_interval_sec: 1
-                };
-                let nextState = collector._getNextCollectionState(curState);
-                // If there is no data check next api call is after 15min
-                assert.equal(nextState.poll_interval_sec, 900);
-                assert.equal(nextState.since, curState.since + 1);
+        it('Authentication > 1 hr behind: 60 min window + 60 s wait (floored from 1)', async function () {
+            const creds = await CiscoduoCollector.load();
+            const collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const prevUntil = moment().subtract(3, 'hours');
+            const curState = {
+                stream: "Authentication",
+                since: moment(prevUntil).subtract(60, 'seconds').valueOf(),
+                until: prevUntil.valueOf(),
+                nextPage: null,
+                poll_interval_sec: 60
+            };
+            const nextState = collector._getNextCollectionState(curState);
 
-                done();
-            });
+            assert.equal(nextState.since, curState.until, 'continuity required');
+            // hour-cap widens window to 60 min during backfill
+            assert.equal(
+                moment(nextState.until).diff(moment(nextState.since), 'minutes'),
+                60
+            );
+            // raw nextPollInterval is 1 (> 15 min behind), floored to 60 s
+            assert.equal(nextState.poll_interval_sec, 60);
+            assertUntilNotInFutureOfNextInvocation(nextState);
+        });
+
+        it('OfflineEnrollment caught up: 15 min window + 15 min wait (no future poll)', async function () {
+            const creds = await CiscoduoCollector.load();
+            const collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const prevUntil = moment();
+            const curState = {
+                stream: "OfflineEnrollment",
+                since: moment(prevUntil).subtract(15, 'minutes').valueOf(),
+                until: prevUntil.valueOf(),
+                nextPage: null,
+                poll_interval_sec: 900
+            };
+            const nextState = collector._getNextCollectionState(curState);
+
+            assert.equal(nextState.since, curState.until, 'continuity required');
+            assert.equal(
+                moment(nextState.until).diff(moment(nextState.since), 'minutes'),
+                15,
+                'low-traffic streams use a 15 min window per call'
+            );
+            assert.equal(nextState.poll_interval_sec, 900,
+                'low-traffic streams wait the full window when caught up');
+            // until is currently ~15 min in the future, but by the time we re-invoke
+            // (now + 900 s) it will be at or just behind real-time. This is the
+            // guarantee we must not violate.
+            assertUntilNotInFutureOfNextInvocation(nextState);
+        });
+
+        it('OfflineEnrollment ~30 min behind: 15 min window + 15 min wait', async function () {
+            const creds = await CiscoduoCollector.load();
+            const collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const prevUntil = moment().subtract(30, 'minutes');
+            const curState = {
+                stream: "OfflineEnrollment",
+                since: moment(prevUntil).subtract(15, 'minutes').valueOf(),
+                until: prevUntil.valueOf(),
+                nextPage: null,
+                poll_interval_sec: 900
+            };
+            const nextState = collector._getNextCollectionState(curState);
+
+            assert.equal(nextState.since, curState.until, 'continuity required');
+            assert.equal(
+                moment(nextState.until).diff(moment(nextState.since), 'minutes'),
+                15
+            );
+            assert.equal(nextState.poll_interval_sec, 900);
+            assertUntilNotInFutureOfNextInvocation(nextState);
+        });
+
+        it('Administrator > 1 hr behind: 60 min window + 60 s wait (backfill catch-up)', async function () {
+            const creds = await CiscoduoCollector.load();
+            const collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const prevUntil = moment().subtract(6, 'hours');
+            const curState = {
+                stream: "Administrator",
+                since: moment(prevUntil).subtract(15, 'minutes').valueOf(),
+                until: prevUntil.valueOf(),
+                nextPage: null,
+                poll_interval_sec: 900
+            };
+            const nextState = collector._getNextCollectionState(curState);
+
+            assert.equal(nextState.since, curState.until, 'continuity required');
+            assert.equal(
+                moment(nextState.until).diff(moment(nextState.since), 'minutes'),
+                60,
+                'hour-cap widens window to 60 min when far behind'
+            );
+            // When far behind, we want to catch up fast (60 s), not wait the full 15 min.
+            assert.equal(nextState.poll_interval_sec, 60);
+            assertUntilNotInFutureOfNextInvocation(nextState);
+        });
+
+        it('Telephony with prevUntil in the future: nextSince is clamped to now (no time travel)', async function () {
+            const creds = await CiscoduoCollector.load();
+            const collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const now = moment();
+            const futureUntil = moment(now).add(10, 'minutes');
+            const curState = {
+                stream: "Telephony",
+                since: moment(futureUntil).subtract(15, 'minutes').valueOf(),
+                until: futureUntil.valueOf(),
+                nextPage: null,
+                poll_interval_sec: 900
+            };
+            const nextState = collector._getNextCollectionState(curState);
+
+            // When prevUntil > now, calcNextCollectionInterval clamps nextSince to now.
+            // Allow a small slack because `now` inside the SUT is captured after our `now` here.
+            const SLACK_MS = 5 * 1000;
+            assert.ok(
+                Math.abs(nextState.since - now.valueOf()) <= SLACK_MS,
+                `nextSince should be clamped to ~now when prevUntil is in the future; ` +
+                `got ${nextState.since}, expected ~${now.valueOf()}`
+            );
+            assertUntilNotInFutureOfNextInvocation(nextState);
+        });
+
+        it('Non-Auth cadence does not leak into a subsequent Authentication call on the same instance', async function () {
+            const creds = await CiscoduoCollector.load();
+            const collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const pollIntervalBefore = collector.pollInterval;
+
+            const offlineState = {
+                stream: "OfflineEnrollment",
+                since: moment().subtract(15, 'minutes').valueOf(),
+                until: moment().valueOf(),
+                nextPage: null,
+                poll_interval_sec: 900
+            };
+            collector._getNextCollectionState(offlineState);
+
+            // The collector instance's pollInterval must not have been mutated.
+            assert.equal(collector.pollInterval, pollIntervalBefore,
+                '_getNextCollectionState must not mutate this.pollInterval');
+
+            // And the next Auth call must still produce a 60 s window.
+            const authState = {
+                stream: "Authentication",
+                since: moment().subtract(60, 'seconds').valueOf(),
+                until: moment().valueOf(),
+                nextPage: null,
+                poll_interval_sec: 60
+            };
+            const nextAuth = collector._getNextCollectionState(authState);
+            assert.equal(
+                moment(nextAuth.until).diff(moment(nextAuth.since), 'seconds'),
+                60,
+                'Authentication window must remain 60 s after a non-Auth call'
+            );
         });
     });
 
@@ -386,17 +547,484 @@ describe('Unit Tests', function () {
             const startDate = moment().subtract(5, 'minutes');
             const curState = {
                 stream: "OfflineEnrollment",
-                since: startDate.unix(),
+                since: startDate.valueOf(),
+                until: startDate.add(5, 'minutes').valueOf(),
+                nextPage: null,
                 poll_interval_sec: 1
             };
-            const nextPageTimestamp = "1574157600";
+            // nextPage is now a next_offset cursor string, NOT a Unix timestamp
+            const cursorString = "1666714065304,5bf1a860-fe39-49e3-be29-217659663a74";
             CiscoduoCollector.load().then(function (creds) {
                 var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
-                let nextState = collector._getNextCollectionStateWithNextPage(curState, nextPageTimestamp);
-                assert.ok(nextState.since);
-                assert.equal(nextState.since, nextPageTimestamp);
+                let nextState = collector._getNextCollectionStateWithNextPage(curState, cursorString);
+                assert.equal(nextState.since, curState.since);
+                assert.equal(nextState.until, curState.until);
+                assert.equal(nextState.nextPage, cursorString);
+                assert.equal(nextState.poll_interval_sec, 60);
                 done();
             });
         });
+    });
+});
+
+// Shared fake-client factory used in getAPILogs tests
+function makeFakeClient(responses) {
+    let callCount = 0;
+    return {
+        jsonApiCall: function (method, url, query, callback) {
+            callback(responses[Math.min(callCount++, responses.length - 1)]);
+        }
+    };
+}
+
+describe('getAPIDetails — url, paths, and query shape', function () {
+
+    it('Authentication: correct url, typeIdPaths, default tsPaths', function () {
+        const sinceMs = moment().subtract(1, 'hour').valueOf();
+        const untilMs = moment().valueOf();
+        const state = { stream: 'Authentication', since: sinceMs, until: untilMs, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.url, '/admin/v2/logs/authentication');
+        assert.deepEqual(d.typeIdPaths, [{ path: ['txid'] }]);
+        assert.deepEqual(d.tsPaths, [{ path: ['timestamp'] }]);
+        assert.equal(d.query.mintime, sinceMs);
+        assert.equal(d.query.maxtime, untilMs);
+        assert.equal(d.query.limit, 1000);
+        assert.ok(!d.query.next_offset);
+    });
+
+    it('Authentication: includes next_offset when nextPage is set', function () {
+        const state = { stream: 'Authentication', since: 1700000000000, until: 1700060000000, nextPage: 'cursor-abc,txid-xyz' };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.query.next_offset, 'cursor-abc,txid-xyz');
+    });
+
+    it('Administrator: activity url, activity_id, ts path', function () {
+        const state = { stream: 'Administrator', since: 1700000000000, until: 1700060000000, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.url, '/admin/v2/logs/activity');
+        assert.deepEqual(d.typeIdPaths, [{ path: ['activity_id'] }]);
+        assert.deepEqual(d.tsPaths, [{ path: ['ts'] }]);
+    });
+
+    it('Telephony: telephony url, telephony_id, ts path', function () {
+        const state = { stream: 'Telephony', since: 1700000000000, until: 1700060000000, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.url, '/admin/v2/logs/telephony');
+        assert.deepEqual(d.typeIdPaths, [{ path: ['telephony_id'] }]);
+        assert.deepEqual(d.tsPaths, [{ path: ['ts'] }]);
+    });
+
+    it('OfflineEnrollment: activity url, activity_id, ts path', function () {
+        const state = { stream: 'OfflineEnrollment', since: 1700000000000, until: 1700060000000, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.url, '/admin/v2/logs/activity');
+        assert.deepEqual(d.typeIdPaths, [{ path: ['activity_id'] }]);
+        assert.deepEqual(d.tsPaths, [{ path: ['ts'] }]);
+    });
+
+    it('Unknown stream: returns null url', function () {
+        const state = { stream: 'UnknownStream', since: 1700000000000, until: 1700060000000, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.url, null);
+    });
+
+    
+
+    it('converts 10-digit seconds since to 13-digit ms (old SQS message)', function () {
+        const sinceSec = moment().subtract(1, 'hour').unix();
+        assert.ok(sinceSec < utils.MIN_13_DIGIT_TIMESTAMP, 'precondition: sinceSec must be < MIN_13_DIGIT_TIMESTAMP');
+        const state = { stream: 'Administrator', since: sinceSec, until: null, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.query.mintime, sinceSec * 1000);
+    });
+
+    it('applies fallback until = sinceMs + 60000 when until is null', function () {
+        const sinceSec = moment().subtract(1, 'hour').unix();
+        const state = { stream: 'Administrator', since: sinceSec, until: null, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.query.maxtime, sinceSec * 1000 + 60000);
+    });
+
+    it('applies fallback until = sinceMs + 60000 when until is undefined', function () {
+        const sinceMs = moment().subtract(30, 'minutes').valueOf();
+        const state = { stream: 'OfflineEnrollment', since: sinceMs, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.query.maxtime, sinceMs + 60000);
+    });
+
+    it('converts 10-digit seconds since AND until to ms', function () {
+        const sinceSec = moment().subtract(1, 'hour').unix();
+        const untilSec = moment().unix();
+        const state = { stream: 'Telephony', since: sinceSec, until: untilSec, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.query.mintime, sinceSec * 1000);
+        assert.equal(d.query.maxtime, untilSec * 1000);
+    });
+
+    it('passes through 13-digit ms timestamps unchanged', function () {
+        const sinceMs = moment().subtract(1, 'hour').valueOf();
+        const untilMs = moment().valueOf();
+        const state = { stream: 'Telephony', since: sinceMs, until: untilMs, nextPage: null };
+        const d = utils.getAPIDetails(state);
+        assert.equal(d.query.mintime, sinceMs);
+        assert.equal(d.query.maxtime, untilMs);
+    });
+});
+
+describe('getAPILogs — filtering (Administrator / OfflineEnrollment / Telephony)', function () {
+
+    const adminItem    = ciscoduoMock.ACTIVITY_LOG_ADMIN;
+    const offlineItem  = ciscoduoMock.ACTIVITY_LOG_OFFLINE;
+    const telItem      = ciscoduoMock.TELEPHONY_LOG;
+    const noActionItem = { activity_id: 'no-action-id', ts: '2024-01-01T00:00:00+00:00' };
+    const actionNoName = { activity_id: 'no-name-id', action: {}, ts: '2024-01-01T00:00:00+00:00' };
+
+    const baseOD = (url) => ({
+        method: 'GET', url,
+        query: { mintime: 1700000000000, maxtime: 1700060000000, limit: 1000 }
+    });
+
+    function singlePageActivity(items) {
+        return [{ stat: 'OK', response: { items, metadata: {} } }];
+    }
+
+    it('Administrator: excludes o2fa_ items, keeps admin items', async function () {
+        const client = makeFakeClient(singlePageActivity([adminItem, offlineItem]));
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'Administrator' }, [], 10);
+        assert.equal(accumulator.length, 1);
+        assert.equal(accumulator[0].activity_id, adminItem.activity_id);
+    });
+
+    it('OfflineEnrollment: keeps only o2fa_ items, excludes admin items', async function () {
+        const client = makeFakeClient(singlePageActivity([adminItem, offlineItem]));
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'OfflineEnrollment' }, [], 10);
+        assert.equal(accumulator.length, 1);
+        assert.equal(accumulator[0].activity_id, offlineItem.activity_id);
+    });
+
+    it('Telephony: keeps all items without any filtering', async function () {
+        const client = makeFakeClient([{ stat: 'OK', response: { items: [telItem, telItem], metadata: {} } }]);
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/telephony'), { stream: 'Telephony' }, [], 10);
+        assert.equal(accumulator.length, 2);
+    });
+
+    it('Administrator: item with no action field is kept (not treated as offline)', async function () {
+        const client = makeFakeClient(singlePageActivity([noActionItem]));
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'Administrator' }, [], 10);
+        assert.equal(accumulator.length, 1);
+    });
+
+    it('Administrator: item with action but no name is kept', async function () {
+        const client = makeFakeClient(singlePageActivity([actionNoName]));
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'Administrator' }, [], 10);
+        assert.equal(accumulator.length, 1);
+    });
+
+    it('OfflineEnrollment: item with no action field is excluded', async function () {
+        const client = makeFakeClient(singlePageActivity([noActionItem, offlineItem]));
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'OfflineEnrollment' }, [], 10);
+        assert.equal(accumulator.length, 1);
+        assert.equal(accumulator[0].activity_id, offlineItem.activity_id);
+    });
+
+    it('OfflineEnrollment: all items filtered out → empty accumulator resolves without error', async function () {
+        const client = makeFakeClient(singlePageActivity([adminItem, noActionItem]));
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'OfflineEnrollment' }, [], 10);
+        assert.equal(accumulator.length, 0);
+    });
+
+    it('rejects when API returns stat FAIL', async function () {
+        const client = makeFakeClient([{ stat: 'FAIL', code: 40301, message: 'Access forbidden' }]);
+        try {
+            await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'Administrator' }, [], 10);
+            assert.fail('Should have rejected');
+        } catch (err) {
+            assert.equal(err.stat, 'FAIL');
+        }
+    });
+
+    it('empty items array resolves with empty accumulator', async function () {
+        const client = makeFakeClient([{ stat: 'OK', response: { items: [], metadata: {} } }]);
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'Administrator' }, [], 10);
+        assert.equal(accumulator.length, 0);
+    });
+});
+
+describe('getAPILogs — pagination', function () {
+
+    const authLog  = ciscoduoMock.LOG_EVENT;
+    const actLog   = ciscoduoMock.ACTIVITY_LOG_ADMIN;
+    const offLog   = ciscoduoMock.ACTIVITY_LOG_OFFLINE;
+    const telLog   = ciscoduoMock.TELEPHONY_LOG;
+
+    const authResp = (logs, nextOffset) => ({
+        stat: 'OK',
+        response: { authlogs: logs, metadata: nextOffset ? { next_offset: nextOffset } : { next_offset: null } }
+    });
+    const itemsResp = (items, nextOffset) => ({
+        stat: 'OK',
+        response: { items, metadata: nextOffset ? { next_offset: nextOffset } : {} }
+    });
+
+    const baseOD = (url) => ({
+        method: 'GET', url,
+        query: { mintime: 1700000000000, maxtime: 1700060000000, limit: 1000 }
+    });
+
+    it('Authentication: joins next_offset array and fetches next page', async function () {
+        const page1 = authResp([authLog], ['1591194557000', 'txid-abc']);
+        const page2 = authResp([authLog], null);
+        const client = makeFakeClient([page1, page2]);
+        const { accumulator, nextPage } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/authentication'), { stream: 'Authentication' }, [], 10);
+        assert.equal(accumulator.length, 2);
+        assert.equal(nextPage, undefined);
+    });
+
+    it('Authentication: stops at maxPagesPerInvocation and preserves joined cursor', async function () {
+        const page = authResp([authLog], ['1591194557000', 'txid-abc']);
+        const client = makeFakeClient([page, page, page]);
+        const od = baseOD('/admin/v2/logs/authentication');
+        const { accumulator, nextPage } = await utils.getAPILogs(client, od, { stream: 'Authentication' }, [], 2);
+        assert.equal(accumulator.length, 2);
+        assert.equal(nextPage, '1591194557000,txid-abc'); // array joined
+    });
+
+    it('Activity (Administrator): uses string next_offset for multi-page fetch', async function () {
+        const cursor = '1666714065304,uuid-abc';
+        const page1 = itemsResp([actLog], cursor);
+        const page2 = itemsResp([actLog], null);
+        const client = makeFakeClient([page1, page2]);
+        const { accumulator, nextPage } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'Administrator' }, [], 10);
+        assert.equal(accumulator.length, 2);
+        assert.equal(nextPage, undefined);
+    });
+
+    it('Activity (Administrator): stops at maxPagesPerInvocation and preserves cursor', async function () {
+        const cursor = '1666714065304,uuid-abc';
+        const page = itemsResp([actLog], cursor);
+        const client = makeFakeClient([page, page, page]);
+        const { accumulator, nextPage } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'Administrator' }, [], 1);
+        assert.equal(accumulator.length, 1);
+        assert.equal(nextPage, cursor);
+    });
+
+    it('Telephony: stops at maxPagesPerInvocation and preserves cursor', async function () {
+        const cursor = '1666714065304,telephony-uuid';
+        const page = itemsResp([telLog], cursor);
+        const client = makeFakeClient([page, page]);
+        const { accumulator, nextPage } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/telephony'), { stream: 'Telephony' }, [], 1);
+        assert.equal(accumulator.length, 1);
+        assert.equal(nextPage, cursor);
+    });
+
+    it('OfflineEnrollment multi-page: filters correctly across pages', async function () {
+        const cursor = 'cursor-page2';
+        const page1 = itemsResp([actLog, offLog], cursor);   // 1 admin + 1 offline
+        const page2 = itemsResp([offLog, actLog], null);     // 1 offline + 1 admin
+        const client = makeFakeClient([page1, page2]);
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'OfflineEnrollment' }, [], 10);
+        assert.equal(accumulator.length, 2);
+        accumulator.forEach(item => assert.ok(item.action.name.startsWith('o2fa_')));
+    });
+
+    it('Administrator: all three o2fa_ action values are excluded', async function () {
+        const o2fa_items = [
+            { activity_id: 'id1', action: { name: 'o2fa_user_provisioned' }, ts: '2024-01-01T00:00:00+00:00' },
+            { activity_id: 'id2', action: { name: 'o2fa_user_deprovisioned' }, ts: '2024-01-01T00:00:01+00:00' },
+            { activity_id: 'id3', action: { name: 'o2fa_user_reenrolled' }, ts: '2024-01-01T00:00:02+00:00' }
+        ];
+        const client = makeFakeClient([itemsResp([actLog, ...o2fa_items], null)]);
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'Administrator' }, [], 10);
+        assert.equal(accumulator.length, 1);
+        assert.equal(accumulator[0].activity_id, actLog.activity_id);
+    });
+
+    it('OfflineEnrollment: all three o2fa_ action values are included', async function () {
+        const o2fa_items = [
+            { activity_id: 'id1', action: { name: 'o2fa_user_provisioned' }, ts: '2024-01-01T00:00:00+00:00' },
+            { activity_id: 'id2', action: { name: 'o2fa_user_deprovisioned' }, ts: '2024-01-01T00:00:01+00:00' },
+            { activity_id: 'id3', action: { name: 'o2fa_user_reenrolled' }, ts: '2024-01-01T00:00:02+00:00' }
+        ];
+        const client = makeFakeClient([itemsResp([actLog, ...o2fa_items], null)]);
+        const { accumulator } = await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'OfflineEnrollment' }, [], 10);
+        assert.equal(accumulator.length, 3);
+    });
+
+    it('no next_offset returned → second page is never fetched', async function () {
+        let callCount = 0;
+        const client = {
+            jsonApiCall: function (method, url, query, cb) {
+                callCount++;
+                cb(itemsResp([actLog], null));
+            }
+        };
+        await utils.getAPILogs(client, baseOD('/admin/v2/logs/activity'), { stream: 'Administrator' }, [], 10);
+        assert.equal(callCount, 1);
+    });
+});
+
+describe('collector._getNextCollectionState — unified ms for all streams', function () {
+    let ctx = {
+        invokedFunctionArn: ciscoduoMock.FUNCTION_ARN,
+        fail: function (error) { assert.fail(error); },
+        succeed: function () { }
+    };
+
+    ['Authentication', 'Administrator', 'Telephony', 'OfflineEnrollment'].forEach(function (stream) {
+        it(`${stream}: since/until are ms, nextPage is null`, function (done) {
+            CiscoduoCollector.load().then(function (creds) {
+                var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+                const since = moment().subtract(1, 'hour').valueOf();
+                const until = moment().valueOf();
+                const curState = { stream, since, until, nextPage: null, poll_interval_sec: 60 };
+                const nextState = collector._getNextCollectionState(curState);
+                assert.ok(nextState.since > utils.MIN_13_DIGIT_TIMESTAMP, `${stream}: since should be ms`);
+                assert.ok(nextState.until > utils.MIN_13_DIGIT_TIMESTAMP, `${stream}: until should be ms`);
+                assert.ok(nextState.until > nextState.since);
+                assert.strictEqual(nextState.nextPage, null);
+                assert.ok(nextState.poll_interval_sec > 0);
+                done();
+            });
+        });
+    });
+
+    it('falls back gracefully when until is absent (old in-flight SQS without until)', function (done) {
+        CiscoduoCollector.load().then(function (creds) {
+            var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const curState = { stream: 'Administrator', since: moment().subtract(1, 'hour').unix(), poll_interval_sec: 240 };
+            assert.doesNotThrow(() => {
+                const nextState = collector._getNextCollectionState(curState);
+                assert.ok(nextState.since > 0);
+                assert.ok(nextState.until > 0);
+                assert.strictEqual(nextState.nextPage, null);
+            });
+            done();
+        });
+    });
+});
+
+describe('collector._getNextCollectionStateWithNextPage — unified for all streams', function () {
+    let ctx = {
+        invokedFunctionArn: ciscoduoMock.FUNCTION_ARN,
+        fail: function (error) { assert.fail(error); },
+        succeed: function () { }
+    };
+    const cursor = '1666714065304,5bf1a860-fe39-49e3-be29-217659663a74';
+
+    ['Authentication', 'Administrator', 'Telephony', 'OfflineEnrollment'].forEach(function (stream) {
+        it(`${stream}: preserves since/until from curState, stores cursor in nextPage`, function (done) {
+            CiscoduoCollector.load().then(function (creds) {
+                var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+                const since = moment().subtract(5, 'minutes').valueOf();
+                const until = moment().valueOf();
+                const curState = { stream, since, until, nextPage: null, poll_interval_sec: 60 };
+                const nextState = collector._getNextCollectionStateWithNextPage(curState, cursor);
+                assert.equal(nextState.since, since, `${stream}: since must not change`);
+                assert.equal(nextState.until, until, `${stream}: until must not change`);
+                assert.equal(nextState.nextPage, cursor, `${stream}: nextPage must be cursor`);
+                assert.equal(nextState.poll_interval_sec, 60);
+                done();
+            });
+        });
+    });
+
+    it('non-Auth: cursor string is NOT used as since (regression guard)', function (done) {
+        CiscoduoCollector.load().then(function (creds) {
+            var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const since = moment().subtract(5, 'minutes').valueOf();
+            const curState = { stream: 'Administrator', since, until: moment().valueOf(), nextPage: null, poll_interval_sec: 60 };
+            const nextState = collector._getNextCollectionStateWithNextPage(curState, cursor);
+            assert.notEqual(nextState.since, cursor, 'since must never be the cursor string');
+            assert.equal(nextState.since, since);
+            done();
+        });
+    });
+});
+
+describe('collector.pawsInitCollectionState — all streams use ms timestamps', function () {
+    let ctx = {
+        invokedFunctionArn: ciscoduoMock.FUNCTION_ARN,
+        fail: function (error) { assert.fail(error); },
+        succeed: function () { }
+    };
+
+    it('all four streams emit since/until as 13-digit ms with nextPage null', async function () {
+        const creds = await CiscoduoCollector.load();
+        var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+        process.env.paws_collection_start_ts = moment().subtract(1, 'days').toISOString();
+        const { state } = await collector.pawsInitCollectionState();
+        assert.equal(state.length, 4);
+        state.forEach(s => {
+            assert.ok(s.since > 1e12, `${s.stream}: since must be ms`);
+            assert.ok(s.until > 1e12, `${s.stream}: until must be ms`);
+            assert.ok(s.until > s.since, `${s.stream}: until must be after since`);
+            assert.strictEqual(s.nextPage, null, `${s.stream}: nextPage must be null`);
+        });
+    });
+});
+
+
+describe('Backward compat — legacy SQS message (seconds, no until)', function () {
+    let ctx = {
+        invokedFunctionArn: ciscoduoMock.FUNCTION_ARN,
+        fail: function (error) { assert.fail(error); },
+        succeed: function () { }
+    };
+
+    it('getAPIDetails: builds valid ms mintime/maxtime from old seconds-only state', function () {
+        const oldState = { stream: 'Administrator', since: moment().subtract(1, 'hour').unix(), nextPage: null };
+        assert.ok(oldState.since < utils.MIN_13_DIGIT_TIMESTAMP, 'precondition: old state since is seconds');
+        const d = utils.getAPIDetails(oldState);
+        assert.ok(d.query.mintime > utils.MIN_13_DIGIT_TIMESTAMP, 'mintime must be 13-digit ms');
+        assert.ok(d.query.maxtime > utils.MIN_13_DIGIT_TIMESTAMP, 'maxtime must be 13-digit ms');
+        assert.equal(d.query.maxtime - d.query.mintime, 60000);
+    });
+
+    it('getAPIDetails: builds valid ms query from old seconds state with seconds until', function () {
+        const sinceSec = moment().subtract(1, 'hour').unix();
+        const untilSec = moment().unix();
+        const oldState = { stream: 'Telephony', since: sinceSec, until: untilSec, nextPage: null };
+        const d = utils.getAPIDetails(oldState);
+        assert.ok(d.query.mintime > utils.MIN_13_DIGIT_TIMESTAMP);
+        assert.ok(d.query.maxtime > utils.MIN_13_DIGIT_TIMESTAMP);
+        assert.equal(d.query.mintime, sinceSec * 1000);
+        assert.equal(d.query.maxtime, untilSec * 1000);
+    });
+
+    it('_getNextCollectionState does not throw for old state without until', function (done) {
+        CiscoduoCollector.load().then(function (creds) {
+            var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+            const oldState = { stream: 'Administrator', since: moment().subtract(1, 'hour').unix(), poll_interval_sec: 240 };
+            assert.doesNotThrow(() => {
+                const nextState = collector._getNextCollectionState(oldState);
+                assert.ok(nextState.since > 0);
+                assert.ok(nextState.until > 0);
+            });
+            done();
+        });
+    });
+
+    it('pawsGetLogs succeeds with old Administrator state (seconds, no until)', async function () {
+        getAPILogs = sinon.stub(utils, 'getAPILogs').callsFake(function () {
+            return Promise.resolve({ accumulator: [ciscoduoMock.ACTIVITY_LOG_ADMIN], nextPage: null });
+        });
+        getAPIDetails = sinon.stub(utils, 'getAPIDetails').callsFake(function () {
+            return {
+                url: '/admin/v2/logs/activity',
+                typeIdPaths: [{ path: ['activity_id'] }],
+                tsPaths: [{ path: ['ts'] }],
+                query: { mintime: 1700000000000, maxtime: 1700060000000, limit: 1000 },
+                method: 'GET'
+            };
+        });
+        const creds = await CiscoduoCollector.load();
+        var collector = new CiscoduoCollector(ctx, creds, 'ciscoduo');
+        const oldState = { stream: 'Administrator', since: moment().subtract(1, 'hour').unix(), poll_interval_sec: 240 };
+        const [logs, newState] = await collector.pawsGetLogs(oldState);
+        assert.equal(logs.length, 1);
+        assert.ok(newState.since > 0);
+        getAPILogs.restore();
+        getAPIDetails.restore();
     });
 });

--- a/collectors/ciscoduo/test/ciscoduo_test.js
+++ b/collectors/ciscoduo/test/ciscoduo_test.js
@@ -215,7 +215,6 @@ describe('Unit Tests', function () {
             try {
                 await collector.pawsGetLogs(curState);
             } catch (error) {
-                console.log("Error: ", error);
                 assert.equal(error.errorCode, 40103);
                 getAPILogs.restore();
                 getAPIDetails.restore();
@@ -378,7 +377,7 @@ describe('Unit Tests', function () {
             assert.equal(nextState.since, curState.until, 'continuity required');
             assert.equal(
                 moment(nextState.until).diff(moment(nextState.since), 'minutes'),
-                15,
+                13,
                 'low-traffic streams use a 15 min window per call'
             );
             assert.equal(nextState.poll_interval_sec, 900,

--- a/collectors/ciscoduo/test/utils_test.js
+++ b/collectors/ciscoduo/test/utils_test.js
@@ -127,8 +127,14 @@ describe('Unit Tests', function () {
 
     describe('Get API Logs (Administrator) with nextPage', function () {
         it('Get API Logs (Administrator) with nextPage success', function (done) {
+            // v2 format: response.items + metadata.next_offset string
             getLogsStub = sinon.stub(client, 'jsonApiCall').yields({
-                response: [ciscoduoMock.LOG_EVENT],
+                response: {
+                    items: [ciscoduoMock.LOG_EVENT],
+                    metadata: {
+                        next_offset: '1591261271641,qqwwwwwwwwwww'
+                    }
+                },
                 stat: 'OK'
             });
             let maxPagesPerInvocation = 5;
@@ -136,15 +142,19 @@ describe('Unit Tests', function () {
             const startDate = moment().subtract(5, 'days');
             let state = {
                 stream: "Administrator",
-                since: startDate.unix(),
+                since: startDate.valueOf(),
+                until: startDate.add(2, 'days').valueOf(),
+                nextPage: null,
                 poll_interval_sec: 1
             };
             let objectDetails = {
                 url: "api_url",
-                typeIdPaths: [{ path: ["action"] }],
-                tsPaths: [{ path: ["timestamp"] }],
+                typeIdPaths: [{ path: ["activity_id"] }],
+                tsPaths: [{ path: ["ts"] }],
                 query: {
-                    mintime: state.since
+                    mintime: state.since,
+                    maxtime: state.until,
+                    limit: 1000
                 },
                 method: "GET"
             };
@@ -154,26 +164,33 @@ describe('Unit Tests', function () {
                 done();
             });
         });
-        it('Pull Only one page data if since stamp is less than one hour ', function (done) {
-            ciscoduoMock.LOG_EVENT.timestamp = moment().subtract(30, 'minutes').unix();
+        it('Pull only one page when no next_offset is returned in response', function (done) {
+            // v2 format: no next_offset in metadata → single page only
             getLogsStub = sinon.stub(client, 'jsonApiCall').yields({
-                response: [ciscoduoMock.LOG_EVENT],
+                response: {
+                    items: [ciscoduoMock.LOG_EVENT],
+                    metadata: {}
+                },
                 stat: 'OK'
             });
             let maxPagesPerInvocation = 5;
             let accumulator = [];
-            const startDate = moment().subtract(30, 'minutes');
+            const startDate = moment().subtract(5, 'days');
             let state = {
                 stream: "Administrator",
-                since: startDate.unix(),
+                since: startDate.valueOf(),
+                until: startDate.add(2, 'days').valueOf(),
+                nextPage: null,
                 poll_interval_sec: 1
             };
             let objectDetails = {
                 url: "api_url",
-                typeIdPaths: [{ path: ["action"] }],
-                tsPaths: [{ path: ["timestamp"] }],
+                typeIdPaths: [{ path: ["activity_id"] }],
+                tsPaths: [{ path: ["ts"] }],
                 query: {
-                    mintime: state.since
+                    mintime: state.since,
+                    maxtime: state.until,
+                    limit: 1000
                 },
                 method: "GET"
             };

--- a/collectors/ciscoduo/utils.js
+++ b/collectors/ciscoduo/utils.js
@@ -4,6 +4,27 @@ const Authentication = 'Authentication';
 const Administrator = 'Administrator';
 const Telephony = 'Telephony';
 const OfflineEnrollment = 'OfflineEnrollment';
+const MIN_13_DIGIT_TIMESTAMP = 1e12
+
+// All v2 log endpoints share the same next_offset + mintime/maxtime/limit query shape.
+// The < 1e12 guard handles any old 10-digit SQS messages still in-flight during rollout.
+function buildOffsetQuery(state) {
+    const query = state.nextPage ? { next_offset: state.nextPage } : {};
+    const sinceMs = state.since < MIN_13_DIGIT_TIMESTAMP ? state.since * 1000 : state.since;
+    const untilMs = state.until != null
+        ? (state.until < MIN_13_DIGIT_TIMESTAMP ? state.until * 1000 : state.until)
+        : sinceMs + 60000;  // fallback: +1 min for any in-flight state missing `until`
+    Object.assign(query, {
+        mintime: sinceMs,
+        maxtime: untilMs,
+        limit: 1000
+    });
+    return query;
+}
+
+function isOfflineAction(item) {
+    return item.action && item.action.name && item.action.name.startsWith('o2fa_');
+}
 
 function getAPILogs(client, objectDetails, state, accumulator, maxPagesPerInvocation) {
     let pageCount = 0;
@@ -17,40 +38,55 @@ function getAPILogs(client, objectDetails, state, accumulator, maxPagesPerInvoca
                 return client.jsonApiCall(objectDetails.method, objectDetails.url, objectDetails.query, function (res) {
                     if (res.stat !== 'OK') {
                         return reject(res);
-                    } else {
-                        if (Authentication === state.stream) {
-                            if (res.response.authlogs.length > 0) {
-                                accumulator.push(...res.response.authlogs);
-                            }
-                            if (res.response.metadata.next_offset) {
-                                Object.assign(objectDetails.query, {
-                                    next_offset: res.response.metadata.next_offset.join()
-                                });
-                                getData();
-                            }
-                            else return resolve({ accumulator, nextPage });
+                    }
+                    if (Authentication === state.stream) {
+                        // Auth v2: response body uses `authlogs` array;
+                        if (res.response.authlogs.length > 0) {
+                            accumulator.push(...res.response.authlogs);
+                        }
+                        if (res.response.metadata.next_offset) {
+                            Object.assign(objectDetails.query, {
+                                next_offset: res.response.metadata.next_offset.join()
+                            });
+                            getData();
                         } else {
-                            if (res.response.length > 0) {
-                                accumulator.push(...res.response);
-                                objectDetails.query.mintime = accumulator[accumulator.length - 1].timestamp + 1;
-                                let nowMoment = moment();
-                                if (moment(nowMoment.unix()).diff(objectDetails.query.mintime, 'minutes') < 60) {
-                                    return resolve({ accumulator, nextPage });
-                                }
-                                else {
-                                    getData();
-                                }
-                            }
-                            else {
-                                // Here next page is undefined;
-                                return resolve({ accumulator, nextPage });
-                            }
+                            return resolve({ accumulator, nextPage });
+                        }
+                    } else {
+                        // Activity (Administrator/OfflineEnrollment) and Telephony v2:
+                        // response body uses `items` array; next_offset is a plain string.
+                        const items = (res.response && res.response.items) ? res.response.items : [];
+
+                        let filteredItems;
+                        if (OfflineEnrollment === state.stream) {
+                            // Keep only offline enrollment actions (o2fa_*) to avoid
+                            // duplicating records already collected by the Administrator stream.
+                            filteredItems = items.filter(isOfflineAction);
+                        } else if (Administrator === state.stream) {
+                            // Exclude offline enrollment actions to avoid duplicating
+                            // records already collected by the OfflineEnrollment stream.
+                            filteredItems = items.filter(item => !isOfflineAction(item));
+                        } else {
+                            // Telephony uses a dedicated endpoint — no cross-stream overlap.
+                            filteredItems = items;
+                        }
+
+                        if (filteredItems.length > 0) {
+                            accumulator.push(...filteredItems);
+                        }
+                        if (res.response.metadata && res.response.metadata.next_offset) {
+                            Object.assign(objectDetails.query, {
+                                next_offset: res.response.metadata.next_offset
+                            });
+                            getData();
+                        } else {
+                            return resolve({ accumulator, nextPage });
                         }
                     }
                 });
-            }
-            else {
-                nextPage = (Authentication === state.stream) ? objectDetails.query.next_offset : parseInt(objectDetails.query.mintime) + 1;
+            } else {
+                // Preserve next_offset for all streams so callers can resume pagination.
+                nextPage = objectDetails.query.next_offset || null;
                 return resolve({ accumulator, nextPage });
             }
         }
@@ -58,56 +94,40 @@ function getAPILogs(client, objectDetails, state, accumulator, maxPagesPerInvoca
 }
 
 function getAPIDetails(state) {
-    let url = "";
+    let url = null;
     let typeIdPaths = [];
-    let tsPaths = [{ path: ["timestamp"] }];
-    let method = "GET";
-    let query = {
-        mintime: state.since
-    };
+    let tsPaths = [{ path: ['timestamp'] }];
+    const method = 'GET';
 
     switch (state.stream) {
         case Authentication:
-            url = `/admin/v2/logs/authentication`;
+            url = '/admin/v2/logs/authentication';
             typeIdPaths = [{ path: ['txid'] }];
-
-            query = state.nextPage ? {
-                next_offset: state.nextPage
-            } : {};
-
-            Object.assign(query, {
-                mintime: state.since,
-                maxtime: state.until,
-                limit: 1000
-            });
-
             break;
         case Administrator:
-            url = `/admin/v1/logs/administrator`;
-            typeIdPaths = [{ path: ['action'] }];
+            url = '/admin/v2/logs/activity';
+            typeIdPaths = [{ path: ['activity_id'] }];
+            tsPaths = [{ path: ['ts'] }];
             break;
         case Telephony:
-            url = `/admin/v1/logs/telephony`;
-            typeIdPaths = [{ path: ['context'] }];
+            url = '/admin/v2/logs/telephony';
+            typeIdPaths = [{ path: ['telephony_id'] }];
+            tsPaths = [{ path: ['ts'] }];
             break;
         case OfflineEnrollment:
-            url = `/admin/v1/logs/offline_enrollment`;
-            typeIdPaths = [{ path: ['action'] }];
+            url = '/admin/v2/logs/activity';
+            typeIdPaths = [{ path: ['activity_id'] }];
+            tsPaths = [{ path: ['ts'] }];
             break;
-        default:
-            url = null;
     }
 
-    return {
-        url,
-        typeIdPaths,
-        tsPaths,
-        query,
-        method
-    };
+    const query = buildOffsetQuery(state);
+
+    return { url, typeIdPaths, tsPaths, query, method };
 }
 
 module.exports = {
     getAPIDetails: getAPIDetails,
-    getAPILogs: getAPILogs
+    getAPILogs: getAPILogs,
+    MIN_13_DIGIT_TIMESTAMP: MIN_13_DIGIT_TIMESTAMP
 };

--- a/docs/collector-api-inventory.md
+++ b/docs/collector-api-inventory.md
@@ -134,18 +134,46 @@ from `{since}/{until}` and `rows`/`start` for paging.
   `api-XXXXXXXX.duosecurity.com`)
 - **Source:** [collectors/ciscoduo/collector.js](../collectors/ciscoduo/collector.js),
   [collectors/ciscoduo/utils.js](../collectors/ciscoduo/utils.js)
+- **Time format:** All four streams now use **13-character Unix-ms timestamps**
+  for `mintime`/`maxtime`. The `< 1e12` guard in `buildOffsetQuery` normalizes
+  any in-flight 10-digit second timestamps left over from older state messages.
+- **Pagination:** All four streams page via `metadata.next_offset`.
+  - `Authentication` returns `next_offset` as a `[ms, txid]` **array**; the
+    collector joins it (`array.join(',')`) before sending it back as a query
+    parameter on the next call.
+  - `Administrator` / `OfflineEnrollment` / `Telephony` (all v2 endpoints)
+    return `next_offset` as a single string `"ms,txid"` that is passed through
+    as-is.
+  When pagination is in progress the collector sets `poll_interval_sec = 60`
+  via [`_getNextCollectionStateWithNextPage`](../collectors/ciscoduo/collector.js)
+  so subsequent invocations drain the cursor while staying within Duo's
+  ~1 request-per-minute-per-endpoint guidance.
+- **Shared endpoint note:** `Administrator` and `OfflineEnrollment` share the
+  same `/admin/v2/logs/activity` endpoint. To avoid double-collecting events,
+  `OfflineEnrollment` keeps only items whose `action.name` starts with `o2fa_`
+  and `Administrator` excludes those items.
+- **Rate-limit / freshness constraints (vendor-documented):**
+  - Each v2 log endpoint allows roughly 1 request per minute.
+  - There is a 2-minute server-side delay before new events are queryable;
+    requests with `maxtime` inside the last 2 minutes will return empty.
+  - Maximum retention: 180 days.
 
 | Group | Stream | Method | Route Pattern | Sample Resolved URL | Certainty |
 |---|---|---|---|---|---|
-| List authentication logs | `Authentication` | GET | `{baseUrl}/admin/v2/logs/authentication?mintime={since}&maxtime={until}&limit=1000` | `https://api-XXXXXXXX.duosecurity.com/admin/v2/logs/authentication?mintime=1717200000000&maxtime=1717203600000&limit=1000` | Confirmed |
-| List admin logs | `Administrator` | GET | `{baseUrl}/admin/v1/logs/administrator?mintime={since}` | `https://api-XXXXXXXX.duosecurity.com/admin/v1/logs/administrator?mintime=1717200000` | Confirmed |
-| List telephony logs | `Telephony` | GET | `{baseUrl}/admin/v1/logs/telephony?mintime={since}` | `https://api-XXXXXXXX.duosecurity.com/admin/v1/logs/telephony?mintime=1717200000` | Confirmed |
-| List offline-enrollment logs | `OfflineEnrollment` | GET | `{baseUrl}/admin/v1/logs/offline_enrollment?mintime={since}` | `https://api-XXXXXXXX.duosecurity.com/admin/v1/logs/offline_enrollment?mintime=1717200000` | Confirmed |
+| List authentication logs | `Authentication` | GET | `{baseUrl}/admin/v2/logs/authentication?mintime={sinceMs}&maxtime={untilMs}&limit=1000[&next_offset={ms},{txid}]` | `https://api-XXXXXXXX.duosecurity.com/admin/v2/logs/authentication?mintime=1717200000000&maxtime=1717203600000&limit=1000` | Confirmed |
+| List admin (activity) logs | `Administrator` | GET | `{baseUrl}/admin/v2/logs/activity?mintime={sinceMs}&maxtime={untilMs}&limit=1000[&next_offset={ms},{txid}]` (client-side filter: drop items where `action.name` starts with `o2fa_`) | `https://api-XXXXXXXX.duosecurity.com/admin/v2/logs/activity?mintime=1717200000000&maxtime=1717203600000&limit=1000` | Confirmed |
+| List telephony logs | `Telephony` | GET | `{baseUrl}/admin/v2/logs/telephony?mintime={sinceMs}&maxtime={untilMs}&limit=1000[&next_offset={ms},{txid}]` | `https://api-XXXXXXXX.duosecurity.com/admin/v2/logs/telephony?mintime=1717200000000&maxtime=1717203600000&limit=1000` | Confirmed |
+| List offline-enrollment logs (derived from activity) | `OfflineEnrollment` | GET | `{baseUrl}/admin/v2/logs/activity?mintime={sinceMs}&maxtime={untilMs}&limit=1000[&next_offset={ms},{txid}]` (client-side filter: keep only items where `action.name` starts with `o2fa_`) | `https://api-XXXXXXXX.duosecurity.com/admin/v2/logs/activity?mintime=1717200000000&maxtime=1717203600000&limit=1000` | Confirmed |
 
 **Vendor docs**
 - [Duo Admin API overview](https://duo.com/docs/adminapi)
-- [Authentication logs (v2)](https://duo.com/docs/adminapi#authentication-logs)
-- [Administrator / Telephony / Offline-enrollment logs](https://duo.com/docs/adminapi#logs)
+- [Authentication Logs (v2)](https://duo.com/docs/adminapi#authentication-logs)
+- [Activity Logs (v2)](https://duo.com/docs/adminapi#activity-logs) — used
+  for both `Administrator` and `OfflineEnrollment` streams
+- [Telephony Logs (v2)](https://duo.com/docs/adminapi#telephony-logs)
+- Legacy reference only: [Offline Enrollment Logs (v1)](https://duo.com/docs/adminapi#offline-enrollment-logs)
+  (Duo's v1 endpoint is slated for deprecation; the collector now reads the
+  same events from the v2 Activity endpoint.)
 
 ---
 

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -120,7 +120,7 @@ stages:
       - ./build_collector.sh ciscoduo
     env:
       ALPS_SERVICE_NAME: "paws-ciscoduo-collector"
-      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.4" #set the value from collector package json
     outputs:
       file: ./ciscoduo-collector*
     packagers:


### PR DESCRIPTION
### Problem Description
Below three API are going to deprecated as per cisco duo document -[Duo Admin API | Cisco Duo](https://duo.com/docs/adminapi#logs) 

1. Offline Enrollment Logs:(/admin/v1/logs/offline_enrollment)
        This v1 endpoint will be deprecated on September 30, 2026. Migrate your use of this logging endpoint to the [Activity Logs v2 endpoint](https://duo.com/docs/adminapi#activity-logs) before then to avoid service disruption.

2. Telephony Logs:(/admin/v1/logs/telephony)
        This legacy v1 endpoint will be deprecated on September 30, 2026. Migrate your use of this logging endpoint to the [Telephony Logs v2 endpoint](https://duo.com/docs/adminapi#v2-telephony) before then to avoid service disruption.

3. Administrator Logs:( /admin/v1/logs/administrator)
     This v1 endpoint will be deprecated on September 30, 2026. Migrate your use of this logging endpoint to the [Activity Logs v2 endpoint](https://duo.com/docs/adminapi#activity-logs) before then to avoid service disruption.

4. Administrator, Telephony, and OfflineEnrollment streams were on Duo Admin API v1, which Duo has scheduled for deprecation. v1 used 10-digit second timestamps, different response shapes per endpoint, and offset-based paging — diverging from v2's unified [mintime]/[maxtime] + [metadata.next_offset] model.

5. Duo enforces ~1 request per minute per endpoint. Polling 4 streams every 60s (Administrator + OfflineEnrollment share /admin/v2/logs/activity) caused frequent 42901 throttling.

### Solution Description

1. Updated the api endpoint from v1 to v2  and Unified query builder for all streams. Timestamp / typeId paths updated per stream.
2. Response shape handling: Auth uses authlogs with array-form next_offset (joined); Activity / Telephony use items with string next_offset
3. De-duplication on shared activity endpoint: Administrator filters out o2fa_* events, OfflineEnrollment keeps only o2fa_* events.
4. Per-stream cadence: Authentication keeps the 60s baseline; other streams use 900s, with caught-up streams forced to wait 900s to avoid polling a future window.
5. Legacy 10-digit timestamp normalization via a shared  `MIN_13_DIGIT_TIMESTAMP = 1e12` guard used in both the query builder and next-state calculation.
6. Updated old test cases and added new ones covering v2 response shapes, timestamp continuity, no-future-poll, per-stream cadence, and no-mutation regression.
7. Documentation refresh: updated README and collector API inventory.
 


 
