### PR TITLE
[ALL PAWS collectors]: Updated the AWS Lambda runtime nodejs 22.x to 24.x

### DIFF
--- a/collectors/auth0/al-auth0-collector.json
+++ b/collectors/auth0/al-auth0-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/auth0/local/sam-template.yaml
+++ b/collectors/auth0/local/sam-template.yaml
@@ -34,7 +34,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/auth0/package.json
+++ b/collectors/auth0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-collector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Alert Logic AWS based Auth0 Log Collector extension",
   "repository": {},
   "private": true,
@@ -24,8 +24,8 @@
     "sinon": "^21.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "auth0": "^3.7.2",
     "debug": "^4.4.3",
     "moment": "^2.30.1"

--- a/collectors/carbonblack/al-carbonblack-collector.json
+++ b/collectors/carbonblack/al-carbonblack-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/carbonblack/local/sam-template.yaml
+++ b/collectors/carbonblack/local/sam-template.yaml
@@ -36,7 +36,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/carbonblack/package.json
+++ b/collectors/carbonblack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbonblack-collector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Alert Logic AWS based Carbonblack Log Collector",
   "repository": {},
   "private": true,
@@ -24,8 +24,8 @@
     "sinon": "^21.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "moment": "2.30.1",
     "test": "^3.3.0"

--- a/collectors/ciscoamp/al-ciscoamp-collector.json
+++ b/collectors/ciscoamp/al-ciscoamp-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/ciscoamp/local/sam-template.yaml
+++ b/collectors/ciscoamp/local/sam-template.yaml
@@ -34,7 +34,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },

--- a/collectors/ciscomeraki/al-ciscomeraki-collector.json
+++ b/collectors/ciscomeraki/al-ciscomeraki-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/ciscomeraki/local/sam-template.yaml
+++ b/collectors/ciscomeraki/local/sam-template.yaml
@@ -40,7 +40,7 @@ Resources:
           secret:
           dl_s3_bucket_name:
       CodeUri: 
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/ciscomeraki/package.json
+++ b/collectors/ciscomeraki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscomeraki-collector",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Alert Logic AWS based Cisco Meraki Log Collector",
   "repository": {},
   "private": true,
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },

--- a/collectors/crowdstrike/al-crowdstrike-collector.json
+++ b/collectors/crowdstrike/al-crowdstrike-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/crowdstrike/local/sam-template.yaml
+++ b/collectors/crowdstrike/local/sam-template.yaml
@@ -34,7 +34,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri: 
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300
       MemorySize: 1024

--- a/collectors/crowdstrike/package.json
+++ b/collectors/crowdstrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crowdstrike-collector",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Alert Logic AWS based Crowdstrike Log Collector",
   "repository": {},
   "private": true,
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },

--- a/collectors/googlestackdriver/al-googlestackdriver-collector.json
+++ b/collectors/googlestackdriver/al-googlestackdriver-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/googlestackdriver/local/sam-template.yaml
+++ b/collectors/googlestackdriver/local/sam-template.yaml
@@ -36,7 +36,7 @@ Resources:
           ssm_direct:
           collector_status_api: api.product.dev.alertlogic.com
       CodeUri: 
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 600
       MemorySize: 1024

--- a/collectors/googlestackdriver/package.json
+++ b/collectors/googlestackdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlestackdriver-collector",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Alert Logic AWS based Googlestackdriver Log Collector",
   "repository": {},
   "private": true,
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "google-auth-library": "^10.3.0",
     "googleapis": "^160.0.0",

--- a/collectors/gsuite/al-gsuite-collector.json
+++ b/collectors/gsuite/al-gsuite-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/gsuite/local/sam-template.yaml
+++ b/collectors/gsuite/local/sam-template.yaml
@@ -34,7 +34,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/gsuite/package.json
+++ b/collectors/gsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsuite-collector",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Alert Logic AWS based Gsuite Log Collector",
   "repository": {},
   "private": true,
@@ -25,8 +25,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "googleapis": "^160.0.0",
     "moment": "2.30.1"

