### PR TITLE
[o365 and Cisco amp collector]Fix url.parse() deprecation warning in Node.js 24

### DIFF
--- a/collectors/ciscoamp/package.json
+++ b/collectors/ciscoamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ciscoamp-collector",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Alert Logic AWS based Ciscoamp Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/ciscoamp/test/ciscoamp_test.js
+++ b/collectors/ciscoamp/test/ciscoamp_test.js
@@ -180,7 +180,7 @@ describe('Unit Tests', function () {
                         count++;
                         ciscoampMock.LOG_EVENT.date = lastOneHrTimeStamp;
                         return new Promise(function (resolve, reject) {
-                            return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: "nextPageUrl" }, results: { total: 100 } } });
+                            return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: "https://api.amp.cisco.com/v1/events?start_date=2026-01-01&offset=500" }, results: { total: 100 } } });
                         });
                     } else {
                         ciscoampMock.LOG_EVENT.date = moment().subtract(2, 'days').toISOString();
@@ -227,7 +227,7 @@ describe('Unit Tests', function () {
                     count++;
                     ciscoampMock.LOG_EVENT.date = count === 1 ? lastOneHrTimeStamp : moment().subtract(count, 'hours').toISOString();
                     return new Promise(function (resolve, reject) {
-                        return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: `nextPageUrl${count}` }, results: { total: 100 } } });
+                        return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: `https://api.amp.cisco.com/v1/events?page=${count}` }, results: { total: 100 } } });
                     });
                 });
             getAPIDetails = sinon.stub(utils, 'getAPIDetails').callsFake(
@@ -253,7 +253,7 @@ describe('Unit Tests', function () {
             const [logs, newState, newPollInterval] = await collector.pawsGetLogs(curState);
             assert.equal(logs.length, 10);
             assert.equal(newState.poll_interval_sec, newPollInterval);
-            assert.equal(newState.nextPage, 'nextPageUrl10');
+            assert.equal(newState.nextPage, '/v1/events?page=10');
             // checked date from first page will be store in state.until
             assert.equal(newState.until, moment(lastOneHrTimeStamp).add(1, 'seconds').toISOString());
             alserviceStub.get.restore();
@@ -267,7 +267,7 @@ describe('Unit Tests', function () {
                     count++;
                     ciscoampMock.LOG_EVENT.date = moment().subtract(count, 'hours').toISOString();
                     return new Promise(function (resolve, reject) {
-                        return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: `nextPageUrl${10 + count}` }, results: { total: 100 } } });
+                        return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: `https://api.amp.cisco.com/v1/events?page=${10 + count}` }, results: { total: 100 } } });
                     });
                 });
             getAPIDetails = sinon.stub(utils, 'getAPIDetails').callsFake(
@@ -293,7 +293,7 @@ describe('Unit Tests', function () {
             const [logs, newState, newPollInterval] = await collector.pawsGetLogs(curState);
             assert.equal(logs.length, 10);
             assert.equal(newState.poll_interval_sec, newPollInterval);
-            assert.equal(newState.nextPage, 'nextPageUrl20');
+            assert.equal(newState.nextPage, '/v1/events?page=20');
             // checked date from first page will be store in state.until
             assert.equal(newState.until, curState.until);
             alserviceStub.get.restore();
@@ -308,7 +308,7 @@ describe('Unit Tests', function () {
                     if (count < 5) {
                         ciscoampMock.LOG_EVENT.date = moment().subtract(count, 'hours').toISOString();
                         return new Promise(function (resolve, reject) {
-                            return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: `nextPageUrl${20 + count}` }, results: { total: 100 } } });
+                            return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: `https://api.amp.cisco.com/v1/events?page=${20 + count}` }, results: { total: 100 } } });
                         });
                     } else {
                         ciscoampMock.LOG_EVENT.date = ciscoampMock.LOG_EVENT.date = moment().subtract(count, 'hours').toISOString();

--- a/collectors/ciscoamp/test/utils_test.js
+++ b/collectors/ciscoamp/test/utils_test.js
@@ -73,7 +73,7 @@ describe('Unit Tests', function () {
             alserviceStub.get = sinon.stub(RestServiceClient.prototype, 'get').callsFake(
                 function fakeFn() {
                     return new Promise(function (resolve, reject) {
-                        return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { next: "nextPageUrl" }, results: { total: 100 } } });
+                        return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { next: "https://api.amp.cisco.com/v1/events?start_date=2026-01-01&offset=500" }, results: { total: 100 } } });
                     });
                 });
             let maxPagesPerInvocation = 5;