--- a/collectors/mimecast/al-mimecast-collector.json
+++ b/collectors/mimecast/al-mimecast-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/mimecast/local/sam-template.yaml
+++ b/collectors/mimecast/local/sam-template.yaml
@@ -35,7 +35,7 @@ Resources:
           ssm_direct:
           paws_type_name:
       CodeUri: 
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/mimecast/package.json
+++ b/collectors/mimecast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast-collector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Alert Logic AWS based Mimecast Log Collector",
   "repository": {},
   "private": true,
@@ -25,8 +25,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "adm-zip": "^0.5.16",
     "debug": "^4.4.3",
     "moment": "2.30.1",

--- a/collectors/o365/al-o365-collector.json
+++ b/collectors/o365/al-o365-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/o365/local/sam-template.yaml
+++ b/collectors/o365/local/sam-template.yaml
@@ -35,7 +35,7 @@ Resources:
           paws_dedup_logs_ddb_table_name:
           ssm_direct:
       CodeUri: 
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 60 
       MemorySize: 1024

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@alertlogic/al-aws-collector-js": "4.2.5",
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "@azure/ms-rest-azure-js": "2.1.0",
     "@azure/ms-rest-js": "2.7.0",
     "@azure/ms-rest-nodeauth": "3.1.1",

--- a/collectors/okta/al-okta-collector.json
+++ b/collectors/okta/al-okta-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/okta/local/sam-template.yaml
+++ b/collectors/okta/local/sam-template.yaml
@@ -31,7 +31,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri: 
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/okta/package.json
+++ b/collectors/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "okta-collector",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Alert Logic AWS based Okta Log Collector",
   "repository": {},
   "private": true,
@@ -25,8 +25,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "@okta/okta-sdk-nodejs": "~7.3.0",
     "debug": "^4.4.3",
     "moment": "2.30.1"

--- a/collectors/salesforce/al-salesforce-collector.json
+++ b/collectors/salesforce/al-salesforce-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/salesforce/local/sam-template.yaml
+++ b/collectors/salesforce/local/sam-template.yaml
@@ -35,7 +35,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/salesforce/package.json
+++ b/collectors/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-collector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Alert Logic AWS based Salesforce Log Collector",
   "repository": {},
   "private": true,
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "jsforce": "^3.7.0",
     "jsonwebtoken": "^9.0.2",

--- a/collectors/sentinelone/al-sentinelone-collector.json
+++ b/collectors/sentinelone/al-sentinelone-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/sentinelone/local/sam-template.yaml
+++ b/collectors/sentinelone/local/sam-template.yaml
@@ -32,7 +32,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri: 
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sentinelone/package.json
+++ b/collectors/sentinelone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone-collector",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Alert Logic AWS based Sentinelone Log Collector",
   "repository": {},
   "private": true,
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },

--- a/collectors/sophos/al-sophos-collector.json
+++ b/collectors/sophos/al-sophos-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/sophos/local/sam-template.yaml
+++ b/collectors/sophos/local/sam-template.yaml
@@ -32,7 +32,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:      
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sophos/package.json
+++ b/collectors/sophos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophos-collector",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Alert Logic AWS based Sophos Log Collector",
   "repository": {},
   "private": true,
@@ -26,8 +26,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },

--- a/collectors/sophossiem/al-sophossiem-collector.json
+++ b/collectors/sophossiem/al-sophossiem-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/sophossiem/local/sam-template.yaml
+++ b/collectors/sophossiem/local/sam-template.yaml
@@ -32,7 +32,7 @@ Resources:
           paws_type_name:
           ssm_direct:
       CodeUri:     
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/collectors/sophossiem/package.json
+++ b/collectors/sophossiem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sophossiem-collector",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Alert Logic AWS based Sophossiem Log Collector",
   "repository": {},
   "private": true,
@@ -24,8 +24,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.21",
-    "@alertlogic/paws-collector": "2.3.5",
+    "@alertlogic/al-collector-js": "3.0.27",
+    "@alertlogic/paws-collector": "2.3.6",
     "debug": "^4.4.3",
     "moment": "2.30.1"
   },

--- a/collectors/template/collector.json
+++ b/collectors/template/collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs22.x"
+        "value": "nodejs24.x"
     }
 }

--- a/collectors/template/local/sam-template.yaml
+++ b/collectors/template/local/sam-template.yaml
@@ -25,7 +25,7 @@ Resources:
           collector_id:
           ssm_direct:
           paws_type_name:
-      Runtime: nodejs22.x
+      Runtime: nodejs24.x
       Handler: index.handler
       Timeout: 300 
       MemorySize: 1024

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -60,7 +60,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-auth0-collector"
-      ALPS_SERVICE_VERSION: "1.2.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 24
       - ./build_collector.sh auth0
@@ -82,7 +82,7 @@ stages:
       - ./build_collector.sh carbonblack
     env:
       ALPS_SERVICE_NAME: "paws-carbonblack-collector"
-      ALPS_SERVICE_VERSION: "1.2.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
     outputs:
       file: ./carbonblack-collector*
     packagers:
@@ -98,7 +98,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-ciscoamp-collector"
-      ALPS_SERVICE_VERSION: "1.2.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 24
       - ./build_collector.sh ciscoamp
@@ -139,7 +139,7 @@ stages:
       - ./build_collector.sh ciscomeraki
     env:
       ALPS_SERVICE_NAME: "paws-ciscomeraki-collector"
-      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.4" #set the value from collector package json
     outputs:
       file: ./ciscomeraki-collector*
     packagers:
@@ -155,7 +155,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-crowdstrike-collector"
-      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.4" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 24
       - ./build_collector.sh crowdstrike
@@ -177,7 +177,7 @@ stages:
       - ./build_collector.sh googlestackdriver
     env:
       ALPS_SERVICE_NAME: "paws-googlestackdriver-collector"
-      ALPS_SERVICE_VERSION: "1.3.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.3" #set the value from collector package json
     outputs:
       file: ./googlestackdriver-collector*
     packagers:
@@ -193,7 +193,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-gsuite-collector"
-      ALPS_SERVICE_VERSION: "1.3.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.3" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 24
       - ./build_collector.sh gsuite
@@ -215,7 +215,7 @@ stages:
       - ./build_collector.sh mimecast
     env:
       ALPS_SERVICE_NAME: "paws-mimecast-collector"
-      ALPS_SERVICE_VERSION: "1.2.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
     outputs:
       file: ./mimecast-collector*
     packagers:
@@ -231,7 +231,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-o365-collector"
-      ALPS_SERVICE_VERSION: "1.3.3" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.4" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 24
       - ./build_collector.sh o365
@@ -253,7 +253,7 @@ stages:
       - ./build_collector.sh okta
     env:
       ALPS_SERVICE_NAME: "paws-okta-collector"
-      ALPS_SERVICE_VERSION: "1.3.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.3" #set the value from collector package json
     outputs:
       file: ./okta-collector*
     packagers:
@@ -269,7 +269,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-salesforce-collector"
-      ALPS_SERVICE_VERSION: "1.2.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 24
       - ./build_collector.sh salesforce
@@ -291,7 +291,7 @@ stages:
       - ./build_collector.sh sentinelone
     env:
       ALPS_SERVICE_NAME: "paws-sentinelone-collector"
-      ALPS_SERVICE_VERSION: "1.2.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
     outputs:
       file: ./sentinelone-collector*
     packagers:
@@ -307,7 +307,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-sophos-collector"
-      ALPS_SERVICE_VERSION: "1.1.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.1.3" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 24
       - ./build_collector.sh sophos
@@ -329,7 +329,7 @@ stages:
       - ./build_collector.sh sophossiem
     env:
       ALPS_SERVICE_NAME: "paws-sophossiem-collector"
-      ALPS_SERVICE_VERSION: "1.3.2" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.3" #set the value from collector package json
     outputs:
       file: ./sophossiem-collector*
     packagers:


### PR DESCRIPTION


### Problem Description: 
The all AWS collector Lambda functions currently run on the nodejs22.x runtime.  Node.js 24.x has been released as the latest LTS version . Proactively upgrading ensures we stay on a supported, actively maintained runtime before Node.js 22.x approaches end-of-life (April 2027) .

### Solution Description: 
We currently updated to nodejs24.x across all 15 PAWS collectors 
- Update the Per-collector metadata JSON files (al-*-collector.json / collector.json) that drive the Asset/PS pipeline overrides.
- Update Local SAM development templates used by run-sam.sh and per-collector sam-template.yaml.
- Update the package dependancy for parent library

 