@@ -91,7 +91,7 @@ describe('Unit Tests', function () {
             const baseUrl = process.env.paws_endpoint;
             utils.getAPILogs(baseUrl, authorization, apiUrl, state, accumulator, maxPagesPerInvocation).then(data => {
                 assert(accumulator.length == 5, "accumulator length is wrong");  
-                assert.equal(data.nextPage, 'nextPageUrl');
+                assert.equal(data.nextPage, '/v1/events?start_date=2026-01-01&offset=500');
                 assert.notEqual(data.newSince, null);
                 alserviceStub.get.restore();
                 done();
@@ -105,7 +105,7 @@ describe('Unit Tests', function () {
                     if (count < 3) {
                         count++;
                         return new Promise(function (resolve, reject) {
-                            return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: "nextPageUrl" }, results: { total: 100 } } });
+                            return resolve({ data: [ciscoampMock.LOG_EVENT], metadata: { links: { self: "selfPageUrl", next: "https://api.amp.cisco.com/v1/events?start_date=2026-01-01&offset=500" }, results: { total: 100 } } });
                         });
                     } else {
                         return new Promise(function (resolve, reject) {

--- a/collectors/ciscoamp/utils.js
+++ b/collectors/ciscoamp/utils.js
@@ -1,5 +1,4 @@
 const RestServiceClient = require('@alertlogic/al-collector-js').RestServiceClient;
-var url = require("url");
 
 const Audit_Logs = 'AuditLogs';
 const Events = 'Events';
@@ -34,7 +33,8 @@ function getAPILogs(baseUrl, authorization, apiUrl, state, accumulator, maxPages
                         }
                     }
                     if (body.metadata.links.next) {
-                        apiUrl = url.parse(body.metadata.links.next).path;
+                        const _next = new URL(body.metadata.links.next);
+                        apiUrl = _next.pathname + _next.search;
                         getData();
                     }
                     else {

--- a/collectors/o365/lib/o365_mgmnt/o365management.js
+++ b/collectors/o365/lib/o365_mgmnt/o365management.js
@@ -228,7 +228,7 @@ class O365Management extends msRestAzure.AzureServiceClient {
         queryParameters.push('PublisherIdentifier=' + encodeURIComponent(publisherId));
         if (queryParameters.length > 0) {
             // check if pre formed url already has a query string
-            const queryKeys = Object.keys(url.parse(requestUrl, true).query);
+            const queryKeys = [...new URL(requestUrl).searchParams.keys()];
             const joinChar = queryKeys.length > 0 ? '&' : '?';
             requestUrl += joinChar + queryParameters.join('&');
         }

--- a/collectors/o365/package.json
+++ b/collectors/o365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "o365-collector",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Alert Logic AWS based O365 Log Collector",
   "repository": {},
   "private": true,

--- a/collectors/o365/test/o365managment_test.js
+++ b/collectors/o365/test/o365managment_test.js
@@ -1,6 +1,5 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const url = require('url');
 const {O365Management} = require('../lib/o365_mgmnt/o365management');
 const msRest = require('@azure/ms-rest-js');
 const {ApplicationTokenCredentials} = require('@azure/ms-rest-nodeauth');
@@ -301,10 +300,10 @@ describe('O365 managment tests', function() {
                             status: 200
                         };
 
-                        const query = url.parse(request.url,true).query;
-                        const queryKeys = Object.keys(query);
+                        const query = new URL(request.url).searchParams;
+                        const queryKeys = Array.from(query.keys());
                         assert.equal(queryKeys.length, 1);
-                        assert.equal(query.PublisherIdentifier, '79ca7c9d-83ce-498f-952f-4c03b56ab573');
+                        assert.equal(query.get('PublisherIdentifier'), '79ca7c9d-83ce-498f-952f-4c03b56ab573');
                         return resolve(mockRes);
                     });
                 });
@@ -331,12 +330,12 @@ describe('O365 managment tests', function() {
                             status: 200
                         };
 
-                        const query = url.parse(request.url,true).query;
-                        const queryKeys = Object.keys(query);
+                        const query = new URL(request.url).searchParams;
+                        const queryKeys = Array.from(query.keys());
                         assert.equal(queryKeys.length, 3);
-                        assert.equal(query.PublisherIdentifier, '79ca7c9d-83ce-498f-952f-4c03b56ab573');
-                        assert.equal(query.foo, 'bar');
-                        assert.equal(query.stuff, 'junk');
+                        assert.equal(query.get('PublisherIdentifier'), '79ca7c9d-83ce-498f-952f-4c03b56ab573');
+                        assert.equal(query.get('foo'), 'bar');
+                        assert.equal(query.get('stuff'), 'junk');
                         return resolve(mockRes);
                     });
                 });

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -98,7 +98,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-ciscoamp-collector"
-      ALPS_SERVICE_VERSION: "1.2.3" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.2.4" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 24
       - ./build_collector.sh ciscoamp
@@ -231,7 +231,7 @@ stages:
           trigger_phrase: build-collectors
     env:
       ALPS_SERVICE_NAME: "paws-o365-collector"
-      ALPS_SERVICE_VERSION: "1.3.4" #set the value from collector package json
+      ALPS_SERVICE_VERSION: "1.3.5" #set the value from collector package json
     commands:
       - source $NVM_DIR/nvm.sh && nvm use 24
       - ./build_collector.sh o365


### PR DESCRIPTION
### Problem Description
Node.js 24 emits [DEP0169] DeprecationWarning: url.parse() behavior is not standardized and prone to errors that have security implications on every Lambda invocation in the ciscoamp and o365 collectors

### Solution Description
Replaced url.parse() with the new URL:
- utils.js: url.parse(links.next).path → new URL(links.next) with pathname + search
- o365management.js: url.parse(requestUrl, true).query → new URL(requestUrl).searchParams.keys()
- Removed unused require('url') imports from both files
 
